### PR TITLE
chore: audit and prepare v0.1.3 internal release

### DIFF
--- a/.github/workflows/desktop-stable-release.yml
+++ b/.github/workflows/desktop-stable-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+      - "!v*.*.*-*"
 
 permissions:
   contents: read

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,19 +1,27 @@
 # Security Policy
 
-Reporting a vulnerability
-- Please email security@puppyone.ai with details and steps to reproduce.
+## Reporting a vulnerability
 
-Secrets and environment variables
+Please email security@puppyone.ai with details and steps to reproduce. Do not
+open a public issue for a vulnerability that could put users or credentials at
+risk.
+
+## Secrets and environment variables
+
 - Do not commit `.env` files or real secrets. `.env` files are globally ignored.
 - Use `.env.example` templates to document variables.
-- If a secret is leaked:
-  1) Rotate the key immediately with the provider
-  2) Purge history (see issue instructions: git-filter-repo or BFG)
-  3) Verify GitHub secret scanning and push protection
+- If a secret is leaked, rotate it immediately, purge it from Git history, and
+  verify GitHub secret scanning and push protection.
 
-Dependency security
-Trademarks and branding
-- This project does not grant rights to use puppyone trademarks, service marks, or logos
-- Remove third-party brand assets unless explicitly licensed; prefer neutral icons
-- Keep dependencies up to date; we use lockfiles and pinned versions where possible
-- Enable GitHub Dependabot alerts and code scanning
+## Dependency security
+
+- Keep dependencies up to date; we use lockfiles and pinned versions where
+  possible.
+- Enable GitHub Dependabot alerts and code scanning.
+
+## Trademarks and branding
+
+- This project does not grant rights to use PuppyOne trademarks, service marks,
+  or logos.
+- Remove third-party brand assets unless explicitly licensed; prefer neutral
+  icons.

