### PR TITLE
Fix channel-specific macOS app bundle names

### DIFF
--- a/scripts/release-support/desktop-build-preparation.mjs
+++ b/scripts/release-support/desktop-build-preparation.mjs
@@ -89,6 +89,7 @@ export function createDesktopElectronBuilderConfig({
     ...baseBuild,
     appId: policy.applicationId,
     productName: policy.applicationName,
+    executableName: policy.applicationName,
     artifactName: "puppyone-${version}-${arch}.${ext}",
     buildVersion: identity.platformBuildNumber ?? identity.baseVersion,
     extraMetadata: {
@@ -105,6 +106,7 @@ export function createDesktopElectronBuilderConfig({
       : [],
     mac: {
       ...(baseBuild.mac ?? {}),
+      executableName: policy.applicationName,
       bundleShortVersion: identity.baseVersion,
       bundleVersion: identity.platformBuildNumber ?? identity.baseVersion,
       ...(identity.channel === "stable"

--- a/tests/desktopBuildIdentity.test.mjs
+++ b/tests/desktopBuildIdentity.test.mjs
@@ -162,6 +162,7 @@ describe("desktop build identity", () => {
     expect(config).toMatchObject({
       appId: "ai.puppyone.desktop.internal",
       productName: "PuppyOne Internal",
+      executableName: "PuppyOne Internal",
       extraMetadata: { version: "1.4.0-internal.42" },
       buildVersion: "42",
       publish: [{
@@ -171,6 +172,7 @@ describe("desktop build identity", () => {
       mac: {
         bundleShortVersion: "1.4.0",
         bundleVersion: "42",
+        executableName: "PuppyOne Internal",
         hardenedRuntime: false,
         identity: "-",
         notarize: false,


### PR DESCRIPTION
## Summary
- preserve the Build Identity channel application name as both the generated macOS bundle and executable name
- add regression assertions for the Internal configuration

## Validation
- npm run lint
- npm run build
- npm test -- tests/desktopBuildIdentity.test.mjs tests/packagedDesktopBuildVerifier.test.mjs tests/macosReleasePolicy.test.mjs
- npm test -- tests/markdownMediaWorkspace.test.tsx

The complete suite reached 1575/1576 before an unrelated Markdown media timing test timed out; that test passed immediately in isolation and the PR CI remains the merge gate.