### PR TITLE
fix: isolate duplicate desktop launches

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -32,6 +32,10 @@ import {
   createApplicationQuitIntent,
   createDocumentSessionCloseCoordinator,
 } from "./main/document-session-close-coordinator.mjs";
+import {
+  createDesktopLaunchIntent,
+  handleSecondInstanceLaunch,
+} from "./main/desktop-launch-intent.mjs";
 import { registerAgentIpcHandlers } from "./main/ipc/agent-ipc.mjs";
 import { registerAppPreviewIpcHandlers } from "./main/ipc/app-preview-ipc.mjs";
 import { registerCloudIpcHandlers } from "./main/ipc/cloud-ipc.mjs";
@@ -81,6 +85,24 @@ const projectRoot = path.resolve(__dirname, "..");
 const preloadPath = path.join(__dirname, "preload.cjs");
 const rendererDistPath = path.join(projectRoot, "dist", "index.html");
 const appName = "puppyone";
+
+app.setName(appName);
+if (process.platform === "win32") {
+  app.setAppUserModelId("ai.puppyone.desktop");
+}
+
+// Resolve only core launch data before the single-instance boundary. A
+// duplicate CLI launch must exit before optional subsystems are constructed.
+const initialLaunchIntent = createDesktopLaunchIntent({
+  argv: process.argv,
+  workingDirectory: process.cwd(),
+  isPackaged: app.isPackaged,
+});
+const gotSingleInstanceLock = app.requestSingleInstanceLock(initialLaunchIntent);
+if (!gotSingleInstanceLock) {
+  app.exit(0);
+}
+
 const devServerUrl = process.env.PUPPYONE_DESKTOP_DEV_URL;
 const rendererApplicationUrl = devServerUrl || pathToFileURL(rendererDistPath).toString();
 const viewerPackFeatureProfile = resolveViewerPackFeatureProfile({
@@ -218,16 +240,6 @@ const cloudGitConnectCoordinator = createCloudGitConnectCoordinator({
   operationLease: cloudGitOperationLease,
   secretVault: cloudPublishSecretVault,
 });
-
-app.setName(appName);
-if (process.platform === "win32") {
-  app.setAppUserModelId("ai.puppyone.desktop");
-}
-
-const gotSingleInstanceLock = app.requestSingleInstanceLock();
-if (!gotSingleInstanceLock) {
-  app.exit(0);
-}
 
 async function createWindow(options = {}) {
   await localeService.refreshSystemLanguages();
@@ -376,16 +388,18 @@ function revealWindow(window) {
 }
 
 function revealLastFocusedWindow() {
+  void createOrRevealWindow().catch((error) => {
+    console.error("Unable to reveal the last focused puppyone window:", error);
+  });
+}
+
+async function createOrRevealWindow() {
   const window = getLastFocusedWindow();
   if (window) {
     revealWindow(window);
-    return;
+    return window;
   }
-  void createWindow();
-}
-
-function createOrRevealWindow() {
-  revealLastFocusedWindow();
+  return createWindow();
 }
 
 function getLastFocusedWindow() {
@@ -461,13 +475,16 @@ function setDockMenu() {
   app.dock.setMenu(dockMenu);
 }
 
-app.on("second-instance", (_event, argv) => {
-  const workspacePath = findWorkspacePathArg(argv);
-  if (workspacePath) {
-    void openWorkspaceInNewWindow(workspacePath);
-    return;
-  }
-  createOrRevealWindow();
+app.on("second-instance", (_event, argv, workingDirectory, launchIntent) => {
+  void handleSecondInstanceLaunch({
+    launchIntent,
+    argv,
+    workingDirectory,
+    isPackaged: app.isPackaged,
+    openWorkspaceInNewWindow,
+    revealOrCreateWindow: createOrRevealWindow,
+    reportError: (message, error) => console.error(message, error),
+  });
 });
 
 app.whenReady().then(async () => {
@@ -524,9 +541,9 @@ app.whenReady().then(async () => {
   }
   registerIpcHandlers();
   updateService.start();
-  await createWindow({
-    initialWorkspacePath: await workspaceStateStore.readLastActiveWorkspacePath(),
-  });
+  const initialWorkspacePath = initialLaunchIntent.workspacePath
+    ?? await workspaceStateStore.readLastActiveWorkspacePath();
+  await createWindow({ initialWorkspacePath });
 
   app.on("activate", () => {
     void localeService.refreshSystemLanguages().catch((error) => {
@@ -967,19 +984,4 @@ async function showHomepageForCurrentWindow(sender) {
   void agentService.closeSessionsForWindow(window.webContents.id);
   workspaceWatchService.stopForWindow(window.webContents.id);
   gitMetadataWatchService.stopForWindow(window.webContents.id);
-}
-
-function findWorkspacePathArg(argv) {
-  for (const arg of [...argv].reverse()) {
-    if (typeof arg !== "string" || arg.trim().length === 0) continue;
-    if (isCloudAuthCallbackUrl(arg)) continue;
-    if (arg.startsWith("-")) continue;
-    const candidate = path.resolve(arg);
-    try {
-      if (fs.statSync(candidate).isDirectory()) return candidate;
-    } catch {
-      // Not a local directory argument.
-    }
-  }
-  return null;
 }

--- a/electron/main/desktop-launch-intent.mjs
+++ b/electron/main/desktop-launch-intent.mjs
@@ -1,0 +1,161 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const DESKTOP_LAUNCH_INTENT_VERSION = 1;
+
+export function createDesktopLaunchIntent({
+  argv = process.argv,
+  workingDirectory = process.cwd(),
+  isPackaged = false,
+  statSync = fs.statSync,
+} = {}) {
+  const launchArguments = Array.isArray(argv)
+    ? argv.slice(isPackaged ? 1 : 2)
+    : [];
+
+  return {
+    version: DESKTOP_LAUNCH_INTENT_VERSION,
+    workspacePath: findWorkspacePathArg(launchArguments, {
+      workingDirectory,
+      statSync,
+    }),
+  };
+}
+
+export function parseDesktopLaunchIntent(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  if (value.version !== DESKTOP_LAUNCH_INTENT_VERSION) return null;
+
+  if (value.workspacePath === null) {
+    return {
+      version: DESKTOP_LAUNCH_INTENT_VERSION,
+      workspacePath: null,
+    };
+  }
+
+  if (
+    typeof value.workspacePath !== "string"
+    || value.workspacePath.trim().length === 0
+    || !path.isAbsolute(value.workspacePath)
+  ) {
+    return null;
+  }
+
+  return {
+    version: DESKTOP_LAUNCH_INTENT_VERSION,
+    workspacePath: path.normalize(value.workspacePath),
+  };
+}
+
+export function findWorkspacePathArg(argv, {
+  workingDirectory = process.cwd(),
+  statSync = fs.statSync,
+} = {}) {
+  const args = Array.isArray(argv) ? argv : [];
+  const basePath = resolveWorkingDirectory(workingDirectory);
+
+  for (const rawArgument of [...args].reverse()) {
+    if (typeof rawArgument !== "string") continue;
+    const argument = rawArgument.trim();
+    if (!argument || argument.startsWith("-")) continue;
+
+    try {
+      const candidate = path.resolve(basePath, argument);
+      if (statSync(candidate).isDirectory()) return candidate;
+    } catch {
+      // Command-line input is untrusted. Non-path arguments are ignored.
+    }
+  }
+
+  return null;
+}
+
+export async function handleSecondInstanceLaunch({
+  launchIntent,
+  argv,
+  workingDirectory,
+  isPackaged = false,
+  statSync = fs.statSync,
+  openWorkspaceInNewWindow,
+  revealOrCreateWindow,
+  reportError = console.error,
+} = {}) {
+  const intent = parseDesktopLaunchIntent(launchIntent)
+    ?? createDesktopLaunchIntent({
+      argv,
+      workingDirectory,
+      isPackaged,
+      statSync,
+    });
+
+  if (!intent.workspacePath) {
+    return revealSafely({
+      revealOrCreateWindow,
+      reportError,
+      successStatus: "revealed-window",
+    });
+  }
+
+  try {
+    await openWorkspaceInNewWindow(intent.workspacePath);
+    return {
+      status: "opened-workspace",
+      workspacePath: intent.workspacePath,
+    };
+  } catch (error) {
+    reportSafely(
+      reportError,
+      "Unable to open the workspace requested by a second puppyone instance:",
+      error,
+    );
+    return revealSafely({
+      revealOrCreateWindow,
+      reportError,
+      successStatus: "recovered-window",
+      workspacePath: intent.workspacePath,
+    });
+  }
+}
+
+function resolveWorkingDirectory(value) {
+  if (typeof value !== "string" || value.trim().length === 0) return process.cwd();
+  try {
+    return path.resolve(value);
+  } catch {
+    return process.cwd();
+  }
+}
+
+async function revealSafely({
+  revealOrCreateWindow,
+  reportError,
+  successStatus,
+  workspacePath = null,
+}) {
+  try {
+    await revealOrCreateWindow();
+    return {
+      status: successStatus,
+      workspacePath,
+    };
+  } catch (error) {
+    reportSafely(
+      reportError,
+      "Unable to reveal puppyone after a second-instance launch:",
+      error,
+    );
+    return {
+      status: "ignored-error",
+      workspacePath,
+    };
+  }
+}
+
+function reportSafely(reportError, message, error) {
+  if (typeof reportError !== "function") return;
+  try {
+    reportError(message, error);
+  } catch {
+    // A diagnostic sink must never turn an optional launch route into a crash.
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppyone/desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppyone/desktop",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puppyone/desktop",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/scripts/terminal-preview-launcher.mjs
+++ b/scripts/terminal-preview-launcher.mjs
@@ -8,6 +8,8 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const DEFAULT_REMOTE_HOST = "downloads.puppyone.ai";
+const DOWNLOAD_PROGRESS_REFRESH_MS = 100;
+const DOWNLOAD_PROGRESS_MILESTONE_PERCENT = 10;
 
 export async function preparePreviewApp({
   packageRoot,
@@ -15,6 +17,7 @@ export async function preparePreviewApp({
   metadata,
   fetchImpl = globalThis.fetch,
   log = console,
+  onDownloadProgress = null,
 } = {}) {
   const resolvedPackageRoot = packageRoot
     ? path.resolve(packageRoot)
@@ -54,12 +57,16 @@ export async function preparePreviewApp({
   const extractionRoot = path.join(temporaryRoot, "extracted");
 
   try {
-    log.info?.(`Downloading PuppyOne preview ${packageMetadata.appVersion}…`);
+    if (typeof onDownloadProgress !== "function") {
+      log.info?.(`Downloading PuppyOne preview ${packageMetadata.appVersion}…`);
+    }
     await downloadVerifiedArchive({
       archivePath,
       fetchImpl,
       metadata: packageMetadata,
+      onProgress: onDownloadProgress,
     });
+    log.info?.(`Preparing downloaded PuppyOne preview ${packageMetadata.appVersion}…`);
     await fs.promises.mkdir(extractionRoot, { recursive: true });
     await runCommand("/usr/bin/ditto", ["-x", "-k", archivePath, extractionRoot]);
 
@@ -237,7 +244,12 @@ function createReadyMarker(metadata) {
   };
 }
 
-async function downloadVerifiedArchive({ archivePath, fetchImpl, metadata }) {
+async function downloadVerifiedArchive({
+  archivePath,
+  fetchImpl,
+  metadata,
+  onProgress,
+}) {
   const archiveUrl = new URL(metadata.archiveUrl);
   if (archiveUrl.protocol === "file:") {
     await fs.promises.copyFile(fileURLToPath(archiveUrl), archivePath);
@@ -245,6 +257,7 @@ async function downloadVerifiedArchive({ archivePath, fetchImpl, metadata }) {
     if (typeof fetchImpl !== "function") {
       throw new Error("Node.js 18 or later is required to download the PuppyOne preview.");
     }
+    notifyDownloadProgress(onProgress, 0, metadata.archiveBytes);
     const response = await fetchImpl(archiveUrl, {
       headers: { "user-agent": "puppyone-terminal-preview" },
       redirect: "follow",
@@ -273,6 +286,7 @@ async function downloadVerifiedArchive({ archivePath, fetchImpl, metadata }) {
           throw new Error("PuppyOne preview download exceeded the expected size.");
         }
         await handle.write(buffer);
+        notifyDownloadProgress(onProgress, bytes, metadata.archiveBytes);
       }
     } finally {
       await handle.close();
@@ -289,6 +303,92 @@ async function downloadVerifiedArchive({ archivePath, fetchImpl, metadata }) {
   if (actualSha256 !== metadata.archiveSha256) {
     throw new Error("PuppyOne preview archive failed SHA-256 verification.");
   }
+}
+
+function notifyDownloadProgress(onProgress, downloadedBytes, totalBytes) {
+  if (typeof onProgress !== "function") return;
+  onProgress({
+    downloadedBytes,
+    percent: totalBytes > 0
+      ? Math.min(100, Math.floor((downloadedBytes / totalBytes) * 100))
+      : null,
+    totalBytes,
+  });
+}
+
+export function createTerminalDownloadProgress({ label, stream }) {
+  const interactive = stream?.isTTY === true;
+  let active = false;
+  let completed = false;
+  let lastMilestone = -1;
+  let lastRenderedAt = 0;
+
+  function update({ downloadedBytes, percent, totalBytes }) {
+    if (completed || typeof stream?.write !== "function") return;
+
+    const now = Date.now();
+    if (interactive) {
+      if (
+        active
+        && percent !== 100
+        && now - lastRenderedAt < DOWNLOAD_PROGRESS_REFRESH_MS
+      ) {
+        return;
+      }
+      stream.write(
+        `\r\u001b[2K${formatDownloadProgress(label, downloadedBytes, totalBytes, percent)}`,
+      );
+      active = true;
+      lastRenderedAt = now;
+      if (percent === 100) {
+        stream.write("\n");
+        completed = true;
+      }
+      return;
+    }
+
+    const milestone = percent === 100
+      ? 100
+      : Math.floor((percent ?? 0) / DOWNLOAD_PROGRESS_MILESTONE_PERCENT)
+        * DOWNLOAD_PROGRESS_MILESTONE_PERCENT;
+    if (milestone <= lastMilestone) return;
+    stream.write(
+      `${formatDownloadProgress(label, downloadedBytes, totalBytes, percent)}\n`,
+    );
+    active = true;
+    lastMilestone = milestone;
+    if (percent === 100) completed = true;
+  }
+
+  function stop() {
+    if (interactive && active && !completed && typeof stream?.write === "function") {
+      stream.write("\n");
+    }
+    completed = true;
+  }
+
+  return { stop, update };
+}
+
+function formatDownloadProgress(label, downloadedBytes, totalBytes, percent) {
+  const progressPercent = Number.isFinite(percent) ? `${percent}%` : "";
+  const byteCounts = totalBytes > 0
+    ? `${formatBytes(downloadedBytes)} / ${formatBytes(totalBytes)}`
+    : formatBytes(downloadedBytes);
+  return `${label} ${progressPercent} (${byteCounts})`.replace("  ", " ");
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KiB", "MiB", "GiB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  if (unitIndex === 0) return `${Math.round(value)} ${units[unitIndex]}`;
+  return `${value.toFixed(value >= 10 ? 1 : 2)} ${units[unitIndex]}`;
 }
 
 async function hashFile(filename) {
@@ -349,11 +449,21 @@ async function main() {
     await fs.promises.rm(cacheRoot, { recursive: true, force: true });
   }
 
-  const prepared = await preparePreviewApp({
-    cacheRoot,
-    metadata,
-    packageRoot,
+  const downloadProgress = createTerminalDownloadProgress({
+    label: `Downloading PuppyOne preview ${metadata.appVersion}…`,
+    stream: process.stdout,
   });
+  let prepared;
+  try {
+    prepared = await preparePreviewApp({
+      cacheRoot,
+      metadata,
+      onDownloadProgress: downloadProgress.update,
+      packageRoot,
+    });
+  } finally {
+    downloadProgress.stop();
+  }
   if (options.prepareOnly) {
     console.log(prepared.appRoot);
     return;

--- a/tests/electron.desktop-launch-intent.test.mjs
+++ b/tests/electron.desktop-launch-intent.test.mjs
@@ -1,0 +1,157 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createDesktopLaunchIntent,
+  findWorkspacePathArg,
+  handleSecondInstanceLaunch,
+  parseDesktopLaunchIntent,
+} from "../electron/main/desktop-launch-intent.mjs";
+
+const workingDirectory = path.resolve("/tmp", "puppyone-launch-tests");
+const workspacePath = path.join(workingDirectory, "workspace");
+
+describe("Desktop launch intent", () => {
+  it("keeps optional subsystem construction behind the single-instance boundary", () => {
+    const mainSource = fs.readFileSync(
+      new URL("../electron/main.mjs", import.meta.url),
+      "utf8",
+    );
+    const instanceBoundary = mainSource.indexOf(
+      "app.requestSingleInstanceLock(initialLaunchIntent)",
+    );
+
+    expect(instanceBoundary).toBeGreaterThan(-1);
+    expect(mainSource).not.toContain("isCloudAuthCallbackUrl");
+    for (const optionalComposition of [
+      "const terminalService = createTerminalService({",
+      "const agentRuntimeRegistry = createDefaultAgentRuntimeHost({",
+      "const cloudAuthService = createCloudAuthService({",
+    ]) {
+      expect(mainSource.indexOf(optionalComposition)).toBeGreaterThan(instanceBoundary);
+    }
+  });
+
+  it("does not mistake Electron's development app entry for a workspace", () => {
+    const statSync = vi.fn(() => ({ isDirectory: () => true }));
+
+    const intent = createDesktopLaunchIntent({
+      argv: ["/Applications/Electron", ".", "--inspect=0"],
+      workingDirectory,
+      isPackaged: false,
+      statSync,
+    });
+
+    expect(intent).toEqual({ version: 1, workspacePath: null });
+    expect(statSync).not.toHaveBeenCalled();
+  });
+
+  it("resolves an explicit development CLI workspace before acquiring the instance lock", () => {
+    const statSync = vi.fn((candidate) => ({
+      isDirectory: () => candidate === workspacePath,
+    }));
+
+    const intent = createDesktopLaunchIntent({
+      argv: ["/Applications/Electron", ".", "./workspace"],
+      workingDirectory,
+      isPackaged: false,
+      statSync,
+    });
+
+    expect(intent).toEqual({ version: 1, workspacePath });
+  });
+
+  it("ignores malformed, flag, file, and missing arguments without throwing", () => {
+    const statSync = vi.fn((candidate) => {
+      if (candidate.endsWith("file.md")) return { isDirectory: () => false };
+      throw new Error("missing");
+    });
+
+    expect(findWorkspacePathArg(
+      [null, "", "--flag", "missing", "file.md"],
+      { workingDirectory, statSync },
+    )).toBeNull();
+  });
+
+  it("accepts only a versioned absolute-path payload", () => {
+    expect(parseDesktopLaunchIntent({ version: 1, workspacePath })).toEqual({
+      version: 1,
+      workspacePath,
+    });
+    expect(parseDesktopLaunchIntent({ version: 1, workspacePath: null })).toEqual({
+      version: 1,
+      workspacePath: null,
+    });
+    expect(parseDesktopLaunchIntent({ version: 1, workspacePath: "./relative" })).toBeNull();
+    expect(parseDesktopLaunchIntent({ version: 2, workspacePath })).toBeNull();
+    expect(parseDesktopLaunchIntent(null)).toBeNull();
+  });
+
+  it("uses the structured lock payload instead of Chromium-mutated argv", async () => {
+    const openWorkspaceInNewWindow = vi.fn(async () => undefined);
+    const revealOrCreateWindow = vi.fn(async () => undefined);
+
+    const result = await handleSecondInstanceLaunch({
+      launchIntent: { version: 1, workspacePath },
+      argv: ["/Applications/Electron", ".", "--original-process-start-time=123"],
+      workingDirectory,
+      isPackaged: false,
+      openWorkspaceInNewWindow,
+      revealOrCreateWindow,
+    });
+
+    expect(result).toEqual({ status: "opened-workspace", workspacePath });
+    expect(openWorkspaceInNewWindow).toHaveBeenCalledWith(workspacePath);
+    expect(revealOrCreateWindow).not.toHaveBeenCalled();
+  });
+
+  it("reveals the primary window when the second launch has no workspace", async () => {
+    const revealOrCreateWindow = vi.fn(async () => undefined);
+
+    const result = await handleSecondInstanceLaunch({
+      launchIntent: { version: 1, workspacePath: null },
+      openWorkspaceInNewWindow: vi.fn(),
+      revealOrCreateWindow,
+    });
+
+    expect(result).toEqual({ status: "revealed-window", workspacePath: null });
+    expect(revealOrCreateWindow).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to the primary window when opening a requested workspace fails", async () => {
+    const openError = new Error("workspace unavailable");
+    const reportError = vi.fn();
+    const revealOrCreateWindow = vi.fn(async () => undefined);
+
+    const result = await handleSecondInstanceLaunch({
+      launchIntent: { version: 1, workspacePath },
+      openWorkspaceInNewWindow: vi.fn(async () => {
+        throw openError;
+      }),
+      revealOrCreateWindow,
+      reportError,
+    });
+
+    expect(result).toEqual({ status: "recovered-window", workspacePath });
+    expect(revealOrCreateWindow).toHaveBeenCalledOnce();
+    expect(reportError).toHaveBeenCalledWith(
+      "Unable to open the workspace requested by a second puppyone instance:",
+      openError,
+    );
+  });
+
+  it("contains both fallback and logging failures instead of rejecting", async () => {
+    const result = await handleSecondInstanceLaunch({
+      launchIntent: { version: 1, workspacePath: null },
+      openWorkspaceInNewWindow: vi.fn(),
+      revealOrCreateWindow: () => {
+        throw new Error("window failed");
+      },
+      reportError: () => {
+        throw new Error("logging failed");
+      },
+    });
+
+    expect(result).toEqual({ status: "ignored-error", workspacePath: null });
+  });
+});

--- a/tests/terminalPreviewLauncher.test.mjs
+++ b/tests/terminalPreviewLauncher.test.mjs
@@ -6,6 +6,7 @@ import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  createTerminalDownloadProgress,
   preparePreviewApp,
   validatePreviewMetadata,
 } from "../scripts/terminal-preview-launcher.mjs";
@@ -58,6 +59,7 @@ describe("Terminal preview launcher", () => {
 
   macIntegrationIt("accepts an HTTPS response without a Content-Length header", async () => {
     const fixture = await createPreviewFixture();
+    const progress = [];
     const prepared = await preparePreviewApp({
       cacheRoot: path.join(fixture.root, "https-cache"),
       metadata: {
@@ -66,12 +68,75 @@ describe("Terminal preview launcher", () => {
       },
       fetchImpl: async () => new Response(fixture.archive),
       log: { info() {} },
+      onDownloadProgress: (event) => progress.push(event),
     });
 
     expect(prepared.reused).toBe(false);
     expect(await fs.promises.stat(prepared.executablePath)).toMatchObject({
       mode: expect.any(Number),
     });
+    expect(progress[0]).toEqual({
+      downloadedBytes: 0,
+      percent: 0,
+      totalBytes: fixture.archive.byteLength,
+    });
+    expect(progress.at(-1)).toEqual({
+      downloadedBytes: fixture.archive.byteLength,
+      percent: 100,
+      totalBytes: fixture.archive.byteLength,
+    });
+  });
+
+  it("renders live terminal progress and bounded milestone output", () => {
+    let terminalOutput = "";
+    const terminalProgress = createTerminalDownloadProgress({
+      label: "Downloading test…",
+      stream: {
+        isTTY: true,
+        write(value) {
+          terminalOutput += value;
+        },
+      },
+    });
+    terminalProgress.update({
+      downloadedBytes: 0,
+      percent: 0,
+      totalBytes: 100,
+    });
+    terminalProgress.update({
+      downloadedBytes: 100,
+      percent: 100,
+      totalBytes: 100,
+    });
+    terminalProgress.stop();
+
+    expect(terminalOutput).toContain("\r\u001b[2KDownloading test… 0% (0 B / 100 B)");
+    expect(terminalOutput).toContain("\r\u001b[2KDownloading test… 100% (100 B / 100 B)\n");
+
+    let logOutput = "";
+    const logProgress = createTerminalDownloadProgress({
+      label: "Downloading test…",
+      stream: {
+        isTTY: false,
+        write(value) {
+          logOutput += value;
+        },
+      },
+    });
+    for (const percent of [0, 4, 47, 49, 100]) {
+      logProgress.update({
+        downloadedBytes: percent,
+        percent,
+        totalBytes: 100,
+      });
+    }
+    logProgress.stop();
+
+    expect(logOutput).toBe(
+      "Downloading test… 0% (0 B / 100 B)\n"
+      + "Downloading test… 47% (47 B / 100 B)\n"
+      + "Downloading test… 100% (100 B / 100 B)\n",
+    );
   });
 
   it("rejects insecure URLs and paths that escape the app bundle", () => {


### PR DESCRIPTION
## Summary
- resolve desktop launch intent before optional subsystems are constructed
- pass a versioned launch payload through Electron's single-instance lock
- contain duplicate-launch workspace and window errors instead of surfacing an uncaught exception
- bump the internal hotfix base version to 0.1.4

## Verification
- 26 targeted Electron tests passed
- ESLint passed
- TypeScript passed
- full production build and architecture checks passed

## Release
Intended for `v0.1.4-internal.1`. This PR remains draft while the internal artifact is validated.