--- a/docs/architecture/desktop-agent/history/codex-vertical-slice.md
+++ b/docs/architecture/desktop-agent/history/codex-vertical-slice.md
@@ -42,7 +42,7 @@ Copy the following prompt to the implementation agent:
 ```text
 Implement the first Codex-backed Desktop Agent Chat vertical slice in:
 
-  /Users/supersayajin/Desktop/puppyone desktop
+  /path/to/puppyone-desktop
 
 Do not stop after planning or producing a mockup. Implement the feature, add
 tests, run the relevant verification, and report remaining gaps accurately.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "@puppyone/desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppyone/desktop",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.159",
         "@xterm/addon-web-links": "^0.12.0",
@@ -456,9 +457,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -655,9 +656,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -833,9 +834,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -931,9 +932,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1033,9 +1034,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.15",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
+      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3205,16 +3206,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4518,9 +4519,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4572,9 +4573,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -5145,9 +5146,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5473,9 +5474,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -5547,9 +5548,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5844,9 +5845,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6443,9 +6444,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -7257,9 +7258,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -7824,9 +7825,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -7844,7 +7845,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9119,9 +9120,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@puppyone/desktop",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/puppyone-ai/puppyone-desktop.git"
+  },
+  "homepage": "https://github.com/puppyone-ai/puppyone-desktop#readme",
+  "bugs": {
+    "url": "https://github.com/puppyone-ai/puppyone-desktop/issues"
+  },
   "type": "module",
   "main": "electron/main.mjs",
   "puppyoneCapabilities": {

--- a/scripts/release-support/internal-release-workflow-policy.mjs
+++ b/scripts/release-support/internal-release-workflow-policy.mjs
@@ -29,6 +29,7 @@ export function inspectStableReleaseWorkflow(workflowSource) {
   const errors = inspectSource(workflowSource, "stable release workflow");
   if (errors.length > 0) return errors;
   requireSnippets(workflowSource, errors, [
+    ["- \"!v*.*.*-*\"", "internal or other prerelease tags must not trigger the stable workflow"],
     ["runs-on: macos-15", "the stable build must pin its macOS runner"],
     ["name: desktop-signing", "stable signing must use its dedicated deployment environment"],
     ["Test release transaction and Terminal launcher", "the stable build must run release integration tests on macOS"],

--- a/tests/cloudApi.client.test.ts
+++ b/tests/cloudApi.client.test.ts
@@ -563,7 +563,7 @@ describe("session / api-base guards", () => {
   });
 
   it("rejects with 401 (without calling the bridge) when the requested api base != the session's", async () => {
-    const otherApi = "https://qubits-try.puppyone.ai/api/v1";
+    const otherApi = "https://subdomain.puppyone.ai/api/v1";
     await expect(
       cloudApiRequest("/projects/", session, undefined, {}, otherApi),
     ).rejects.toThrow(/sign in/i);

--- a/tests/cloudEndpoint.test.mjs
+++ b/tests/cloudEndpoint.test.mjs
@@ -21,11 +21,11 @@ describe("normalizeCloudApiBaseUrl", () => {
   });
 
   it("strips trailing slashes, hash and query", () => {
-    expect(normalizeCloudApiBaseUrl("https://qubits-try.puppyone.ai/api/v1/")).toBe(
-      "https://qubits-try.puppyone.ai/api/v1",
+    expect(normalizeCloudApiBaseUrl("https://subdomain.puppyone.ai/api/v1/")).toBe(
+      "https://subdomain.puppyone.ai/api/v1",
     );
-    expect(normalizeCloudApiBaseUrl("https://qubits-try.puppyone.ai/api/v1?x=1#frag")).toBe(
-      "https://qubits-try.puppyone.ai/api/v1",
+    expect(normalizeCloudApiBaseUrl("https://subdomain.puppyone.ai/api/v1?x=1#frag")).toBe(
+      "https://subdomain.puppyone.ai/api/v1",
     );
   });
 
@@ -44,7 +44,7 @@ describe("normalizeCloudApiBaseUrl", () => {
 
   it("SSRF guard: allows the PuppyOne host family and localhost (dev)", () => {
     expect(normalizeCloudApiBaseUrl("https://api.puppyone.ai/api/v1")).toBe("https://api.puppyone.ai/api/v1");
-    expect(normalizeCloudApiBaseUrl("https://qubits-try.puppyone.ai/api/v1")).toBe("https://qubits-try.puppyone.ai/api/v1");
+    expect(normalizeCloudApiBaseUrl("https://subdomain.puppyone.ai/api/v1")).toBe("https://subdomain.puppyone.ai/api/v1");
     expect(normalizeCloudApiBaseUrl("http://localhost:8000/api/v1")).toBe("http://localhost:8000/api/v1");
   });
 });
@@ -81,10 +81,10 @@ describe("normalizeCloudApiPath", () => {
 describe("sameCloudApiBaseUrl", () => {
   it("treats trailing-slash / scheme-normalized variants as equal", () => {
     expect(
-      sameCloudApiBaseUrl("https://qubits-try.puppyone.ai/api/v1", "https://qubits-try.puppyone.ai/api/v1/"),
+      sameCloudApiBaseUrl("https://subdomain.puppyone.ai/api/v1", "https://subdomain.puppyone.ai/api/v1/"),
     ).toBe(true);
     expect(
-      sameCloudApiBaseUrl("https://qubits-try.puppyone.ai/api/v1", "https://api.puppyone.ai/api/v1"),
+      sameCloudApiBaseUrl("https://subdomain.puppyone.ai/api/v1", "https://api.puppyone.ai/api/v1"),
     ).toBe(false);
   });
 });

--- a/tests/desktopWorkspaceSwitcherCopyPath.test.ts
+++ b/tests/desktopWorkspaceSwitcherCopyPath.test.ts
@@ -7,9 +7,9 @@ import {
 describe("desktop workspace switcher copy path", () => {
   it("copies the filesystem root for local projects", () => {
     expect(getProjectCopyPath(createItem({
-      detail: "/Users/supersayajin/Desktop/demo",
-      path: "/Users/supersayajin/Desktop/demo",
-    }))).toBe("/Users/supersayajin/Desktop/demo");
+      detail: "/Users/example/Desktop/demo",
+      path: "/Users/example/Desktop/demo",
+    }))).toBe("/Users/example/Desktop/demo");
   });
 
   it("skips an item without a filesystem root", () => {
@@ -21,9 +21,9 @@ describe("desktop workspace switcher copy path", () => {
 
   it("copies every registered local workspace root", () => {
     expect(getProjectCopyPath(createItem({
-      detail: "/Users/supersayajin/Library/Caches/puppyone/demo",
-      path: "/Users/supersayajin/Library/Caches/puppyone/demo",
-    }))).toBe("/Users/supersayajin/Library/Caches/puppyone/demo");
+      detail: "/Users/example/Library/Caches/puppyone/demo",
+      path: "/Users/example/Library/Caches/puppyone/demo",
+    }))).toBe("/Users/example/Library/Caches/puppyone/demo");
   });
 });
 


### PR DESCRIPTION
## Summary
- prepare package version 0.1.3 and add Apache-2.0 package metadata
- remove a personal filesystem path and replace a staging hostname in tests
- update vulnerable transitive dependencies; npm audit is now 0 critical / 0 high
- keep internal prerelease tags from triggering the signed stable workflow
- clarify the security reporting policy

## Open-source audit
- current tree and production build scanned with Gitleaks: no leaks
- complete Git history scanned: two false positives from a test-only idempotency key
- no blocking dependency licenses found; Anthropic Agent SDK remains covered by its own terms and THIRD_PARTY_NOTICES.md
- 3 moderate npm advisories remain in the Claude Agent SDK -> MCP SDK -> Hono chain; the advisory is Windows-only serve-static path traversal, while this release targets macOS arm64. npm offers only a breaking SDK downgrade.

## Verification
- npm ci
- npm run lint
- npm run check:boundaries
- npm test (236 files, 1516 tests)
- production npm run build
- release-policy tests
- actionlint on release workflows
- Gitleaks on current tree and dist