### PR TITLE
Fix Internal draft release verification

### DIFF
--- a/.github/workflows/desktop-release-publish.yml
+++ b/.github/workflows/desktop-release-publish.yml
@@ -388,6 +388,7 @@ jobs:
       - name: Verify published GitHub Release state
         env:
           GH_TOKEN: ${{ github.token }}
+          PUBLISH_GITHUB_RELEASE: ${{ inputs.publish_github_release }}
           RELEASE_COMMIT: ${{ steps.release.outputs.commit }}
           RELEASE_ID: ${{ steps.github_verify.outputs.release_id || steps.github_state.outputs.release_id }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
@@ -397,14 +398,21 @@ jobs:
           : "${RELEASE_ID:?GitHub Release ID is required}"
           RESPONSE="${RUNNER_TEMP}/github-release-published.json"
           gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" > "${RESPONSE}"
+          if [ "${PUBLISH_GITHUB_RELEASE}" = "true" ]; then
+            EXPECTED_DRAFT=false
+          else
+            EXPECTED_DRAFT=true
+          fi
           node scripts/verify-github-release-assets.mjs \
             --bundle "${BUNDLE_DIRECTORY}" \
             --release-json "${RESPONSE}" \
-            --expect-draft false
-          REMOTE_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq .sha)"
-          if [ "${REMOTE_SHA}" != "${RELEASE_COMMIT}" ]; then
-            echo "Published tag ${RELEASE_TAG} resolves to ${REMOTE_SHA}, not ${RELEASE_COMMIT}." >&2
-            exit 1
+            --expect-draft "${EXPECTED_DRAFT}"
+          if [ "${PUBLISH_GITHUB_RELEASE}" = "true" ]; then
+            REMOTE_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq .sha)"
+            if [ "${REMOTE_SHA}" != "${RELEASE_COMMIT}" ]; then
+              echo "Published tag ${RELEASE_TAG} resolves to ${REMOTE_SHA}, not ${RELEASE_COMMIT}." >&2
+              exit 1
+            fi
           fi
 
       - name: Promote mutable R2 latest files

--- a/scripts/release-support/internal-release-workflow-policy.mjs
+++ b/scripts/release-support/internal-release-workflow-policy.mjs
@@ -149,6 +149,13 @@ export function inspectReleasePublisherWorkflow(workflowSource) {
     "PUBLISH_GITHUB_RELEASE: ${{ inputs.publish_github_release }}",
     "the GitHub release-state step must receive the caller's draft/public policy explicitly",
   );
+  requireStageSnippet(
+    workflowSource,
+    errors,
+    "Verify published GitHub Release state",
+    "PUBLISH_GITHUB_RELEASE: ${{ inputs.publish_github_release }}",
+    "the final GitHub release verification must receive the caller's draft/public policy explicitly",
+  );
   assertOrder(workflowSource, errors, [
     "Validate release bundle and caller contract",
     "Inspect immutable R2 release state",

--- a/tests/macosReleasePolicy.test.mjs
+++ b/tests/macosReleasePolicy.test.mjs
@@ -167,6 +167,20 @@ describe("desktop release publisher workflow", () => {
       "the GitHub release-state step must receive the caller's draft/public policy explicitly",
     );
   });
+
+  it("requires final GitHub verification to preserve the Internal draft policy", () => {
+    const workflow = readFileSync(
+      new URL("../.github/workflows/desktop-release-publish.yml", import.meta.url),
+      "utf8",
+    ).replace(
+      "          PUBLISH_GITHUB_RELEASE: ${{ inputs.publish_github_release }}\n          RELEASE_COMMIT: ${{ steps.release.outputs.commit }}",
+      "          RELEASE_COMMIT: ${{ steps.release.outputs.commit }}",
+    );
+
+    expect(inspectReleasePublisherWorkflow(workflow)).toContain(
+      "the final GitHub release verification must receive the caller's draft/public policy explicitly",
+    );
+  });
 });
 
 describe("desktop legacy archive workflow", () => {


### PR DESCRIPTION
## Summary
- verify the final GitHub release state against the caller's public/draft policy
- keep Internal release records collaborator-only while still allowing R2 latest/catalog promotion
- require this policy in the release workflow architecture gate

## Validation
- npm test -- tests/macosReleasePolicy.test.mjs tests/desktopReleaseMetadata.test.mjs
- npm run lint
- npm run build

This fixes the failure observed in Internal run 30269574378 after the immutable R2 bundle and GitHub draft assets had already passed SHA-256 verification.