### PR TITLE
Repair partial R2 release backfills safely

### DIFF
--- a/.github/workflows/desktop-legacy-archive.yml
+++ b/.github/workflows/desktop-legacy-archive.yml
@@ -7,6 +7,10 @@ on:
         description: Delete verified 0.1.0 and 0.1.1 root objects after archival
         type: boolean
         default: false
+      repair_partial_backfills:
+        description: Delete manifest-extraneous objects from uncommitted historical prefixes
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -162,6 +166,72 @@ jobs:
               --notarized false \
               --notes-file "artifacts/${tag}-notes.md" \
               --asset "artifacts/legacy-source/puppyone-${version}-arm64.dmg"
+          done
+
+      - name: Repair explicitly authorized partial R2 backfills
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          tags=(
+            v0.1.1-internal.1
+            v0.1.2-internal.2
+            v0.1.2-internal.4
+          )
+          for tag in "${tags[@]}"; do
+            bundle="artifacts/backfill-${tag}"
+            prefix="desktop/internal/mac/${tag}"
+            if aws s3api head-object \
+              --bucket "${R2_BUCKET}" \
+              --key "${prefix}/release.json" \
+              --endpoint-url "${ENDPOINT}" >/dev/null 2>&1; then
+              continue
+            fi
+
+            listing="${RUNNER_TEMP}/${tag}-repair-r2.json"
+            unexpected="${RUNNER_TEMP}/${tag}-unexpected-objects.txt"
+            aws s3api list-objects-v2 \
+              --bucket "${R2_BUCKET}" \
+              --prefix "${prefix}/" \
+              --endpoint-url "${ENDPOINT}" \
+              --output json > "${listing}"
+            node -e '
+              const path=require("node:path");
+              const manifest=require(path.resolve(process.argv[1]));
+              const listing=require(path.resolve(process.argv[2]));
+              const prefix=`${process.argv[3]}/`;
+              const expected=new Set(manifest.assets.map((asset) => `${prefix}${asset.name}`));
+              for (const item of listing.Contents ?? []) {
+                if (!expected.has(item.Key)) process.stdout.write(`${item.Key}\n`);
+              }
+            ' "${bundle}/release.json" "${listing}" "${prefix}" > "${unexpected}"
+
+            if [ ! -s "${unexpected}" ]; then
+              continue
+            fi
+            echo "Manifest-extraneous objects found in uncommitted prefix ${prefix}:"
+            sed 's/^/- /' "${unexpected}"
+            if [ "${{ inputs.repair_partial_backfills }}" != "true" ]; then
+              echo "Re-run with repair_partial_backfills enabled to delete only these uncommitted objects." >&2
+              exit 1
+            fi
+            while IFS= read -r key; do
+              case "${key}" in
+                "${prefix}/"*) ;;
+                *)
+                  echo "Refusing to delete object outside ${prefix}: ${key}" >&2
+                  exit 1
+                  ;;
+              esac
+              aws s3api delete-object \
+                --bucket "${R2_BUCKET}" \
+                --key "${key}" \
+                --endpoint-url "${ENDPOINT}"
+            done < "${unexpected}"
           done
 
       - name: Backfill immutable GitHub releases into R2

--- a/scripts/release-support/internal-release-workflow-policy.mjs
+++ b/scripts/release-support/internal-release-workflow-policy.mjs
@@ -109,6 +109,7 @@ export function inspectLegacyArchiveWorkflow(workflowSource) {
   if (errors.length > 0) return errors;
   requireSnippets(workflowSource, errors, [
     ["delete_root_objects:", "root deletion must require an explicit workflow input"],
+    ["repair_partial_backfills:", "partial backfill repair must require an explicit workflow input"],
     ["default: false", "root deletion must be disabled by default"],
     ["group: desktop-release-publish", "archive catalog updates must share the global publication lock"],
     ["name: desktop-internal", "archive credentials must use a deployment environment"],
@@ -117,12 +118,16 @@ export function inspectLegacyArchiveWorkflow(workflowSource) {
     ["Verify every backfilled R2 object by SHA-256", "all historical R2 copies must be content-verified"],
     ["Attach and verify metadata on historical GitHub Releases", "GitHub history must receive the same release metadata as R2"],
     ["Merge release history into catalog", "all historical releases must appear in the website catalog"],
+    ["Repair explicitly authorized partial R2 backfills", "uncommitted historical prefixes must have an explicit repair stage"],
+    ["inputs.repair_partial_backfills", "partial backfill repair must be explicitly gated"],
+    ["Refusing to delete object outside", "partial backfill repair must enforce its prefix boundary"],
     ["if: ${{ inputs.delete_root_objects }}", "root deletion must be explicitly gated"],
   ]);
   assertOrder(workflowSource, errors, [
     "Build verified bundles from canonical GitHub Releases",
     "Download original root objects",
     "Create honest legacy archive metadata",
+    "Repair explicitly authorized partial R2 backfills",
     "Backfill immutable GitHub releases into R2",
     "Upload immutable legacy archives",
     "Verify every backfilled R2 object by SHA-256",


### PR DESCRIPTION
## Summary

- add an explicit, default-off repair input for uncommitted historical R2 prefixes
- compare existing objects with canonical GitHub Release manifests
- delete only manifest-extraneous keys within the exact historical prefix
- preserve the existing refusal behavior unless repair is explicitly authorized

## Context

The first history-backfill run safely stopped because an old partial upload left three YAML files under `desktop/internal/mac/v0.1.1-internal.1/`. No `release.json` commit marker exists for that prefix, and no root legacy objects were deleted.

## Validation

- `npm test -- tests/macosReleasePolicy.test.mjs`
- `npm run lint`
- `node scripts/check-macos-release-config.mjs`
- `git diff --check`
