### PR TITLE
release: prepare PuppyOne Desktop v0.1.5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,9 @@ VITE_DESKTOP_CLOUD_GIT_ORIGIN=https://api.puppyone.ai
 PUPPYONE_DESKTOP_RENDERER_URL=http://127.0.0.1:5173
 PUPPYONE_CLOUD_DEV_ROOT=../puppyone
 
-# Optional Electron updater override for local/internal testing.
-# PUPPYONE_DESKTOP_UPDATE_URL=https://updates.puppyone.ai/desktop/stable/mac/latest
-# PUPPYONE_DESKTOP_UPDATE_CHANNEL=stable
+# Optional only for an unpackaged Development updater test. Both are required.
+# PUPPYONE_DESKTOP_DEV_UPDATE_URL=https://localhost.invalid/desktop/dev/mac/latest
+# PUPPYONE_DESKTOP_FORCE_DEV_UPDATE_CONFIG=1
 
 # Enable verbose updater logs in Electron.
 # PUPPYONE_DESKTOP_UPDATE_LOG_CONSOLE=1

--- a/.github/workflows/desktop-legacy-archive.yml
+++ b/.github/workflows/desktop-legacy-archive.yml
@@ -31,12 +31,18 @@ jobs:
       AWS_EC2_METADATA_DISABLED: "true"
       AWS_PAGER: ""
       CATALOG_KEY: desktop/catalog/releases.json
+      INTERNAL_CATALOG_KEY: desktop/internal/catalog/releases.json
       PUBLIC_DOWNLOAD_ORIGIN: https://downloads.puppyone.ai
       R2_BUCKET: puppyone-desktop
 
     steps:
       - name: Checkout trusted archive code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
 
       - name: Validate archive credentials and tools
         env:
@@ -413,7 +419,7 @@ jobs:
               --include-metadata true
           done
 
-      - name: Download current release catalog
+      - name: Download current release catalogs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -426,52 +432,82 @@ jobs:
             --bucket "${R2_BUCKET}" \
             --key "${CATALOG_KEY}" \
             --endpoint-url "${ENDPOINT}" >/dev/null 2>&1; then
-            aws s3 cp "s3://${R2_BUCKET}/${CATALOG_KEY}" "${RUNNER_TEMP}/catalog-0.json" \
+            aws s3 cp "s3://${R2_BUCKET}/${CATALOG_KEY}" "${RUNNER_TEMP}/catalog-public-0.json" \
+              --endpoint-url "${ENDPOINT}" \
+              --only-show-errors
+          fi
+          if aws s3api head-object \
+            --bucket "${R2_BUCKET}" \
+            --key "${INTERNAL_CATALOG_KEY}" \
+            --endpoint-url "${ENDPOINT}" >/dev/null 2>&1; then
+            aws s3 cp "s3://${R2_BUCKET}/${INTERNAL_CATALOG_KEY}" "${RUNNER_TEMP}/catalog-internal-0.json" \
               --endpoint-url "${ENDPOINT}" \
               --only-show-errors
           fi
 
-      - name: Merge release history into catalog
+      - name: Merge release history into channel-specific catalogs
         shell: bash
         run: |
           set -euo pipefail
           node scripts/update-desktop-release-catalog.mjs \
-            --existing "${RUNNER_TEMP}/catalog-0.json" \
+            --existing "${RUNNER_TEMP}/catalog-public-0.json" \
             --release artifacts/archive-v0.1.0-legacy.0/release.json \
-            --output "${RUNNER_TEMP}/catalog-1.json"
+            --channels stable,archive \
+            --output "${RUNNER_TEMP}/catalog-public-1.json"
           node scripts/update-desktop-release-catalog.mjs \
-            --existing "${RUNNER_TEMP}/catalog-1.json" \
+            --existing "${RUNNER_TEMP}/catalog-public-1.json" \
             --release artifacts/archive-v0.1.1-legacy.0/release.json \
-            --output "${RUNNER_TEMP}/catalog-2.json"
-          index=2
+            --channels stable,archive \
+            --output "${RUNNER_TEMP}/catalog-public-2.json"
+          index=0
           for tag in v0.1.1-internal.1 v0.1.2-internal.2 v0.1.2-internal.4; do
             next=$((index + 1))
             node scripts/update-desktop-release-catalog.mjs \
-              --existing "${RUNNER_TEMP}/catalog-${index}.json" \
+              --existing "${RUNNER_TEMP}/catalog-internal-${index}.json" \
               --release "artifacts/backfill-${tag}/release.json" \
-              --output "${RUNNER_TEMP}/catalog-${next}.json"
+              --channels internal \
+              --output "${RUNNER_TEMP}/catalog-internal-${next}.json"
             index="${next}"
           done
 
-      - name: Publish and verify complete release catalog
+      - name: Publish and verify channel-specific release catalogs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PUPPYONE_INTERNAL_RELEASE_TOKEN: ${{ secrets.PUPPYONE_INTERNAL_RELEASE_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
           ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
-          aws s3 cp "${RUNNER_TEMP}/catalog-5.json" "s3://${R2_BUCKET}/${CATALOG_KEY}" \
+          aws s3 cp "${RUNNER_TEMP}/catalog-public-2.json" "s3://${R2_BUCKET}/${CATALOG_KEY}" \
             --endpoint-url "${ENDPOINT}" \
             --content-type "application/json; charset=utf-8" \
             --cache-control "public, no-cache, must-revalidate" \
             --only-show-errors
-          curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
-            -H "Cache-Control: no-cache" \
+          aws s3 cp "${RUNNER_TEMP}/catalog-internal-3.json" "s3://${R2_BUCKET}/${INTERNAL_CATALOG_KEY}" \
+            --endpoint-url "${ENDPOINT}" \
+            --content-type "application/json; charset=utf-8" \
+            --cache-control "public, no-cache, must-revalidate" \
+            --only-show-errors
+          CURL_ARGS=(--fail --location --max-redirs 0 --retry 5 --retry-all-errors --silent --show-error -H "Cache-Control: no-cache")
+          if [ -n "${PUPPYONE_INTERNAL_RELEASE_TOKEN}" ]; then
+            CURL_ARGS+=(-H "Authorization: Bearer ${PUPPYONE_INTERNAL_RELEASE_TOKEN}")
+          fi
+          if [ -n "${CF_ACCESS_CLIENT_ID}" ] && [ -n "${CF_ACCESS_CLIENT_SECRET}" ]; then
+            CURL_ARGS+=(-H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}")
+            CURL_ARGS+=(-H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}")
+          fi
+          curl "${CURL_ARGS[@]}" \
             --output "${RUNNER_TEMP}/catalog-public.json" \
             "${PUBLIC_DOWNLOAD_ORIGIN}/${CATALOG_KEY}"
-          cmp "${RUNNER_TEMP}/catalog-5.json" "${RUNNER_TEMP}/catalog-public.json"
+          curl "${CURL_ARGS[@]}" \
+            --output "${RUNNER_TEMP}/catalog-internal.json" \
+            "${PUBLIC_DOWNLOAD_ORIGIN}/${INTERNAL_CATALOG_KEY}"
+          cmp "${RUNNER_TEMP}/catalog-public-2.json" "${RUNNER_TEMP}/catalog-public.json"
+          cmp "${RUNNER_TEMP}/catalog-internal-3.json" "${RUNNER_TEMP}/catalog-internal.json"
 
       - name: Delete verified root objects
         if: ${{ inputs.delete_root_objects }}

--- a/.github/workflows/desktop-release-publish.yml
+++ b/.github/workflows/desktop-release-publish.yml
@@ -61,8 +61,29 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    name: Verify existing distribution contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout trusted publishing code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Verify existing Stable update origin before publication
+        if: ${{ inputs.channel == 'stable' }}
+        run: node scripts/verify-desktop-stable-update-feed.mjs
+
   publish:
     name: Publish verified release
+    needs: preflight
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment:
@@ -73,11 +94,17 @@ jobs:
       AWS_PAGER: ""
       BUNDLE_DIRECTORY: ${{ github.workspace }}/artifacts/desktop-release-bundle
       PUBLIC_DOWNLOAD_ORIGIN: https://downloads.puppyone.ai
+      PUBLIC_UPDATE_ORIGIN: https://updates.puppyone.ai
       R2_BUCKET: puppyone-desktop
 
     steps:
       - name: Checkout trusted publishing code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
 
       - name: Download build-once release bundle
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -107,10 +134,13 @@ jobs:
           LATEST_PREFIX="${R2_PREFIX%/${TAG}}/latest"
           if [ "${EXPECTED_CHANNEL}" = "internal" ]; then
             CATALOG_KEY="desktop/internal/catalog/releases.json"
+            CATALOG_CHANNELS="internal"
           else
             CATALOG_KEY="desktop/catalog/releases.json"
+            CATALOG_CHANNELS="stable,archive"
           fi
           {
+            echo "catalog_channels=${CATALOG_CHANNELS}"
             echo "catalog_key=${CATALOG_KEY}"
             echo "commit=${COMMIT}"
             echo "latest_prefix=${LATEST_PREFIX}"
@@ -479,6 +509,16 @@ jobs:
             --url-prefix "${PUBLIC_DOWNLOAD_ORIGIN}/${LATEST_PREFIX}" \
             --include-aliases true
 
+      - name: Verify Stable updater payloads through every shipped origin
+        if: ${{ inputs.channel == 'stable' }}
+        env:
+          LATEST_PREFIX: ${{ steps.release.outputs.latest_prefix }}
+        run: |
+          node scripts/verify-desktop-release-remote.mjs \
+            --bundle "${BUNDLE_DIRECTORY}" \
+            --url-prefix "${PUBLIC_UPDATE_ORIGIN}/${LATEST_PREFIX}" \
+            --include-aliases true
+
       - name: Publish latest release pointer
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -494,6 +534,12 @@ jobs:
             --content-type "application/json; charset=utf-8" \
             --cache-control "public, no-cache, must-revalidate" \
             --only-show-errors
+
+      - name: Verify promoted Stable update feed contract
+        if: ${{ inputs.channel == 'stable' }}
+        run: |
+          node scripts/verify-desktop-stable-update-feed.mjs \
+            --expected-version "${{ steps.release.outputs.version }}"
 
       - name: Download current release catalog
         env:
@@ -519,6 +565,7 @@ jobs:
           node scripts/update-desktop-release-catalog.mjs \
             --existing "${RUNNER_TEMP}/releases-current.json" \
             --release "${BUNDLE_DIRECTORY}/release.json" \
+            --channels "${{ steps.release.outputs.catalog_channels }}" \
             --output "${RUNNER_TEMP}/releases-next.json"
 
       - name: Publish release catalog
@@ -615,6 +662,7 @@ jobs:
           LATEST_PREFIX: ${{ steps.release.outputs.latest_prefix }}
           R2_PREFIX: ${{ steps.release.outputs.r2_prefix }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_CHANNEL: ${{ inputs.channel }}
         shell: bash
         run: |
           {
@@ -624,4 +672,7 @@ jobs:
             echo "- Immutable R2 manifest: ${PUBLIC_DOWNLOAD_ORIGIN}/${R2_PREFIX}/release.json"
             echo "- Latest pointer: ${PUBLIC_DOWNLOAD_ORIGIN}/${LATEST_PREFIX}/latest.json"
             echo "- Release catalog: ${PUBLIC_DOWNLOAD_ORIGIN}/${CATALOG_KEY}"
+            if [ "${RELEASE_CHANNEL}" = "stable" ]; then
+              echo "- Stable updater feed: ${PUBLIC_UPDATE_ORIGIN}/${LATEST_PREFIX}/stable-mac.yml"
+            fi
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/desktop-update-feed-monitor.yml
+++ b/.github/workflows/desktop-update-feed-monitor.yml
@@ -1,0 +1,45 @@
+name: Desktop Stable Update Feed Monitor
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: desktop-stable-update-feed-monitor
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify shipped Stable update contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout trusted verification code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Verify every shipped Stable update feed
+        id: update_feed
+        run: node scripts/verify-desktop-stable-update-feed.mjs
+
+      - name: Summarize update feed health
+        if: ${{ always() }}
+        env:
+          VERIFY_OUTCOME: ${{ steps.update_feed.outcome }}
+        run: |
+          {
+            echo "### Desktop Stable update feed"
+            echo
+            echo "- Result: ${VERIFY_OUTCOME}"
+            echo "- Machine update origin: https://updates.puppyone.ai/desktop/stable/mac/latest/stable-mac.yml"
+            echo "- Public release pointer: https://downloads.puppyone.ai/desktop/stable/mac/latest/latest.json"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -13,6 +13,26 @@ A release is built exactly once. The verified bundle from that build is uploaded
 unchanged to GitHub and R2. Independent local R2 publishing is intentionally not
 supported because it can split the GitHub, R2, catalog, and updater state.
 
+## Distribution Origins
+
+The release bucket has two public roles, not two copies of every release:
+
+| Origin | Contract | Consumers |
+|---|---|---|
+| `https://updates.puppyone.ai` | permanent Stable machine-update API | Stable apps already installed on user machines |
+| `https://downloads.puppyone.ai` | public download and release-discovery API | website, operators, manual downloads, catalogs |
+
+Both origins expose the same `puppyone-desktop` R2 object keys. The publisher
+uploads each object once, then verifies it through the origin used by each
+consumer. `updates.puppyone.ai` must be a direct custom-domain or pass-through
+mapping, not a redirect to the website origin.
+
+An update feed embedded in a shipped Stable app is a permanent compatibility
+endpoint. `shared/desktop-distribution-contract.mjs` is the source of truth for
+the bucket, origin roles, and every shipped feed contract. A future origin
+migration appends the old and new feeds to that registry and keeps both healthy
+until no supported installed version depends on the old one.
+
 ## R2 Layout
 
 The bucket is `puppyone-desktop`. Existing channel URLs remain compatible:
@@ -132,14 +152,17 @@ resolve and validate Build Identity
 → verify the local bundle
 → create GitHub build-provenance attestations
 → hand off one immutable Actions artifact
+→ verify the existing Stable update contract before any publication write
 → upload the immutable R2 version
 → verify every public R2 object by SHA-256
 → create a GitHub draft release with the same files
 → verify GitHub's asset digests
 → publish Stable GitHub release, or retain Internal as a draft
 → promote channel payloads and aliases
-→ verify every mutable payload by SHA-256
+→ verify every mutable payload through downloads.puppyone.ai by SHA-256
+→ verify Stable updater payloads through updates.puppyone.ai by SHA-256
 → publish latest.json
+→ verify Stable metadata, exact version, payload size, and HTTP byte ranges
 → merge and publish the website catalog
 → verify the public pointer and catalog bytes
 → remove stale files from the mutable latest prefix
@@ -153,6 +176,17 @@ closed and requires a new tag or explicit cleanup.
 
 All GitHub-owned actions are pinned to full commit SHAs. Build provenance is
 generated for binaries, `build-info.json`, `release.json`, and `SHA256SUMS`.
+
+`.github/workflows/desktop-update-feed-monitor.yml` runs the same Stable feed
+contract every six hours and on manual dispatch. It has a read-only GitHub token
+and no signing, R2, or Cloudflare credentials. A failed monitor is an
+operational incident: do not publish another Stable version until the existing
+installed-client path is healthy.
+
+The publisher's live-origin preflight is also a separate read-only job. It runs
+before the deployment-environment job is eligible, so operators are not asked
+to approve and expose publication secrets for a release whose existing
+installed-client path is already broken.
 
 ## GitHub Repository Setup
 
@@ -256,11 +290,17 @@ official references:
 
 ## Cloudflare Setup
 
-The custom domain is:
+Map both public origins to the same `puppyone-desktop` bucket and preserve the
+object path:
 
 ```text
-https://downloads.puppyone.ai
+downloads.puppyone.ai/<key> → puppyone-desktop/<key>
+updates.puppyone.ai/<key>   → puppyone-desktop/<key>
 ```
+
+Provision DNS and a valid TLS certificate for both names. The Stable publisher
+fails closed before changing public state when the currently shipped update
+origin, metadata, payload, or byte-range behavior is unhealthy.
 
 Versioned release paths use:
 
@@ -280,6 +320,11 @@ or starts_with(http.request.uri.path, "/desktop/catalog/")
 Those paths are mutable. Without this rule, an old alias or cached 404 may
 remain visible after R2 has accepted the new object. Versioned paths should stay
 cacheable and immutable.
+
+The Stable update origin must pass through `Range: bytes=0-0` and return `206`
+with a correct `Content-Range` total. Electron's macOS updater depends on ZIP
+range requests; a domain that returns the right file for ordinary browser
+downloads can still be unusable as an updater endpoint.
 
 The R2 credentials should have object read/write/list permission only for the
 `puppyone-desktop` bucket. They do not need Cloudflare account administration
@@ -334,8 +379,8 @@ Prepare a Stable release by first publishing and approving an Internal build
 for the exact commit. Then point the exact matching Stable tag at that commit:
 
 ```bash
-git tag v0.1.4
-git push origin v0.1.4
+git tag v0.1.5
+git push origin v0.1.5
 ```
 
 The tag and package version must match exactly. The stable workflow prepares the
@@ -346,11 +391,21 @@ credentials to only the signing/notarization step.
 Local verification is supported:
 
 ```bash
-PUPPYONE_BUILD_NUMBER=1843 PUPPYONE_RELEASE_TAG=v0.1.4 npm run dist:mac:release
+PUPPYONE_BUILD_NUMBER=1843 PUPPYONE_RELEASE_TAG=v0.1.5 npm run dist:mac:release
 ```
 
 Local publication is not supported. Only the tagged GitHub workflow can publish
 stable GitHub and R2 state.
+
+Operators can run the same read-only production check locally or from Actions:
+
+```bash
+node scripts/verify-desktop-stable-update-feed.mjs
+```
+
+During a Stable publication the workflow additionally passes the new exact
+version with `--expected-version`; this prevents a successful release from
+leaving the website pointer and installed-client feed on different versions.
 
 ## Release History Backfill
 
@@ -387,7 +442,7 @@ The workflow:
 5. Attaches the same metadata files to the three historical GitHub Releases.
 6. Archives both provenance-free root DMGs separately.
 7. Verifies every public R2 object by SHA-256.
-8. Publishes one catalog containing all five historical entries.
+8. Publishes a Stable/archive public catalog and a separate Internal catalog.
 9. Deletes the two root objects only when `delete_root_objects` is explicitly enabled.
 
 Run it first with deletion disabled. After checking the catalog and website,

--- a/docs/architecture/desktop-auto-update-lifecycle.md
+++ b/docs/architecture/desktop-auto-update-lifecycle.md
@@ -47,13 +47,19 @@ as `build-info.json` in packaged applications. It controls:
 
 Published workflows do not compose versions independently.
 
+Distribution coordinates are owned separately by
+`shared/desktop-distribution-contract.mjs`. That module defines one R2 bucket,
+the human download origin, the Stable machine-update origin, and an append-only
+registry of feed URLs embedded in shipped Stable builds. Build Identity consumes
+that contract; it does not redefine distribution URLs.
+
 ## Installed Isolation
 
 | Channel | Application ID | User-data owner | Feed |
 |---|---|---|---|
 | `dev` | `ai.puppyone.desktop.dev` | `puppyone-development` | none |
-| `internal` | `ai.puppyone.desktop.internal` | `puppyone-internal` | `/desktop/internal/mac/latest` |
-| `stable` | `ai.puppyone.desktop` | `puppyone` | `/desktop/stable/mac/latest` |
+| `internal` | `ai.puppyone.desktop.internal` | `puppyone-internal` | `downloads.puppyone.ai/desktop/internal/mac/latest` |
+| `stable` | `ai.puppyone.desktop` | `puppyone` | `updates.puppyone.ai/desktop/stable/mac/latest` |
 
 Application identity is configured before the single-instance lock and before
 services read `userData`. Internal and Stable can therefore be installed and
@@ -91,6 +97,25 @@ The updater receives Build Identity through dependency injection and resolves
 the feed from the fixed channel policy. Packaged builds ignore
 `PUPPYONE_DESKTOP_UPDATE_CHANNEL` and generic feed overrides.
 
+Signed Stable builds discover updates automatically but never download or
+restart automatically:
+
+1. the first check runs 15 seconds after startup plus up to 15 seconds of jitter
+2. subsequent checks run four hours after the prior check completes plus up to
+   30 minutes of jitter
+3. only one check/download/install operation may be in flight
+4. closing the application cancels the pending timer
+
+Jitter prevents all installed clients from hitting the feed at once after a
+release or common workday start. Recursive one-shot timers avoid overlapping
+checks when a network request is slow.
+
+`autoDownload` and `autoInstallOnAppQuit` remain disabled. Discovery changes
+main-process state only. An actionable update appears in the titlebar and in
+**Settings → General → App updates**; the user chooses when to download and
+restart. Settings also retains an explicit manual check. There is no forced
+download, forced restart, or system notification.
+
 The only override is an explicit unpackaged Development test:
 
 ```text
@@ -109,6 +134,11 @@ without adding another channel.
 Stable requires Developer ID signing, hardened runtime, notarization, stapling,
 Gatekeeper acceptance, a ZIP payload, and the channel-specific
 `stable-mac.yml` updater metadata.
+
+The Stable feed is a shipped API, not a replaceable website link. Every feed URL
+ever embedded in a supported Stable build remains in
+`DESKTOP_SHIPPED_STABLE_UPDATE_CONTRACTS`. New releases and the scheduled
+monitor verify all registered endpoints.
 
 ## Update State Machine
 
@@ -173,6 +203,17 @@ Stable is source promotion, not byte promotion. The workflow:
 Internal and Stable use the same canonical publisher. Immutable R2 objects and
 GitHub assets are verified before mutable latest pointers and the catalog.
 
+Stable publication additionally:
+
+1. verifies the current installed-client feed before any external write
+2. promotes each object once into the shared R2 bucket
+3. verifies mutable bytes through both the download and machine-update origins
+4. publishes `latest.json`
+5. checks metadata/pointer version equality and exact payload byte-range support
+
+`.github/workflows/desktop-update-feed-monitor.yml` repeats the read-only
+contract check every six hours, independent of release events.
+
 Internal GitHub records remain drafts in this public repository. R2 authorization
 must be enforced by Cloudflare Access or another authenticated distribution
 boundary; an obscure path or prerelease label is not access control.
@@ -193,7 +234,14 @@ npm run build
 
 Key tests cover resolver validation, application/profile/feed isolation,
 packaged metadata inspection, renderer presentation, updater feed pinning,
-release-manifest equality, and exact-commit Stable promotion.
+automatic scheduling, release-manifest equality, dual-origin publication
+gates, byte-range behavior, and exact-commit Stable promotion.
+
+The production endpoint can be checked without publishing:
+
+```bash
+node scripts/verify-desktop-stable-update-feed.mjs
+```
 
 ## Invariants
 
@@ -202,7 +250,12 @@ release-manifest equality, and exact-commit Stable promotion.
 - Development never uses a product update feed.
 - Internal never resolves the Stable feed.
 - Stable never resolves the Internal feed.
+- A feed embedded in a shipped Stable build remains a supported compatibility
+  endpoint.
+- Background discovery never downloads or restarts without a user action.
 - Packaged version, Build Identity, artifact version, release version, and tag
   agree.
+- The website latest pointer and every shipped Stable feed report the same
+  version.
 - Stable always references verified Internal evidence for the same commit.
 - Published versioned objects are immutable; recovery uses a higher version.

--- a/docs/architecture/desktop-sidebar-scroll-lists.md
+++ b/docs/architecture/desktop-sidebar-scroll-lists.md
@@ -5,6 +5,9 @@ the files explorer, Git working tree, Git history, cloud sidebar lists, and
 future sidebar list surfaces. It also records the app-wide scrollbar styling
 rule that the contract depends on.
 
+For the app-wide rule that separates scrollbar and pane-resizer pointer areas,
+see [Pane Edge Interaction Lanes](pane-edge-interaction-lanes.md).
+
 For the complete sidebar composition, ownership, registry, file layout, CSS,
 performance, and testing architecture, see
 [Desktop Sidebar Architecture](desktop-sidebar-architecture.md). This document
@@ -57,8 +60,8 @@ The shared visual edge contract is:
 - `6px` internal row content inset after the row's outer edge.
 
 These are visual measurements, not a requirement that every sidebar use the
-same four-value `padding` declaration. A reserved `6px` scrollbar gutter means
-a scrolling list has only `6px` of CSS padding on the inline end while still
+same four-value `padding` declaration. A reserved `8px` scrollbar gutter means
+a scrolling list has only `4px` of CSS padding on the inline end while still
 producing the same effective `12px` edge. Git's outer wrapper does not scroll,
 so its section rows and nested scroll lists own the inline edge instead.
 
@@ -73,12 +76,25 @@ so its section rows and nested scroll lists own the inline edge instead.
    reintroduces platform-dependent native scrollbars. To hide a scrollbar,
    use `::-webkit-scrollbar { display: none; }`, not `scrollbar-width: none`.
 
-   The global baseline lives in `src/styles/scrollbars.css`: 6px
-   (`--po-scrollbar-size`) classic scrollbars with a transparent track.
-   Custom WebKit scrollbars are always "classic": when a container
-   overflows, the scrollbar consumes layout width. They never overlay.
+   The global baseline lives in `src/styles/scrollbars.css`: an 8px
+   interaction track (`--po-scrollbar-size`) containing a 6px visible thumb
+   (`--po-scrollbar-thumb-size`) with a 1px transparent inset
+   (`--po-scrollbar-thumb-inset`). This middle weight is shared by sidebar
+   lists, code editors, CSV tables, and horizontal Markdown widgets. Custom
+   WebKit scrollbars are always "classic": when a container overflows, the
+   scrollbar consumes layout width. They never overlay.
 
-2. Reserve the gutter in sidebar scroll containers.
+2. Preserve the transparent thumb inset in every state.
+
+   Stateful thumb rules must change `background-color`, never the
+   `background` shorthand. The shorthand resets `background-clip` to
+   `border-box`, paints beneath the transparent border, and silently turns the
+   intended 6px thumb back into an 8px bar. The default sidebar thumb uses
+   `--desktop-sidebar-scrollbar-thumb` and its hover companion: these
+   compensate for the darker chrome material so the rendered thumb has the
+   same perceived lightness as the editor scrollbar.
+
+3. Reserve the gutter in sidebar scroll containers.
 
    Every sidebar scroll container sets `scrollbar-gutter: stable`, so the
    scrollbar width (`--desktop-sidebar-scrollbar-width`) is reserved whether
@@ -90,7 +106,7 @@ so its section rows and nested scroll lists own the inline edge instead.
    containers must opt out with `scrollbar-gutter: auto` (see
    `.desktop-git-sidebar-list`).
 
-3. Compensate the reserved gutter in the list's right padding.
+4. Compensate the reserved gutter in the list's right padding.
 
    The reserved gutter sits between the border and the padding area, so
    content would be inset by gutter + padding on the right. Lists inside a
@@ -106,6 +122,15 @@ so its section rows and nested scroll lists own the inline edge instead.
    Lists whose rows own their horizontal margins through
    `--desktop-sidebar-row-right-gap` (cloud sidebar) instead override that
    token to `--desktop-sidebar-scroll-right-gap` on the scroll container.
+
+5. Keep resize and scroll hit targets adjacent, never overlapping.
+
+   The explorer scrollbar owns the final 8px inside the sidebar. The shared
+   `.po-pane-edge-resize-handle` contract owns the next 8px inside the main
+   pane. Do not place the resizer inside `.explorer-column`, center it across
+   the boundary, or translate it back toward the sidebar: its higher stacking
+   order would intercept scrollbar drags. The complete cross-pane contract is
+   documented in `pane-edge-interaction-lanes.md`.
 
 ## Implementation Rules
 
@@ -165,7 +190,10 @@ so its section rows and nested scroll lists own the inline edge instead.
   - global WebKit scrollbar baseline and the ban on standard scrollbar
     properties
 - `src/styles/tokens.css`
-  - `--po-scrollbar-size`, `--desktop-sidebar-scrollbar-width`,
+  - `--po-scrollbar-size`, `--po-scrollbar-thumb-size`,
+    `--po-scrollbar-thumb-inset`, `--desktop-sidebar-scrollbar-width`,
+    `--desktop-sidebar-scrollbar-thumb`,
+    `--desktop-sidebar-scrollbar-thumb-hover`,
     `--desktop-sidebar-scroll-right-gap`, and
     `--desktop-sidebar-list-padding-block`
 - `packages/shared-ui/src/sidebar/SidebarScrollArea.tsx`,
@@ -220,7 +248,12 @@ so its section rows and nested scroll lists own the inline edge instead.
   settings.
 - Every sidebar scroll container reserves the scrollbar gutter with
   `scrollbar-gutter: stable`; sidebar scrollbars occupy exactly
-  `--desktop-sidebar-scrollbar-width`, always.
+  `--desktop-sidebar-scrollbar-width` (8px in the default skin), while the
+  visible thumb remains 6px.
+- The explorer scrollbar's 8px track and the resizer's 8px target are adjacent
+  on opposite sides of the pane boundary and never overlap.
+- Scrollbar thumb state rules use `background-color`; no modern scrollbar
+  thumb rule may reset `background-clip` with the `background` shorthand.
 - Sidebar rows keep the same width in short lists, long lists, and while a
   list transitions between the two.
 - Total right inset of list content (reserved gutter + list right padding)

--- a/docs/architecture/pane-edge-interaction-lanes.md
+++ b/docs/architecture/pane-edge-interaction-lanes.md
@@ -1,0 +1,52 @@
+# Pane Edge Interaction Lanes
+
+This document defines the app-wide contract for a scrollbar next to a
+resizable pane boundary. It applies to the Data explorer, the Markdown/editor
+surface next to the auxiliary panel, Git History, and future split panes.
+
+## Problem
+
+A scrollbar and a resize handle cannot share the same pointer area. A resize
+handle normally has a higher stacking order, so centering it across a pane
+boundary intercepts drags intended for the scrollbar. Making either control
+wider does not solve that ownership conflict.
+
+## Contract
+
+Every vertical pane boundary has two adjacent, non-overlapping lanes:
+
+1. The scroll pane owns its final `--po-scrollbar-size` (8px). Its visible
+   thumb remains 6px inside that track.
+2. The neighboring pane owns the next `--po-pane-resizer-hit-size` (8px).
+   The resize handle starts exactly at the boundary and extends away from the
+   scroll pane.
+
+The resize lane uses `SidebarResizeHandle paneEdge`, which adds the shared
+`.po-pane-edge-resize-handle` contract. Feature CSS may choose the boundary
+anchor and visual treatment, but it must not redefine the hit width, translate
+the handle across the boundary, or use a negative half-width offset.
+
+## Current Boundary Mapping
+
+- Data explorer: the resize handle is a sibling after `.explorer-column`,
+  anchored at `--data-explorer-width`, and extends into the main editor pane.
+- Git History: the resize handle is a sibling after the history tree, anchored
+  at `--desktop-history-tree-width`, and extends into the commit-detail pane.
+- Auxiliary panel: the resize handle starts at the panel's inline-start edge
+  and extends into the panel. The Markdown/CodeMirror scrollbar remains wholly
+  inside the editor on the opposite side of that boundary.
+
+Logical inset properties preserve the same ownership in RTL.
+
+## Invariants
+
+- Every vertical pane resize handle uses `paneEdge`.
+- `.po-pane-edge-resize-handle` is the only owner of pane-resizer hit width.
+- Pane-edge handles never use `transform` for placement.
+- Pane-edge handles never use a negative offset to straddle a boundary.
+- A scrollbar and a pane resizer never occupy the same pixels, regardless of
+  stacking order.
+- Table cell, row, column, and diagonal table-resize controls are not pane
+  boundaries and are outside this contract.
+
+The architecture checks live in `tests/scrollbarArchitecture.test.ts`.

--- a/electron/main/ipc/feedback-ipc.mjs
+++ b/electron/main/ipc/feedback-ipc.mjs
@@ -1,4 +1,4 @@
-const DEFAULT_FEEDBACK_ENDPOINT = "https://www.puppyone.ai/api/feedback";
+const DEFAULT_FEEDBACK_ENDPOINT = "https://formspree.io/f/mlgqvydy";
 const MAX_FEEDBACK_LENGTH = 2_000;
 const MAX_LOCALE_LENGTH = 80;
 const MAX_SCREENSHOT_BYTES = 3 * 1024 * 1024;
@@ -36,15 +36,22 @@ export function registerFeedbackIpcHandlers({
       throw new Error("Feedback requires a message or screenshot.");
     }
 
+    const normalizedAppVersion = normalizeContextValue(appVersion);
     const body = new FormData();
     body.set("message", message);
-    body.set("appVersion", normalizeContextValue(appVersion));
+    body.set("appVersion", normalizedAppVersion);
     body.set("locale", locale);
     body.set("platform", normalizeContextValue(platform));
-    body.set("website", "");
+    body.set("source", "PuppyOne Desktop");
+    body.set(
+      "subject",
+      `PuppyOne Desktop Feedback · v${normalizedAppVersion || "unknown"}`,
+    );
+    body.set("timestamp", new Date().toISOString());
+    body.set("_gotcha", "");
     if (screenshot) {
       body.set(
-        "screenshot",
+        "attachment",
         new Blob([screenshot.bytes], { type: screenshot.mimeType }),
         SCREENSHOT_FILENAMES.get(screenshot.mimeType),
       );
@@ -55,6 +62,7 @@ export function registerFeedbackIpcHandlers({
       response = await fetchImpl(feedbackEndpoint, {
         method: "POST",
         headers: {
+          accept: "application/json",
           "user-agent": `puppyone-desktop/${normalizeContextValue(appVersion) || "unknown"}`,
         },
         body,
@@ -64,8 +72,7 @@ export function registerFeedbackIpcHandlers({
       throw new Error("The feedback service is unavailable.");
     }
 
-    const result = await response.json().catch(() => null);
-    if (!response.ok || result?.ok !== true) {
+    if (!response.ok) {
       throw new Error("The feedback service could not accept this message.");
     }
 

--- a/electron/update-service.mjs
+++ b/electron/update-service.mjs
@@ -8,8 +8,13 @@ import {
 } from "../shared/desktop-build-identity.mjs";
 
 const UPDATE_STATE_CHANNEL = "updates:state";
-const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
-const STARTUP_CHECK_DELAY_MS = 15 * 1000;
+
+export const DESKTOP_UPDATE_CHECK_SCHEDULE = Object.freeze({
+  startupDelayMs: 15 * 1000,
+  startupJitterMs: 15 * 1000,
+  intervalMs: 4 * 60 * 60 * 1000,
+  intervalJitterMs: 30 * 60 * 1000,
+});
 
 const UPDATE_ACTION_STATES = new Set([
   "idle",
@@ -52,6 +57,8 @@ export function createUpdateService({
   environment = process.env,
   platform = process.platform,
   autoUpdater = updaterPackage.autoUpdater,
+  checkSchedule = DESKTOP_UPDATE_CHECK_SCHEDULE,
+  random = Math.random,
 }) {
   const configuration = resolveDesktopUpdateConfiguration({
     buildInfo,
@@ -62,9 +69,11 @@ export function createUpdateService({
   const currentVersion = configuration.currentVersion;
   const disabledReason = getDisabledReason(app, configuration, platform);
   const canUseUpdater = !disabledReason;
+  const schedule = normalizeCheckSchedule(checkSchedule);
 
-  let startupCheckTimer = null;
-  let intervalTimer = null;
+  let backgroundCheckTimer = null;
+  let disposed = false;
+  let started = false;
   let operationPromise = null;
   let latestUpdateInfo = null;
   let state = createInitialUpdateState({
@@ -74,6 +83,8 @@ export function createUpdateService({
   });
 
   function start() {
+    if (started) return;
+    started = true;
     configureLogger();
     configureUpdater();
     registerUpdaterEvents();
@@ -87,24 +98,18 @@ export function createUpdateService({
       return;
     }
 
-    startupCheckTimer = setTimeout(() => {
-      void checkForUpdates({ silent: true });
-    }, STARTUP_CHECK_DELAY_MS);
-    intervalTimer = setInterval(() => {
-      void checkForUpdates({ silent: true });
-    }, CHECK_INTERVAL_MS);
+    scheduleBackgroundCheck(schedule.startupDelayMs, schedule.startupJitterMs);
   }
 
   function dispose() {
-    if (startupCheckTimer) clearTimeout(startupCheckTimer);
-    if (intervalTimer) clearInterval(intervalTimer);
-    startupCheckTimer = null;
-    intervalTimer = null;
+    disposed = true;
+    if (backgroundCheckTimer) clearTimeout(backgroundCheckTimer);
+    backgroundCheckTimer = null;
   }
 
   function registerIpcHandlers() {
     ipcMain.handle("updates:get-state", () => state);
-    ipcMain.handle("updates:check", () => checkForUpdates({ silent: false }));
+    ipcMain.handle("updates:check", () => checkForUpdates());
     ipcMain.handle("updates:download", () => downloadUpdate());
     ipcMain.handle("updates:update-now", () => updateNow());
     ipcMain.handle("updates:install", () => installDownloadedUpdate());
@@ -204,14 +209,26 @@ export function createUpdateService({
     });
   }
 
-  async function checkForUpdates({ silent }) {
+  function scheduleBackgroundCheck(baseDelayMs, jitterMs) {
+    if (disposed || !canUseUpdater) return;
+    if (backgroundCheckTimer) clearTimeout(backgroundCheckTimer);
+    const delayMs = baseDelayMs + Math.floor(normalizeRandomValue(random()) * (jitterMs + 1));
+    backgroundCheckTimer = setTimeout(() => {
+      backgroundCheckTimer = null;
+      void checkForUpdates().finally(() => {
+        scheduleBackgroundCheck(schedule.intervalMs, schedule.intervalJitterMs);
+      });
+    }, delayMs);
+    backgroundCheckTimer.unref?.();
+  }
+
+  async function checkForUpdates() {
     return runExclusive(async () => {
       if (!canUseUpdater) return state;
       publishState({
         status: "checking",
         error: null,
         blockers: [],
-        ...(silent ? { silent: true } : {}),
       });
 
       try {
@@ -499,6 +516,37 @@ function normalizeUpdateFeedUrl(value) {
 
 function isTruthyEnvironmentValue(value) {
   return value === "1" || value === "true" || value === "yes";
+}
+
+function normalizeCheckSchedule(value) {
+  const schedule = value && typeof value === "object" ? value : {};
+  return Object.freeze({
+    startupDelayMs: normalizeScheduleNumber(
+      schedule.startupDelayMs,
+      DESKTOP_UPDATE_CHECK_SCHEDULE.startupDelayMs,
+    ),
+    startupJitterMs: normalizeScheduleNumber(
+      schedule.startupJitterMs,
+      DESKTOP_UPDATE_CHECK_SCHEDULE.startupJitterMs,
+    ),
+    intervalMs: normalizeScheduleNumber(
+      schedule.intervalMs,
+      DESKTOP_UPDATE_CHECK_SCHEDULE.intervalMs,
+    ),
+    intervalJitterMs: normalizeScheduleNumber(
+      schedule.intervalJitterMs,
+      DESKTOP_UPDATE_CHECK_SCHEDULE.intervalJitterMs,
+    ),
+  });
+}
+
+function normalizeScheduleNumber(value, fallback) {
+  return Number.isSafeInteger(value) && value >= 0 ? value : fallback;
+}
+
+function normalizeRandomValue(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(0.999999999, value));
 }
 
 function normalizeUpdateInfo(info) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppyone/desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppyone/desktop",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puppyone/desktop",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared-ui/src/data/DataWorkspace.tsx
+++ b/packages/shared-ui/src/data/DataWorkspace.tsx
@@ -9,7 +9,6 @@ import {
   useRef,
   useState,
   type CSSProperties,
-  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
 } from "react";
@@ -45,6 +44,10 @@ import type { DocumentPersistedCommit } from "../editor/document-session/types";
 import { flushActiveDocumentSessions } from "../editor/document-session/activeDocumentSessions";
 import type { FileIconThemeId } from "../file/fileIcons";
 import { usePaneResizeDrag } from "../primitives/usePaneResizeDrag";
+import {
+  SidebarResizeHandle,
+  type SidebarResizeIntent,
+} from "../sidebar/SidebarResizeHandle";
 import { getRendererPerformanceTracker } from "../performance/rendererPerformance";
 import { FileOpenRequestCoordinator } from "./file-open/fileOpenRequestCoordinator";
 import { putBoundedFileContent } from "./file-open/fileContentCache";
@@ -1237,23 +1240,22 @@ export function DataWorkspace({
     },
   });
 
-  const nudgeExplorerWidth = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+  const resizeExplorerByKeyboard = (intent: SidebarResizeIntent, accelerated: boolean) => {
     if (!resizableExplorer) return;
 
-    const step = event.shiftKey ? 24 : 12;
-    if (event.key === "ArrowLeft") {
-      event.preventDefault();
-      setExplorerWidth(resolvedExplorerWidth + (direction === "rtl" ? step : -step));
-    } else if (event.key === "ArrowRight") {
-      event.preventDefault();
-      setExplorerWidth(resolvedExplorerWidth + (direction === "rtl" ? -step : step));
-    } else if (event.key === "Home") {
-      event.preventDefault();
+    if (intent === "minimum") {
       setExplorerWidth(minExplorerWidth);
-    } else if (event.key === "End") {
-      event.preventDefault();
-      setExplorerWidth(maxExplorerWidth);
+      return;
     }
+    if (intent === "maximum") {
+      setExplorerWidth(maxExplorerWidth);
+      return;
+    }
+
+    const step = accelerated ? 24 : 12;
+    const physicalDirection = intent === "decrease" ? -1 : 1;
+    const directionMultiplier = direction === "rtl" ? -1 : 1;
+    setExplorerWidth(resolvedExplorerWidth + physicalDirection * directionMultiplier * step);
   };
 
   const dataContentStyle = resizableExplorer
@@ -1375,21 +1377,21 @@ export function DataWorkspace({
               {renderWorkspaceSlot(explorerFooterSlot, workspaceState)}
             </div>
           )}
-          {resizableExplorer && !explorerCollapsed && (
-            <div
-              className="data-explorer-resizer"
-              role="separator"
-              aria-label={t("shared-ui.explorer.resizeSidebar")}
-              aria-orientation="vertical"
-              aria-valuemin={minExplorerWidth}
-              aria-valuemax={maxExplorerWidth}
-              aria-valuenow={resolvedExplorerWidth}
-              tabIndex={0}
-              onPointerDown={beginExplorerResize}
-              onKeyDown={nudgeExplorerWidth}
-            />
-          )}
         </aside>
+
+        {resizableExplorer && !explorerCollapsed && (
+          <SidebarResizeHandle
+            className="data-explorer-resizer"
+            paneEdge
+            orientation="vertical"
+            label={t("shared-ui.explorer.resizeSidebar")}
+            min={minExplorerWidth}
+            max={maxExplorerWidth}
+            value={resolvedExplorerWidth}
+            onPointerDown={beginExplorerResize}
+            onKeyboardResize={resizeExplorerByKeyboard}
+          />
+        )}
 
         {explorerCollapsed && collapsedExplorerSlot && (
           <div className="data-explorer-collapsed-slot">

--- a/packages/shared-ui/src/data/ExplorerTree.tsx
+++ b/packages/shared-ui/src/data/ExplorerTree.tsx
@@ -40,6 +40,7 @@ import { useExplorerMotion } from "./explorer/useExplorerMotion";
 import {
   EXPLORER_REFERENCE_DRAG_TYPE,
   EXPLORER_TREE_NODE_DRAG_TYPE,
+  parseExplorerReferenceDrag,
   serializeExplorerReferenceDrag,
 } from "./explorer/explorerReferenceDrag";
 import {
@@ -250,10 +251,11 @@ export function ExplorerTree({
   ), []);
   const selectedPathsRef = useRef(selectedPaths);
   const selectedDragNodesRef = useRef(selectedDragNodes);
-  const draggedNodesRef = useRef(draggedNodes);
+  // This ref is the operational drag session. React state below is only its
+  // visual projection and must never overwrite the session during render.
+  const draggedNodesRef = useRef<DataNode[]>([]);
   selectedPathsRef.current = selectedPaths;
   selectedDragNodesRef.current = selectedDragNodes;
-  draggedNodesRef.current = draggedNodes;
   const dragCallbacksRef = useRef({ onImportFiles, onMoveNode, onMoveNodes });
   dragCallbacksRef.current = { onImportFiles, onMoveNode, onMoveNodes };
 
@@ -264,6 +266,7 @@ export function ExplorerTree({
 
   const clearDragState = useCallback(() => {
     clearDropTarget();
+    draggedNodesRef.current = [];
     setDraggedNodes((current) => (current.length === 0 ? current : []));
   }, [clearDropTarget]);
 
@@ -286,17 +289,20 @@ export function ExplorerTree({
     window.addEventListener("dragend", clearDragState, true);
     window.addEventListener("drop", clearAfterDrop, true);
     window.addEventListener("keydown", clearOnEscape, true);
-    window.addEventListener("blur", clearDragState, true);
+    // Window focus is not a drag terminal signal. Chromium/Electron may move
+    // focus while a native drag session is still active, so preserve the
+    // synchronous source session and clear only stale hover feedback.
+    window.addEventListener("blur", clearDropTarget, true);
     document.addEventListener("visibilitychange", clearOnVisibilityChange, true);
     return () => {
       disposed = true;
       window.removeEventListener("dragend", clearDragState, true);
       window.removeEventListener("drop", clearAfterDrop, true);
       window.removeEventListener("keydown", clearOnEscape, true);
-      window.removeEventListener("blur", clearDragState, true);
+      window.removeEventListener("blur", clearDropTarget, true);
       document.removeEventListener("visibilitychange", clearOnVisibilityChange, true);
     };
-  }, [clearDragState]);
+  }, [clearDragState, clearDropTarget]);
 
   const setNextDropTarget = useCallback((
     rowPath: string | null,
@@ -317,6 +323,20 @@ export function ExplorerTree({
     });
   }, []);
 
+  const recoverDraggedNodes = useCallback((dataTransfer: DataTransfer): DataNode[] => {
+    const payload = parseExplorerReferenceDrag(dataTransfer.getData(EXPLORER_REFERENCE_DRAG_TYPE));
+    if (!payload || !dragWorkspaceId || payload.workspaceId !== dragWorkspaceId) return [];
+
+    const recoveredNodes = payload.entries
+      .map((entry) => nodeIndex.get(entry.path) ?? null)
+      .filter((node): node is DataNode => node !== null);
+    if (recoveredNodes.length !== payload.entries.length) return [];
+
+    return recoveredNodes.filter((node) => !recoveredNodes.some((candidate) => (
+      candidate.path !== node.path && node.path.startsWith(`${candidate.path}/`)
+    )));
+  }, [dragWorkspaceId, nodeIndex]);
+
   const beginNodeDrag = useCallback((event: ReactDragEvent<HTMLDivElement>, node: DataNode) => {
     event.stopPropagation();
     event.dataTransfer.effectAllowed = moveEnabled ? "copyMove" : "copy";
@@ -331,6 +351,10 @@ export function ExplorerTree({
       );
     }
     event.dataTransfer.setData("text/plain", movingNodes.map((item) => item.path).join("\n"));
+    // Native drag events are not coupled to React's commit timing. Seed the
+    // operation ref synchronously so an immediate dragover/drop cannot observe
+    // the previous render's empty state.
+    draggedNodesRef.current = movingNodes;
     setDraggedNodes(movingNodes);
     setDropTarget(null);
   }, [dragWorkspaceId, moveEnabled]);
@@ -350,9 +374,17 @@ export function ExplorerTree({
     }
 
     const currentDraggedNodes = draggedNodesRef.current;
-    if (!moveEnabled || currentDraggedNodes.length === 0) return false;
+    const transferTypes = Array.from(event.dataTransfer.types);
+    const hasInternalTransfer = transferTypes.includes(EXPLORER_REFERENCE_DRAG_TYPE)
+      || transferTypes.includes(EXPLORER_TREE_NODE_DRAG_TYPE);
+    if (!moveEnabled || (currentDraggedNodes.length === 0 && !hasInternalTransfer)) return false;
 
-    const valid = isValidMoveTargetForNodes(currentDraggedNodes, targetFolderPath);
+    // The HTML drag data store is in protected mode during dragover, so payload
+    // data cannot be read here. A typed internal transfer is provisionally
+    // accepted and is resolved and validated during drop.
+    const valid = currentDraggedNodes.length === 0
+      ? true
+      : isValidMoveTargetForNodes(currentDraggedNodes, targetFolderPath);
     event.preventDefault();
     event.stopPropagation();
     event.dataTransfer.dropEffect = valid ? "move" : "none";
@@ -388,7 +420,9 @@ export function ExplorerTree({
       return;
     }
 
-    const currentDraggedNodes = draggedNodesRef.current;
+    const currentDraggedNodes = draggedNodesRef.current.length > 0
+      ? draggedNodesRef.current
+      : recoverDraggedNodes(event.dataTransfer);
     if (!moveEnabled || currentDraggedNodes.length === 0) return;
 
     event.preventDefault();
@@ -404,7 +438,7 @@ export function ExplorerTree({
     void Promise.resolve(moveResult).catch((error) => {
       console.error("Unable to move explorer item:", error);
     });
-  }, [clearDragState, importEnabled, moveEnabled]);
+  }, [clearDragState, importEnabled, moveEnabled, recoverDraggedNodes]);
 
   const dragController = useMemo<TreeDragController>(() => ({
     // Outbound copy/context drag is independent from in-tree move support.
@@ -562,6 +596,12 @@ export function ExplorerTree({
               </span>
             </div>
           )}
+        </div>
+      )}
+
+      {rootError && nodes.length > 0 && (
+        <div className="explorer-tree-error-banner" role="alert" dir="auto">
+          {rootError}
         </div>
       )}
 

--- a/packages/shared-ui/src/sidebar/SidebarResizeHandle.tsx
+++ b/packages/shared-ui/src/sidebar/SidebarResizeHandle.tsx
@@ -6,6 +6,7 @@ export type SidebarResizeIntent = "decrease" | "increase" | "minimum" | "maximum
 export type SidebarResizeHandleProps = Omit<HTMLAttributes<HTMLDivElement>, "onKeyDown"> & {
   label: string;
   orientation: "horizontal" | "vertical";
+  paneEdge?: boolean;
   value?: number;
   min?: number;
   max?: number;
@@ -20,6 +21,7 @@ export const SidebarResizeHandle = forwardRef<HTMLDivElement, SidebarResizeHandl
     min,
     onKeyboardResize,
     orientation,
+    paneEdge = false,
     role = "separator",
     tabIndex = 0,
     value,
@@ -44,7 +46,11 @@ export const SidebarResizeHandle = forwardRef<HTMLDivElement, SidebarResizeHandl
   return (
     <div
       ref={ref}
-      className={joinSidebarClassNames("po-sidebar-resize-handle", className)}
+      className={joinSidebarClassNames(
+        "po-sidebar-resize-handle",
+        paneEdge && "po-pane-edge-resize-handle",
+        className,
+      )}
       role={role}
       tabIndex={tabIndex}
       aria-label={label}

--- a/packages/shared-ui/src/styles/data-workspace.css
+++ b/packages/shared-ui/src/styles/data-workspace.css
@@ -116,25 +116,14 @@
 }
 
 .data-explorer-resizer {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 35;
-  width: 9px;
-  transform: translateX(4px);
-  cursor: col-resize;
-  touch-action: none;
+  /*
+   * Start at the grid boundary and extend into the main pane. Moving this
+   * target back into the explorer would cover the sidebar scrollbar track.
+   */
+  inset-inline-start: var(--data-explorer-width, clamp(282px, 26vw, 360px));
 }
 
 .data-explorer-resizer::after {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 4px;
-  width: 1px;
-  background: transparent;
-  content: "";
   transition: background 120ms ease, box-shadow 120ms ease;
 }
 
@@ -233,9 +222,14 @@ body.data-sidebar-resizing .data-preview-accessory {
       color-mix(in srgb, var(--po-selected) 38%, transparent) 100%
     )
   );
-  --tree-scrollbar-width: var(--po-tree-scrollbar-width, var(--po-scrollbar-size, 6px));
-  --tree-scrollbar-radius: var(--po-scrollbar-radius, 3px);
+  --tree-scrollbar-width: var(--po-tree-scrollbar-width, var(--po-scrollbar-size, 8px));
+  --tree-scrollbar-radius: var(--po-scrollbar-radius, 999px);
   --tree-scrollbar-transition: var(--po-scrollbar-transition, 0.16s ease);
+  --tree-scrollbar-thumb: var(--desktop-sidebar-scrollbar-thumb, var(--po-scrollbar-thumb));
+  --tree-scrollbar-thumb-hover: var(
+    --desktop-sidebar-scrollbar-thumb-hover,
+    var(--po-scrollbar-thumb-hover)
+  );
 
   position: relative;
   display: flex;
@@ -251,6 +245,19 @@ body.data-sidebar-resizing .data-preview-accessory {
   box-sizing: border-box;
   padding-top: var(--tree-root-top-gap);
   background: var(--po-sidebar);
+}
+
+.explorer-tree-error-banner {
+  flex: 0 0 auto;
+  margin: 6px var(--tree-row-right-gap) 4px var(--tree-row-left-gap);
+  padding: 6px 8px;
+  border: 1px solid color-mix(in srgb, var(--po-danger) 24%, transparent);
+  border-radius: var(--tree-row-radius);
+  background: color-mix(in srgb, var(--po-danger) 8%, var(--po-sidebar));
+  color: var(--po-danger);
+  font-size: 12px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .explorer-tree-scroll {
@@ -276,20 +283,16 @@ body.data-sidebar-resizing .data-preview-accessory {
 }
 
 .explorer-tree-scroll::-webkit-scrollbar-thumb {
+  border: var(--po-scrollbar-thumb-inset, 1px) solid transparent;
   border-radius: var(--tree-scrollbar-radius);
-  background: transparent;
+  background-color: var(--tree-scrollbar-thumb);
+  background-clip: padding-box;
   transition: background-color var(--tree-scrollbar-transition);
-}
-
-.explorer-tree-shell.is-scrollable:hover .explorer-tree-scroll::-webkit-scrollbar-thumb,
-.explorer-tree-shell.is-scrollable:focus-within .explorer-tree-scroll::-webkit-scrollbar-thumb,
-.explorer-tree-scroll.is-scrollable.po-scrollbar-active::-webkit-scrollbar-thumb {
-  background: var(--po-scrollbar-thumb);
 }
 
 .explorer-tree-scroll::-webkit-scrollbar-thumb:hover,
 .explorer-tree-scroll.po-scrollbar-active::-webkit-scrollbar-thumb:hover {
-  background: var(--po-scrollbar-thumb-hover);
+  background-color: var(--tree-scrollbar-thumb-hover);
 }
 
 .explorer-tree-list {

--- a/packages/shared-ui/src/styles/editor/csv-table-editor.css
+++ b/packages/shared-ui/src/styles/editor/csv-table-editor.css
@@ -151,12 +151,11 @@
   min-height: 0;
   overflow: auto;
   overscroll-behavior: contain;
-  scrollbar-color: var(--po-scrollbar-thumb) transparent;
 }
 
 .csv-table-editor__scroll::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
+  width: var(--po-scrollbar-size, 8px);
+  height: var(--po-scrollbar-size, 8px);
 }
 
 .csv-table-editor__scroll::-webkit-scrollbar-track,
@@ -165,9 +164,9 @@
 }
 
 .csv-table-editor__scroll::-webkit-scrollbar-thumb {
-  border: 2px solid transparent;
-  border-radius: 999px;
-  background: var(--po-scrollbar-thumb);
+  border: var(--po-scrollbar-thumb-inset, 1px) solid transparent;
+  border-radius: var(--po-scrollbar-radius, 999px);
+  background-color: var(--po-scrollbar-thumb);
   background-clip: padding-box;
 }
 

--- a/packages/shared-ui/src/styles/editor/editable-table.css
+++ b/packages/shared-ui/src/styles/editor/editable-table.css
@@ -290,12 +290,12 @@
 
 .po-editable-table-context-menu.desktop-menu-surface::-webkit-scrollbar-thumb {
   border: 1px solid var(--po-menu-bg);
-  background: var(--po-scrollbar-thumb);
+  background-color: var(--po-scrollbar-thumb);
   background-clip: padding-box;
 }
 
 .po-editable-table-context-menu.desktop-menu-surface::-webkit-scrollbar-thumb:hover {
-  background: var(--po-scrollbar-thumb-hover);
+  background-color: var(--po-scrollbar-thumb-hover);
   background-clip: padding-box;
 }
 

--- a/packages/shared-ui/src/styles/editor/markdown-code-widgets.css
+++ b/packages/shared-ui/src/styles/editor/markdown-code-widgets.css
@@ -101,7 +101,7 @@
 
 .markdown-codemirror-editor .cm-md-code-textarea::-webkit-scrollbar {
   width: 0;
-  height: 8px;
+  height: var(--po-scrollbar-size, 8px);
 }
 
 .markdown-codemirror-editor .cm-md-code-textarea::-webkit-scrollbar-track,
@@ -110,9 +110,9 @@
 }
 
 .markdown-codemirror-editor .cm-md-code-textarea::-webkit-scrollbar-thumb {
-  border: 2px solid transparent;
-  border-radius: 999px;
-  background: var(--po-scrollbar-thumb);
+  border: var(--po-scrollbar-thumb-inset, 1px) solid transparent;
+  border-radius: var(--po-scrollbar-radius, 999px);
+  background-color: var(--po-scrollbar-thumb);
   background-clip: padding-box;
 }
 

--- a/packages/shared-ui/src/styles/editor/markdown-table-widget.css
+++ b/packages/shared-ui/src/styles/editor/markdown-table-widget.css
@@ -29,7 +29,7 @@
 }
 
 .markdown-codemirror-editor .cm-md-table-widget-wrap::-webkit-scrollbar {
-  height: 8px;
+  height: var(--po-scrollbar-size, 8px);
 }
 
 .markdown-codemirror-editor .cm-md-table-widget-wrap::-webkit-scrollbar-track,
@@ -38,9 +38,9 @@
 }
 
 .markdown-codemirror-editor .cm-md-table-widget-wrap::-webkit-scrollbar-thumb {
-  border: 2px solid transparent;
-  border-radius: 999px;
-  background: var(--po-scrollbar-thumb);
+  border: var(--po-scrollbar-thumb-inset, 1px) solid transparent;
+  border-radius: var(--po-scrollbar-radius, 999px);
+  background-color: var(--po-scrollbar-thumb);
   background-clip: padding-box;
 }
 
@@ -458,12 +458,12 @@
 
 .cm-md-table-context-menu.desktop-menu-surface::-webkit-scrollbar-thumb {
   border: 1px solid var(--po-menu-bg);
-  background: var(--po-scrollbar-thumb);
+  background-color: var(--po-scrollbar-thumb);
   background-clip: padding-box;
 }
 
 .cm-md-table-context-menu.desktop-menu-surface::-webkit-scrollbar-thumb:hover {
-  background: var(--po-scrollbar-thumb-hover);
+  background-color: var(--po-scrollbar-thumb-hover);
   background-clip: padding-box;
 }
 

--- a/packages/shared-ui/src/styles/sidebar-primitives.css
+++ b/packages/shared-ui/src/styles/sidebar-primitives.css
@@ -184,6 +184,25 @@
   cursor: row-resize;
 }
 
+.po-pane-edge-resize-handle {
+  position: absolute;
+  inset-block: 0;
+  z-index: var(--po-pane-resizer-z-index, 35);
+  width: var(--po-pane-resizer-hit-size, 8px);
+  transform: none;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.po-pane-edge-resize-handle::after {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 0;
+  width: var(--po-pane-resizer-line-size, 1px);
+  background: transparent;
+  content: "";
+}
+
 .po-sidebar-resize-handle:focus-visible {
   outline: 2px solid var(--po-focus-ring, var(--po-accent));
   outline-offset: -2px;

--- a/scripts/check-desktop-build-identity-architecture.mjs
+++ b/scripts/check-desktop-build-identity-architecture.mjs
@@ -8,6 +8,15 @@ import {
   getDesktopBuildChannelPolicy,
   resolveDesktopBuildIdentity,
 } from "../shared/desktop-build-identity.mjs";
+import {
+  DESKTOP_INTERNAL_UPDATE_FEED_URL,
+  DESKTOP_PUBLIC_DOWNLOAD_ORIGIN,
+  DESKTOP_SHIPPED_STABLE_UPDATE_CONTRACTS,
+  DESKTOP_STABLE_LATEST_POINTER_URL,
+  DESKTOP_STABLE_UPDATE_ORIGIN,
+  DESKTOP_STABLE_UPDATE_FEED_URL,
+  DESKTOP_SUPPORTED_STABLE_UPDATE_FEED_URLS,
+} from "../shared/desktop-distribution-contract.mjs";
 import { createDesktopElectronBuilderConfig } from "./release-support/desktop-build-preparation.mjs";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -28,11 +37,51 @@ for (const field of ["applicationId", "applicationName", "userDataName"]) {
 if (getDesktopBuildChannelPolicy("dev").updateFeedUrl !== null) {
   errors.push("Development builds must not have a product update feed");
 }
-if (!getDesktopBuildChannelPolicy("internal").updateFeedUrl?.includes("/internal/")) {
-  errors.push("Internal builds must use the Internal update feed");
+if (getDesktopBuildChannelPolicy("internal").updateFeedUrl !== DESKTOP_INTERNAL_UPDATE_FEED_URL) {
+  errors.push("Internal builds must use the canonical Internal distribution feed");
 }
-if (!getDesktopBuildChannelPolicy("stable").updateFeedUrl?.includes("/stable/")) {
-  errors.push("Stable builds must use the Stable update feed");
+if (getDesktopBuildChannelPolicy("stable").updateFeedUrl !== DESKTOP_STABLE_UPDATE_FEED_URL) {
+  errors.push("Stable builds must use the permanent Stable machine update feed");
+}
+if (!DESKTOP_SUPPORTED_STABLE_UPDATE_FEED_URLS.includes(DESKTOP_STABLE_UPDATE_FEED_URL)) {
+  errors.push("the canonical Stable feed must remain in the shipped-feed compatibility registry");
+}
+if (
+  DESKTOP_PUBLIC_DOWNLOAD_ORIGIN === DESKTOP_STABLE_UPDATE_ORIGIN
+  || new URL(DESKTOP_STABLE_LATEST_POINTER_URL).origin !== DESKTOP_PUBLIC_DOWNLOAD_ORIGIN
+  || new URL(DESKTOP_STABLE_UPDATE_FEED_URL).origin !== DESKTOP_STABLE_UPDATE_ORIGIN
+) {
+  errors.push("human download and Stable machine-update origins must retain separate roles");
+}
+if (
+  new Set(DESKTOP_SUPPORTED_STABLE_UPDATE_FEED_URLS).size
+  !== DESKTOP_SUPPORTED_STABLE_UPDATE_FEED_URLS.length
+) {
+  errors.push("the shipped Stable feed compatibility registry must not contain duplicates");
+}
+for (const contract of DESKTOP_SHIPPED_STABLE_UPDATE_CONTRACTS) {
+  if (
+    !/^\d+\.\d+\.\d+$/.test(contract.introducedInVersion)
+    || new URL(contract.feedUrl).protocol !== "https:"
+  ) {
+    errors.push("every shipped Stable feed contract must declare an HTTPS URL and release version");
+  }
+}
+if (
+  !DESKTOP_SHIPPED_STABLE_UPDATE_CONTRACTS.some(({ introducedInVersion, feedUrl }) => (
+    introducedInVersion === "0.1.4" && feedUrl === DESKTOP_STABLE_UPDATE_FEED_URL
+  ))
+) {
+  errors.push("the shipped v0.1.4 Stable feed contract must remain registered");
+}
+const configuredStableProvider = packageMetadata.build?.publish?.find?.(
+  (provider) => provider?.provider === "generic",
+);
+if (
+  configuredStableProvider?.url !== DESKTOP_STABLE_UPDATE_FEED_URL
+  || configuredStableProvider?.channel !== "stable"
+) {
+  errors.push("package.json must embed the canonical Stable machine update feed");
 }
 
 const identities = {
@@ -89,6 +138,8 @@ if (mainSource.includes("app.getVersion()")) {
 
 const updaterSource = await readText("electron/update-service.mjs");
 requireSource(updaterSource, "getDesktopBuildChannelPolicy", "the updater must derive its feed from channel policy");
+requireSource(updaterSource, "DESKTOP_UPDATE_CHECK_SCHEDULE", "the Stable updater must retain bounded automatic discovery");
+requireSource(updaterSource, "scheduleBackgroundCheck", "the Stable updater must schedule non-overlapping background checks");
 for (const forbidden of [
   "PUPPYONE_DESKTOP_UPDATE_CHANNEL",
   "PUPPYONE_DESKTOP_UPDATE_URL",
@@ -117,6 +168,12 @@ requireSource(
   generalSettingsSource,
   "<DesktopBuildVersionSettingsRow />",
   "Settings General must own the user-facing Build Identity",
+);
+const titlebarActionsSource = await readText("src/features/app-shell/DesktopTitlebarActions.tsx");
+requireSource(
+  titlebarActionsSource,
+  "<DesktopUpdateTitlebarButton",
+  "actionable Desktop updates must remain visible outside Settings",
 );
 const sidebarSources = [
   await readText("src/features/app-shell/DesktopDataWorkspaceSurface.tsx"),

--- a/scripts/check-macos-release-config.mjs
+++ b/scripts/check-macos-release-config.mjs
@@ -10,6 +10,7 @@ import {
   inspectLegacyArchiveWorkflow,
   inspectReleasePublisherWorkflow,
   inspectStableReleaseWorkflow,
+  inspectUpdateFeedMonitorWorkflow,
 } from "./release-support/internal-release-workflow-policy.mjs";
 import { inspectMacReleaseReadiness } from "./release-support/macos-release-policy.mjs";
 
@@ -73,6 +74,11 @@ const archiveWorkflow = readFileSync(
   "utf8",
 );
 errors.push(...inspectLegacyArchiveWorkflow(archiveWorkflow));
+const updateFeedMonitorWorkflow = readFileSync(
+  path.join(repoRoot, ".github", "workflows", "desktop-update-feed-monitor.yml"),
+  "utf8",
+);
+errors.push(...inspectUpdateFeedMonitorWorkflow(updateFeedMonitorWorkflow));
 
 try {
   const { validateConfiguration } = require("app-builder-lib/out/util/config/config.js");

--- a/scripts/release-support/desktop-release-metadata.mjs
+++ b/scripts/release-support/desktop-release-metadata.mjs
@@ -374,8 +374,19 @@ export function createLatestPointer(manifest) {
   };
 }
 
-export function mergeReleaseCatalog(existingCatalog, manifest, generatedAt = new Date().toISOString()) {
+export function mergeReleaseCatalog(
+  existingCatalog,
+  manifest,
+  generatedAt = new Date().toISOString(),
+  allowedChannels = null,
+) {
   assertDesktopReleaseManifest(manifest);
+  const channelPolicy = normalizeCatalogChannelPolicy(allowedChannels);
+  if (channelPolicy && !channelPolicy.has(manifest.channel)) {
+    throw new Error(
+      `Release channel ${manifest.channel} is not allowed in this catalog`,
+    );
+  }
   const catalog = existingCatalog == null
     ? {
         schemaVersion: DESKTOP_CATALOG_SCHEMA_VERSION,
@@ -385,6 +396,11 @@ export function mergeReleaseCatalog(existingCatalog, manifest, generatedAt = new
       }
     : structuredClone(existingCatalog);
   assertDesktopReleaseCatalog(catalog);
+  if (channelPolicy) {
+    catalog.releases = catalog.releases.filter((release) => (
+      channelPolicy.has(release.channel)
+    ));
+  }
 
   const existingIndex = catalog.releases.findIndex((release) => release.tag === manifest.tag);
   if (existingIndex >= 0) {
@@ -401,6 +417,20 @@ export function mergeReleaseCatalog(existingCatalog, manifest, generatedAt = new
   ));
   assertDesktopReleaseCatalog(catalog);
   return catalog;
+}
+
+function normalizeCatalogChannelPolicy(allowedChannels) {
+  if (allowedChannels == null) return null;
+  if (!Array.isArray(allowedChannels) || allowedChannels.length === 0) {
+    throw new Error("Catalog channel policy must contain at least one channel");
+  }
+  const channels = new Set(allowedChannels);
+  for (const channel of channels) {
+    if (!["internal", "stable", "archive"].includes(channel)) {
+      throw new Error(`Unsupported catalog channel: ${channel}`);
+    }
+  }
+  return channels;
 }
 
 export function assertDesktopReleaseCatalog(catalog) {

--- a/scripts/release-support/desktop-update-feed-verifier.mjs
+++ b/scripts/release-support/desktop-update-feed-verifier.mjs
@@ -1,0 +1,359 @@
+import {
+  DESKTOP_STABLE_LATEST_POINTER_URL,
+  DESKTOP_STABLE_UPDATE_METADATA_NAME,
+  DESKTOP_SUPPORTED_STABLE_UPDATE_FEED_URLS,
+} from "../../shared/desktop-distribution-contract.mjs";
+
+const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+const SHA512_BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+
+export function parseDesktopUpdaterMetadata(source) {
+  if (typeof source !== "string" || source.trim().length === 0) {
+    throw new Error("Desktop updater metadata is empty.");
+  }
+
+  const metadata = {
+    version: null,
+    files: [],
+    path: null,
+    sha512: null,
+    releaseDate: null,
+  };
+  let readingFiles = false;
+  let currentFile = null;
+
+  for (const rawLine of source.split(/\r?\n/)) {
+    if (!rawLine.trim() || rawLine.trimStart().startsWith("#")) continue;
+    const indentation = rawLine.length - rawLine.trimStart().length;
+    const line = rawLine.trim();
+
+    if (indentation === 0) {
+      readingFiles = false;
+      currentFile = null;
+      const entry = parseMappingEntry(line);
+      if (!entry) continue;
+      if (entry.key === "files" && entry.value === "") {
+        readingFiles = true;
+      } else if (entry.key === "version") {
+        metadata.version = parseScalar(entry.value);
+      } else if (entry.key === "path") {
+        metadata.path = parseScalar(entry.value);
+      } else if (entry.key === "sha512") {
+        metadata.sha512 = parseScalar(entry.value);
+      } else if (entry.key === "releaseDate") {
+        metadata.releaseDate = parseScalar(entry.value);
+      }
+      continue;
+    }
+
+    if (!readingFiles) continue;
+    const fileStart = /^-\s+url:\s*(.+)$/.exec(line);
+    if (fileStart) {
+      currentFile = {
+        url: parseScalar(fileStart[1]),
+        sha512: null,
+        size: null,
+      };
+      metadata.files.push(currentFile);
+      continue;
+    }
+    if (!currentFile) continue;
+    const entry = parseMappingEntry(line);
+    if (!entry) continue;
+    if (entry.key === "sha512") {
+      currentFile.sha512 = parseScalar(entry.value);
+    } else if (entry.key === "size") {
+      currentFile.size = Number.parseInt(parseScalar(entry.value), 10);
+    }
+  }
+
+  const errors = [];
+  if (!VERSION_PATTERN.test(String(metadata.version ?? ""))) {
+    errors.push("version must be a semantic version");
+  }
+  if (!Array.isArray(metadata.files) || metadata.files.length === 0) {
+    errors.push("files must contain at least one update payload");
+  }
+  for (const file of metadata.files) {
+    if (!file.url) errors.push("every update file must declare a URL");
+    if (!isSha512Base64(file.sha512)) {
+      errors.push(`${file.url || "update file"} must declare a base64 SHA-512 digest`);
+    }
+    if (!Number.isSafeInteger(file.size) || file.size <= 0) {
+      errors.push(`${file.url || "update file"} must declare a positive byte size`);
+    }
+  }
+  if (!metadata.files.some(({ url }) => /\.zip(?:$|[?#])/i.test(String(url)))) {
+    errors.push("macOS updater metadata must include a ZIP payload");
+  }
+  const primaryFile = metadata.files.find(({ url }) => url === metadata.path);
+  if (!metadata.path || !primaryFile) {
+    errors.push("path must identify one declared update file");
+  } else if (metadata.sha512 !== primaryFile.sha512) {
+    errors.push("top-level sha512 must match the primary update file");
+  }
+  if (!metadata.releaseDate || Number.isNaN(Date.parse(metadata.releaseDate))) {
+    errors.push("releaseDate must be a valid timestamp");
+  }
+  if (new Set(metadata.files.map(({ url }) => url)).size !== metadata.files.length) {
+    errors.push("update file URLs must be unique");
+  }
+  if (errors.length > 0) {
+    throw new Error(`Invalid Desktop updater metadata:\n${errors.map((error) => `- ${error}`).join("\n")}`);
+  }
+
+  return Object.freeze({
+    ...metadata,
+    files: Object.freeze(metadata.files.map((file) => Object.freeze({ ...file }))),
+  });
+}
+
+export async function verifyDesktopStableUpdateFeeds({
+  attempts = 3,
+  expectedVersion = null,
+  feedUrls = DESKTOP_SUPPORTED_STABLE_UPDATE_FEED_URLS,
+  fetchImpl = globalThis.fetch,
+  latestPointerUrl = DESKTOP_STABLE_LATEST_POINTER_URL,
+  retryDelayMs = 500,
+  timeoutMs = 20_000,
+} = {}) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("Desktop update feed verification requires fetch.");
+  }
+  if (!Array.isArray(feedUrls) || feedUrls.length === 0) {
+    throw new Error("At least one shipped Stable update feed is required.");
+  }
+  if (new Set(feedUrls).size !== feedUrls.length) {
+    throw new Error("Shipped Stable update feeds must be unique.");
+  }
+  for (const [label, value, minimum] of [
+    ["attempts", attempts, 1],
+    ["retryDelayMs", retryDelayMs, 0],
+    ["timeoutMs", timeoutMs, 1],
+  ]) {
+    if (!Number.isSafeInteger(value) || value < minimum) {
+      throw new Error(`${label} must be an integer greater than or equal to ${minimum}.`);
+    }
+  }
+  if (expectedVersion != null && !VERSION_PATTERN.test(String(expectedVersion))) {
+    throw new Error(`Invalid expected Stable version: ${String(expectedVersion)}`);
+  }
+
+  const pointerUrl = normalizeHttpsUrl(latestPointerUrl, "latest pointer");
+  const latestPointer = await fetchJson(pointerUrl, {
+    attempts,
+    fetchImpl,
+    retryDelayMs,
+    timeoutMs,
+  });
+  validateLatestPointer(latestPointer, expectedVersion);
+
+  const reports = [];
+  for (const feedUrl of feedUrls) {
+    const normalizedFeedUrl = normalizeHttpsUrl(feedUrl, "Stable feed").replace(/\/+$/, "");
+    const metadataUrl = `${normalizedFeedUrl}/${DESKTOP_STABLE_UPDATE_METADATA_NAME}`;
+    const source = await fetchText(metadataUrl, {
+      attempts,
+      fetchImpl,
+      retryDelayMs,
+      timeoutMs,
+    });
+    const metadata = parseDesktopUpdaterMetadata(source);
+    const requiredVersion = expectedVersion ?? latestPointer.version;
+    if (metadata.version !== requiredVersion) {
+      throw new Error(
+        `${metadataUrl} reports ${metadata.version}, expected ${requiredVersion}.`,
+      );
+    }
+    if (latestPointer.version !== metadata.version) {
+      throw new Error(
+        `${pointerUrl} reports ${latestPointer.version}, but ${metadataUrl} reports ${metadata.version}.`,
+      );
+    }
+
+    const payloads = [];
+    for (const file of metadata.files) {
+      const payloadUrl = resolveFeedPayloadUrl(normalizedFeedUrl, file.url);
+      await verifyRangeResponse(payloadUrl, file.size, {
+        attempts,
+        fetchImpl,
+        retryDelayMs,
+        timeoutMs,
+      });
+      payloads.push(payloadUrl);
+    }
+    reports.push(Object.freeze({
+      feedUrl: normalizedFeedUrl,
+      metadataUrl,
+      payloads: Object.freeze(payloads),
+      version: metadata.version,
+    }));
+  }
+
+  return Object.freeze({
+    latestPointerUrl: pointerUrl,
+    reports: Object.freeze(reports),
+    version: latestPointer.version,
+  });
+}
+
+function parseMappingEntry(line) {
+  const separator = line.indexOf(":");
+  if (separator < 0) return null;
+  return {
+    key: line.slice(0, separator).trim(),
+    value: line.slice(separator + 1).trim(),
+  };
+}
+
+function parseScalar(value) {
+  const normalized = String(value ?? "").trim();
+  if (
+    normalized.length >= 2
+    && ((normalized.startsWith("'") && normalized.endsWith("'"))
+      || (normalized.startsWith("\"") && normalized.endsWith("\"")))
+  ) {
+    return normalized.slice(1, -1);
+  }
+  return normalized;
+}
+
+function isSha512Base64(value) {
+  const normalized = String(value ?? "");
+  if (
+    !SHA512_BASE64_PATTERN.test(normalized)
+    || normalized.length % 4 !== 0
+  ) {
+    return false;
+  }
+  const bytes = Buffer.from(normalized, "base64");
+  return bytes.byteLength === 64 && bytes.toString("base64") === normalized;
+}
+
+function normalizeHttpsUrl(value, label) {
+  const url = new URL(value);
+  if (
+    url.protocol !== "https:"
+    || url.username
+    || url.password
+    || url.search
+    || url.hash
+  ) {
+    throw new Error(`${label} must be a credential-free HTTPS URL without query or fragment.`);
+  }
+  return url.href;
+}
+
+function resolveFeedPayloadUrl(feedUrl, value) {
+  const base = new URL(`${feedUrl.replace(/\/+$/, "")}/`);
+  const resolved = new URL(value, base);
+  const basePath = base.pathname.endsWith("/") ? base.pathname : `${base.pathname}/`;
+  if (
+    resolved.protocol !== "https:"
+    || resolved.username
+    || resolved.password
+    || resolved.origin !== base.origin
+    || !resolved.pathname.startsWith(basePath)
+  ) {
+    throw new Error(`Update payload must stay under its feed origin and path: ${resolved.href}`);
+  }
+  return resolved.href;
+}
+
+function validateLatestPointer(pointer, expectedVersion) {
+  if (!pointer || typeof pointer !== "object" || Array.isArray(pointer)) {
+    throw new Error("Stable latest.json must be an object.");
+  }
+  if (pointer.channel !== "stable") {
+    throw new Error(`Stable latest.json has channel ${String(pointer.channel)}.`);
+  }
+  if (!VERSION_PATTERN.test(String(pointer.version ?? ""))) {
+    throw new Error("Stable latest.json must declare a semantic version.");
+  }
+  if (pointer.tag !== `v${pointer.version}`) {
+    throw new Error("Stable latest.json tag must match its version.");
+  }
+  if (expectedVersion != null && pointer.version !== expectedVersion) {
+    throw new Error(
+      `Stable latest.json reports ${pointer.version}, expected ${expectedVersion}.`,
+    );
+  }
+}
+
+async function fetchJson(url, options) {
+  const response = await requestWithRetry(url, {}, options);
+  try {
+    return await response.json();
+  } catch (error) {
+    throw new Error(`${url} did not return valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function fetchText(url, options) {
+  const response = await requestWithRetry(url, {}, options);
+  return response.text();
+}
+
+async function verifyRangeResponse(url, expectedBytes, options) {
+  const response = await requestWithRetry(url, {
+    headers: {
+      Range: "bytes=0-0",
+    },
+    acceptedStatuses: [206],
+  }, options);
+  const contentRange = response.headers.get("content-range");
+  const match = /^bytes 0-0\/(\d+)$/.exec(contentRange ?? "");
+  if (!match) {
+    await response.body?.cancel();
+    throw new Error(`${url} did not return a valid one-byte Content-Range.`);
+  }
+  const totalBytes = Number.parseInt(match[1], 10);
+  if (totalBytes !== expectedBytes) {
+    await response.body?.cancel();
+    throw new Error(`${url} reports ${totalBytes} bytes, expected ${expectedBytes}.`);
+  }
+  const body = new Uint8Array(await response.arrayBuffer());
+  if (body.byteLength !== 1) {
+    throw new Error(`${url} returned ${body.byteLength} bytes for a one-byte Range request.`);
+  }
+}
+
+async function requestWithRetry(url, requestOptions, {
+  attempts,
+  fetchImpl,
+  retryDelayMs,
+  timeoutMs,
+}) {
+  let lastError;
+  const acceptedStatuses = requestOptions.acceptedStatuses ?? [];
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(url, {
+        redirect: "error",
+        signal: AbortSignal.timeout(timeoutMs),
+        ...requestOptions,
+        headers: {
+          "Cache-Control": "no-cache",
+          "User-Agent": "puppyone-update-feed-verifier/1",
+          ...(requestOptions.headers ?? {}),
+        },
+      });
+      const statusAccepted = acceptedStatuses.length > 0
+        ? acceptedStatuses.includes(response.status)
+        : response.ok;
+      if (!statusAccepted) {
+        await response.body?.cancel();
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return response;
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts && retryDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * retryDelayMs));
+      }
+    }
+  }
+  throw new Error(
+    `${url} failed after ${attempts} attempt(s): ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+  );
+}

--- a/scripts/release-support/internal-release-workflow-policy.mjs
+++ b/scripts/release-support/internal-release-workflow-policy.mjs
@@ -117,9 +117,14 @@ export function inspectReleasePublisherWorkflow(workflowSource) {
   if (errors.length > 0) return errors;
   requireSnippets(workflowSource, errors, [
     ["group: desktop-release-publish", "all release channels must share one publication lock"],
+    ["preflight:", "the publisher must expose a secretless distribution preflight job"],
+    ["needs: preflight", "publication authority must wait for the distribution preflight"],
     ["name: ${{ inputs.deployment_environment }}", "publishing secrets must be environment-scoped"],
     ["BUNDLE_DIRECTORY: ${{ github.workspace }}/artifacts/desktop-release-bundle", "the publisher must use an absolute release bundle path"],
+    ["node-version: 22", "the publisher must pin the supported Node.js runtime"],
+    ["PUBLIC_UPDATE_ORIGIN: https://updates.puppyone.ai", "Stable publication must preserve the shipped machine update origin"],
     ["Download build-once release bundle", "the publisher must consume the build-once artifact"],
+    ["Verify existing Stable update origin before publication", "Stable publication must fail before mutation when its existing update contract is unhealthy"],
     ["release.json is the commit marker", "R2 publication must use an explicit commit marker"],
     ["--cache-control \"public, max-age=31536000, immutable\"", "versioned release objects must be immutable"],
     ["--cache-control \"public, no-cache, must-revalidate\"", "mutable release objects must revalidate"],
@@ -136,6 +141,9 @@ export function inspectReleasePublisherWorkflow(workflowSource) {
     ["desktop/internal/catalog/releases.json", "Internal releases must use a separate restricted catalog"],
     ["--max-redirs 0", "authenticated Internal verification must reject redirects"],
     ["Verify public pointers and catalog", "mutable public metadata must be verified after publication"],
+    ["Verify Stable updater payloads through every shipped origin", "Stable payloads must be content-verified through the machine update origin"],
+    ["Verify promoted Stable update feed contract", "the promoted Stable feed must be checked against the release version"],
+    ["verify-desktop-stable-update-feed.mjs", "Stable publication must use the canonical update-feed verifier"],
     ["Clean stale mutable release files", "stale latest files must be removed only after the new release is public"],
   ]);
   forbidSnippets(workflowSource, errors, [
@@ -156,8 +164,44 @@ export function inspectReleasePublisherWorkflow(workflowSource) {
     "PUBLISH_GITHUB_RELEASE: ${{ inputs.publish_github_release }}",
     "the final GitHub release verification must receive the caller's draft/public policy explicitly",
   );
+  for (const stageName of [
+    "Verify existing Stable update origin before publication",
+    "Verify Stable updater payloads through every shipped origin",
+    "Verify promoted Stable update feed contract",
+  ]) {
+    requireStageSnippet(
+      workflowSource,
+      errors,
+      stageName,
+      "if: ${{ inputs.channel == 'stable' }}",
+      `the "${stageName}" stage must run only for Stable publication`,
+    );
+  }
+  requireStageSnippet(
+    workflowSource,
+    errors,
+    "Verify promoted Stable update feed contract",
+    "--expected-version \"${{ steps.release.outputs.version }}\"",
+    "the promoted Stable feed must match the exact release version",
+  );
+  requireJobSnippet(
+    workflowSource,
+    errors,
+    "preflight",
+    "permissions:\n      contents: read",
+    "the distribution preflight must override publication authority with a read-only token",
+  );
+  forbidJobSnippet(
+    workflowSource,
+    errors,
+    "preflight",
+    "${{ secrets.",
+    "the distribution preflight must not receive deployment secrets",
+  );
   assertOrder(workflowSource, errors, [
+    "Verify existing Stable update origin before publication",
     "Validate release bundle and caller contract",
+    "Validate publishing credentials and tools",
     "Inspect immutable R2 release state",
     "Upload immutable R2 release",
     "Verify every immutable R2 object by SHA-256",
@@ -168,7 +212,9 @@ export function inspectReleasePublisherWorkflow(workflowSource) {
     "Verify published GitHub Release state",
     "Promote mutable R2 latest files",
     "Verify mutable latest payloads by SHA-256",
+    "Verify Stable updater payloads through every shipped origin",
     "Publish latest release pointer",
+    "Verify promoted Stable update feed contract",
     "Merge immutable release into catalog",
     "Publish release catalog",
     "Verify public pointers and catalog",
@@ -187,11 +233,13 @@ export function inspectLegacyArchiveWorkflow(workflowSource) {
     ["default: false", "root deletion must be disabled by default"],
     ["group: desktop-release-publish", "archive catalog updates must share the global publication lock"],
     ["name: desktop-internal", "archive credentials must use a deployment environment"],
+    ["node-version: 22", "the archive workflow must pin the supported Node.js runtime"],
     ["--provenance backfill", "GitHub-backed history must be marked as a backfill"],
     ["--provenance archive", "provenance-free root artifacts must be marked as archives"],
     ["Verify every backfilled R2 object by SHA-256", "all historical R2 copies must be content-verified"],
     ["Attach and verify metadata on historical GitHub Releases", "GitHub history must receive the same release metadata as R2"],
-    ["Merge release history into catalog", "all historical releases must appear in the website catalog"],
+    ["Merge release history into channel-specific catalogs", "all historical releases must appear in their channel-appropriate catalogs"],
+    ["Publish and verify channel-specific release catalogs", "all historical catalogs must be content-verified after publication"],
     ["Repair explicitly authorized partial R2 backfills", "uncommitted historical prefixes must have an explicit repair stage"],
     ["inputs.repair_partial_backfills", "partial backfill repair must be explicitly gated"],
     ["Refusing to delete object outside", "partial backfill repair must enforce its prefix boundary"],
@@ -206,10 +254,36 @@ export function inspectLegacyArchiveWorkflow(workflowSource) {
     "Upload immutable legacy archives",
     "Verify every backfilled R2 object by SHA-256",
     "Attach and verify metadata on historical GitHub Releases",
-    "Merge release history into catalog",
-    "Publish and verify complete release catalog",
+    "Merge release history into channel-specific catalogs",
+    "Publish and verify channel-specific release catalogs",
     "Delete verified root objects",
   ], "release history backfill");
+  inspectPinnedActions(workflowSource, errors);
+  return errors;
+}
+
+export function inspectUpdateFeedMonitorWorkflow(workflowSource) {
+  const errors = inspectSource(workflowSource, "Stable update feed monitor workflow");
+  if (errors.length > 0) return errors;
+  requireSnippets(workflowSource, errors, [
+    ["schedule:", "the Stable update feed monitor must run on a schedule"],
+    ["cron: \"17 */6 * * *\"", "the Stable update feed monitor must run at least every six hours"],
+    ["workflow_dispatch:", "the Stable update feed monitor must support an operator-triggered check"],
+    ["permissions:\n  contents: read", "the Stable update feed monitor must use a read-only token"],
+    ["group: desktop-stable-update-feed-monitor", "update feed checks must use a dedicated concurrency group"],
+    ["cancel-in-progress: true", "a newer update feed check must replace a stale monitor run"],
+    ["node-version: 22", "the Stable update feed monitor must use the supported Node.js runtime"],
+    ["Verify every shipped Stable update feed", "the monitor must validate every registered compatibility endpoint"],
+    ["node scripts/verify-desktop-stable-update-feed.mjs", "the monitor must use the canonical update-feed verifier"],
+    ["if: ${{ always() }}", "the monitor must summarize both healthy and failed checks"],
+    ["https://updates.puppyone.ai/desktop/stable/mac/latest/stable-mac.yml", "the monitor summary must identify the machine update contract"],
+    ["https://downloads.puppyone.ai/desktop/stable/mac/latest/latest.json", "the monitor summary must identify the public release pointer"],
+  ]);
+  forbidSnippets(workflowSource, errors, [
+    ["contents: write", "the Stable update feed monitor must not receive repository write permission"],
+    ["id-token: write", "the Stable update feed monitor must not receive an OIDC publication token"],
+    ["${{ secrets.", "the Stable update feed monitor must not receive deployment secrets"],
+  ]);
   inspectPinnedActions(workflowSource, errors);
   return errors;
 }
@@ -252,6 +326,24 @@ function requireStageSnippet(source, errors, stageName, snippet, error) {
   const nextStage = source.indexOf("\n      - name:", stageStart + 1);
   const stageSource = source.slice(stageStart, nextStage < 0 ? undefined : nextStage);
   if (!stageSource.includes(snippet)) errors.push(error);
+}
+
+function requireJobSnippet(source, errors, jobName, snippet, error) {
+  const jobSource = getJobSource(source, jobName);
+  if (jobSource == null || !jobSource.includes(snippet)) errors.push(error);
+}
+
+function forbidJobSnippet(source, errors, jobName, snippet, error) {
+  const jobSource = getJobSource(source, jobName);
+  if (jobSource != null && jobSource.includes(snippet)) errors.push(error);
+}
+
+function getJobSource(source, jobName) {
+  const jobPattern = /^  ([A-Za-z0-9_-]+):\s*$/gm;
+  const jobs = Array.from(source.matchAll(jobPattern));
+  const jobIndex = jobs.findIndex((match) => match[1] === jobName);
+  if (jobIndex < 0) return null;
+  return source.slice(jobs[jobIndex].index, jobs[jobIndex + 1]?.index);
 }
 
 function inspectPinnedActions(source, errors) {

--- a/scripts/release-support/macos-release-policy.mjs
+++ b/scripts/release-support/macos-release-policy.mjs
@@ -1,4 +1,7 @@
-const STABLE_UPDATE_URL = "https://updates.puppyone.ai/desktop/stable/mac/latest";
+import {
+  DESKTOP_RELEASE_BUCKET,
+  DESKTOP_STABLE_UPDATE_FEED_URL,
+} from "../../shared/desktop-distribution-contract.mjs";
 
 export function inspectMacReleaseReadiness({
   packageMetadata,
@@ -41,11 +44,11 @@ export function inspectMacReleaseReadiness({
 
   const stableProvider = publish.find((candidate) => candidate?.provider === "generic");
   if (
-    stableProvider?.url !== STABLE_UPDATE_URL
+    stableProvider?.url !== DESKTOP_STABLE_UPDATE_FEED_URL
     || stableProvider?.channel !== "stable"
     || !String(stableProvider?.url ?? "").startsWith("https://")
   ) {
-    errors.push(`the signed app must embed the stable HTTPS update feed ${STABLE_UPDATE_URL}`);
+    errors.push(`the signed app must embed the stable HTTPS update feed ${DESKTOP_STABLE_UPDATE_FEED_URL}`);
   }
 
   if (env.CSC_IDENTITY_AUTO_DISCOVERY === "false") {
@@ -115,7 +118,7 @@ export function getStableReleaseCoordinates({ packageMetadata, env = process.env
   const version = packageMetadata.version;
   const tag = env.PUPPYONE_RELEASE_TAG || `v${version}`;
   return {
-    bucket: env.R2_BUCKET || "puppyone-desktop",
+    bucket: env.R2_BUCKET || DESKTOP_RELEASE_BUCKET,
     endpoint: `https://${env.CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`,
     latestPrefix: "desktop/stable/mac/latest",
     tag,

--- a/scripts/update-desktop-release-catalog.mjs
+++ b/scripts/update-desktop-release-catalog.mjs
@@ -18,7 +18,13 @@ try {
   const existing = existingPath == null
     ? null
     : await readOptionalJson(path.resolve(existingPath));
-  const catalog = mergeReleaseCatalog(existing, manifest, option(args, "generated-at") ?? new Date().toISOString());
+  const allowedChannels = parseChannels(option(args, "channels"));
+  const catalog = mergeReleaseCatalog(
+    existing,
+    manifest,
+    option(args, "generated-at") ?? new Date().toISOString(),
+    allowedChannels,
+  );
   await fs.mkdir(path.dirname(outputPath), { recursive: true });
   await fs.writeFile(outputPath, jsonFile(catalog));
   console.log(`Catalog now contains ${catalog.releases.length} release(s); newest is ${catalog.releases[0]?.tag ?? "none"}.`);
@@ -55,4 +61,11 @@ function required(args, key) {
 
 function option(args, key) {
   return args.get(key);
+}
+
+function parseChannels(value) {
+  if (value == null) return null;
+  const channels = value.split(",").map((channel) => channel.trim()).filter(Boolean);
+  if (channels.length === 0) throw new Error("--channels must contain at least one channel");
+  return channels;
 }

--- a/scripts/verify-desktop-stable-update-feed.mjs
+++ b/scripts/verify-desktop-stable-update-feed.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+import {
+  verifyDesktopStableUpdateFeeds,
+} from "./release-support/desktop-update-feed-verifier.mjs";
+
+export function parseDesktopUpdateFeedVerifierArguments(argv) {
+  const options = {
+    expectedVersion: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument !== "--expected-version") {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error("--expected-version requires a value.");
+    }
+    options.expectedVersion = value;
+    index += 1;
+  }
+
+  return Object.freeze(options);
+}
+
+export async function runDesktopUpdateFeedVerifier(argv = process.argv.slice(2)) {
+  const options = parseDesktopUpdateFeedVerifierArguments(argv);
+  const result = await verifyDesktopStableUpdateFeeds(options);
+
+  console.log(`Verified PuppyOne Desktop Stable update contract for ${result.version}.`);
+  console.log(`Latest pointer: ${result.latestPointerUrl}`);
+  for (const report of result.reports) {
+    console.log(`Update feed: ${report.metadataUrl} (${report.payloads.length} payloads)`);
+  }
+
+  return result;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await runDesktopUpdateFeedVerifier();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/shared/desktop-build-identity.mjs
+++ b/shared/desktop-build-identity.mjs
@@ -1,3 +1,8 @@
+import {
+  DESKTOP_INTERNAL_UPDATE_FEED_URL,
+  DESKTOP_STABLE_UPDATE_FEED_URL,
+} from "./desktop-distribution-contract.mjs";
+
 export const DESKTOP_BUILD_INFO_SCHEMA_VERSION = 1;
 export const DESKTOP_BUILD_PRODUCT = "puppyone-desktop";
 export const DESKTOP_BUILD_CHANNELS = Object.freeze(["dev", "internal", "stable"]);
@@ -39,7 +44,7 @@ const CHANNEL_POLICIES = deepFreeze({
     releaseChannel: "internal",
     releaseAudience: "restricted",
     updateChannel: "internal",
-    updateFeedUrl: "https://updates.puppyone.ai/desktop/internal/mac/latest",
+    updateFeedUrl: DESKTOP_INTERNAL_UPDATE_FEED_URL,
     published: true,
     requiresDeveloperIdSignature: false,
     requiresNotarization: false,
@@ -51,7 +56,7 @@ const CHANNEL_POLICIES = deepFreeze({
     releaseChannel: "stable",
     releaseAudience: "public",
     updateChannel: "stable",
-    updateFeedUrl: "https://updates.puppyone.ai/desktop/stable/mac/latest",
+    updateFeedUrl: DESKTOP_STABLE_UPDATE_FEED_URL,
     published: true,
     requiresDeveloperIdSignature: true,
     requiresNotarization: true,

--- a/shared/desktop-distribution-contract.mjs
+++ b/shared/desktop-distribution-contract.mjs
@@ -1,0 +1,44 @@
+export const DESKTOP_RELEASE_BUCKET = "puppyone-desktop";
+export const DESKTOP_PUBLIC_DOWNLOAD_ORIGIN = "https://downloads.puppyone.ai";
+export const DESKTOP_STABLE_UPDATE_ORIGIN = "https://updates.puppyone.ai";
+
+export const DESKTOP_INTERNAL_UPDATE_FEED_URL = joinOriginPath(
+  DESKTOP_PUBLIC_DOWNLOAD_ORIGIN,
+  "/desktop/internal/mac/latest",
+);
+export const DESKTOP_STABLE_UPDATE_FEED_URL = joinOriginPath(
+  DESKTOP_STABLE_UPDATE_ORIGIN,
+  "/desktop/stable/mac/latest",
+);
+export const DESKTOP_STABLE_LATEST_POINTER_URL = joinOriginPath(
+  DESKTOP_PUBLIC_DOWNLOAD_ORIGIN,
+  "/desktop/stable/mac/latest/latest.json",
+);
+export const DESKTOP_STABLE_UPDATE_METADATA_NAME = "stable-mac.yml";
+
+// Every feed embedded in a shipped Stable application remains a compatibility
+// endpoint. Future migrations append a contract; they never replace an entry.
+export const DESKTOP_SHIPPED_STABLE_UPDATE_CONTRACTS = Object.freeze([
+  Object.freeze({
+    feedUrl: DESKTOP_STABLE_UPDATE_FEED_URL,
+    introducedInVersion: "0.1.4",
+  }),
+]);
+
+export const DESKTOP_SUPPORTED_STABLE_UPDATE_FEED_URLS = Object.freeze(
+  DESKTOP_SHIPPED_STABLE_UPDATE_CONTRACTS.map(({ feedUrl }) => feedUrl),
+);
+
+function joinOriginPath(origin, pathname) {
+  const url = new URL(pathname, `${origin}/`);
+  if (
+    url.protocol !== "https:"
+    || url.username
+    || url.password
+    || url.search
+    || url.hash
+  ) {
+    throw new Error(`Invalid Desktop distribution URL: ${url.href}`);
+  }
+  return url.href.replace(/\/+$/, "");
+}

--- a/src/components/DesktopUpdateControls.tsx
+++ b/src/components/DesktopUpdateControls.tsx
@@ -87,14 +87,17 @@ export function DesktopUpdateTitlebarButton({
   if (!visible) return null;
 
   const Icon = getUpdateIcon(state.status);
-  const busy = state.status === "checking" || state.status === "downloading" || state.status === "installing";
+  const busy = state.status === "checking"
+    || state.status === "downloading"
+    || state.status === "installing";
+  const title = getUpdateTitle(state, t, formatNumber);
 
   return (
     <button
       className={`desktop-titlebar-action desktop-update-titlebar-action ${state.status}`}
       type="button"
-      title={getUpdateTitle(state, t, formatNumber)}
-      aria-label={getUpdateTitle(state, t, formatNumber)}
+      title={title}
+      aria-label={title}
       disabled={busy}
       onClick={onUpdateNow}
     >
@@ -201,10 +204,20 @@ function getUpdateTitle(
   t: MessageFormatter,
   formatNumber: (value: number, options?: Intl.NumberFormatOptions) => string,
 ): string {
-  if (state.status === "available") return t("updates.title.available", { version: state.availableVersion ?? t("updates.version.new") });
+  if (state.status === "available") {
+    return t("updates.title.available", {
+      version: state.availableVersion ?? t("updates.version.new"),
+    });
+  }
   if (state.status === "downloaded") return t("updates.action.restart");
-  if (state.status === "downloading") return t("updates.title.downloading", { progress: formatDownloadProgress(state, formatNumber) });
-  if (state.status === "blocked") return state.blockers[0]?.label ?? t("updates.title.blocked");
+  if (state.status === "downloading") {
+    return t("updates.title.downloading", {
+      progress: formatDownloadProgress(state, formatNumber),
+    });
+  }
+  if (state.status === "blocked") {
+    return state.blockers[0]?.label ?? t("updates.title.blocked");
+  }
   if (state.status === "error") return t("updates.title.failed");
   return t("updates.title.appUpdate");
 }

--- a/src/features/app-shell/auxiliary/AuxiliaryPanelHost.tsx
+++ b/src/features/app-shell/auxiliary/AuxiliaryPanelHost.tsx
@@ -82,6 +82,7 @@ export function AuxiliaryPanelHost({
       {resizable && open && (
         <SidebarResizeHandle
           className="desktop-right-sidebar-resizer"
+          paneEdge
           orientation="vertical"
           label={t("shell.sidebar.resizeAuxiliary")}
           min={minWidth}

--- a/src/features/automation/styles/shell-and-catalog.css
+++ b/src/features/automation/styles/shell-and-catalog.css
@@ -110,7 +110,6 @@
   gap: 3px;
   margin-top: 26px;
   overflow-x: auto;
-  scrollbar-width: none;
 }
 
 .desktop-cloud-automation-category-tabs::-webkit-scrollbar {

--- a/src/features/cloud/history/styles/sidebar.css
+++ b/src/features/cloud/history/styles/sidebar.css
@@ -66,7 +66,7 @@
 
 .desktop-cloud-history-sidebar-list::-webkit-scrollbar-thumb {
   border-radius: 999px;
-  background: var(--po-scrollbar-thumb);
+  background-color: var(--desktop-sidebar-scrollbar-thumb, var(--po-scrollbar-thumb));
 }
 
 .desktop-cloud-history-sidebar-row {

--- a/src/features/cloud/sections/access/styles/base.css
+++ b/src/features/cloud/sections/access/styles/base.css
@@ -216,7 +216,6 @@
   align-items: center;
   gap: 3px;
   overflow-x: auto;
-  scrollbar-width: none;
 }
 
 .desktop-cloud-access-category-tabs::-webkit-scrollbar {

--- a/src/features/cloud/sections/access/styles/create-access-dialog.css
+++ b/src/features/cloud/sections/access/styles/create-access-dialog.css
@@ -223,14 +223,14 @@
 }
 
 .desktop-cloud-create-access-tree-body::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: var(--po-scrollbar-size, 8px);
+  height: var(--po-scrollbar-size, 8px);
 }
 
 .desktop-cloud-create-access-tree-body::-webkit-scrollbar-thumb {
-  border: 2px solid transparent;
-  border-radius: 999px;
-  background: var(--po-scrollbar-thumb);
+  border: var(--po-scrollbar-thumb-inset, 1px) solid transparent;
+  border-radius: var(--po-scrollbar-radius, 999px);
+  background-color: var(--po-scrollbar-thumb);
   background-clip: padding-box;
 }
 

--- a/src/features/cloud/sections/access/styles/scope-detail.css
+++ b/src/features/cloud/sections/access/styles/scope-detail.css
@@ -13,8 +13,8 @@
 }
 
 .desktop-cloud-access-web-detail::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: var(--po-scrollbar-size, 8px);
+  height: var(--po-scrollbar-size, 8px);
 }
 
 .desktop-cloud-access-web-detail::-webkit-scrollbar-track {
@@ -22,9 +22,9 @@
 }
 
 .desktop-cloud-access-web-detail::-webkit-scrollbar-thumb {
-  border: 2px solid transparent;
-  border-radius: 999px;
-  background: var(--po-scrollbar-thumb);
+  border: var(--po-scrollbar-thumb-inset, 1px) solid transparent;
+  border-radius: var(--po-scrollbar-radius, 999px);
+  background-color: var(--po-scrollbar-thumb);
   background-clip: padding-box;
 }
 
@@ -168,4 +168,3 @@
   border-radius: 10px;
   background: var(--po-control);
 }
-

--- a/src/features/cloud/sections/settings/settings.css
+++ b/src/features/cloud/sections/settings/settings.css
@@ -74,7 +74,6 @@
   gap: 3px;
   margin-top: 26px;
   overflow-x: auto;
-  scrollbar-width: none;
 }
 
 .desktop-cloud-settings-tabs::-webkit-scrollbar {

--- a/src/features/cloud/styles/sidebar-shell.css
+++ b/src/features/cloud/styles/sidebar-shell.css
@@ -57,8 +57,8 @@
 }
 
 .desktop-cloud-main-view::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: var(--po-scrollbar-size, 8px);
+  height: var(--po-scrollbar-size, 8px);
 }
 
 .desktop-cloud-main-view::-webkit-scrollbar-track {
@@ -66,14 +66,14 @@
 }
 
 .desktop-cloud-main-view::-webkit-scrollbar-thumb {
-  border: 2px solid transparent;
-  border-radius: 999px;
-  background: var(--po-scrollbar-thumb);
+  border: var(--po-scrollbar-thumb-inset, 1px) solid transparent;
+  border-radius: var(--po-scrollbar-radius, 999px);
+  background-color: var(--po-scrollbar-thumb);
   background-clip: padding-box;
 }
 
 .desktop-cloud-main-view::-webkit-scrollbar-thumb:hover {
-  background: var(--po-scrollbar-thumb-hover);
+  background-color: var(--po-scrollbar-thumb-hover);
   background-clip: padding-box;
 }
 

--- a/src/features/data-workspace/data-shell.css
+++ b/src/features/data-workspace/data-shell.css
@@ -84,23 +84,14 @@
 }
 
 .data-explorer-resizer {
-  position: absolute;
-  inset-block: 0;
-  inset-inline-end: 0;
-  z-index: 35;
-  width: 9px;
-  transform: translateX(4px);
-  cursor: col-resize;
-  touch-action: none;
+  /*
+   * The resize target belongs to the main-pane side of the boundary so it
+   * never competes with the explorer scrollbar immediately inside it.
+   */
+  inset-inline-start: var(--data-explorer-width, clamp(282px, 26vw, 360px));
 }
 
 .data-explorer-resizer::after {
-  position: absolute;
-  inset-block: 0;
-  inset-inline-start: 4px;
-  width: 1px;
-  background: transparent;
-  content: "";
   transition: background 120ms ease, box-shadow 120ms ease;
 }
 

--- a/src/features/desktop-agent/ui/styles/pickers.css
+++ b/src/features/desktop-agent/ui/styles/pickers.css
@@ -121,8 +121,6 @@
   overflow-x: hidden;
   overflow-y: auto;
   padding: 6px;
-  scrollbar-color: var(--po-scrollbar-thumb) transparent;
-  scrollbar-width: thin;
 }
 .desktop-agent-picker-option {
   display: grid;

--- a/src/features/desktop-agent/ui/styles/transcript.css
+++ b/src/features/desktop-agent/ui/styles/transcript.css
@@ -35,15 +35,16 @@
   overflow-y: auto;
   padding: 12px var(--agent-inline-inset) 24px;
   overflow-anchor: none;
-  scrollbar-color: var(--po-scrollbar-thumb) transparent;
-  scrollbar-width: thin;
 }
 
-.desktop-agent-transcript::-webkit-scrollbar { width: 8px; }
+.desktop-agent-transcript::-webkit-scrollbar {
+  width: var(--po-scrollbar-size, 8px);
+}
+
 .desktop-agent-transcript::-webkit-scrollbar-thumb {
-  border: 2px solid transparent;
-  border-radius: 8px;
-  background: var(--po-scrollbar-thumb);
+  border: var(--po-scrollbar-thumb-inset, 1px) solid transparent;
+  border-radius: var(--po-scrollbar-radius, 999px);
+  background-color: var(--po-scrollbar-thumb);
   background-clip: padding-box;
 }
 

--- a/src/features/desktop-terminal/ui/desktop-terminal.css
+++ b/src/features/desktop-terminal/ui/desktop-terminal.css
@@ -22,7 +22,7 @@
 
 .desktop-terminal-xterm {
   --desktop-terminal-scrollbar-track-size: 14px;
-  --desktop-terminal-scrollbar-thumb-size: var(--po-scrollbar-size, 6px);
+  --desktop-terminal-scrollbar-thumb-size: var(--po-scrollbar-thumb-size, 6px);
   --desktop-terminal-scrollbar-thumb-offset: calc(
     var(--desktop-terminal-scrollbar-track-size)
     - var(--desktop-terminal-scrollbar-thumb-size)
@@ -83,8 +83,8 @@
   min-height: 34px;
   border: 0 solid transparent;
   border-left-width: var(--desktop-terminal-scrollbar-thumb-offset);
-  border-radius: var(--po-scrollbar-radius, 3px);
-  background: transparent;
+  border-radius: var(--po-scrollbar-radius, 999px);
+  background-color: transparent;
   background-clip: padding-box;
   transition: background-color var(--po-scrollbar-transition, 0.16s ease);
 }
@@ -92,13 +92,13 @@
 .desktop-terminal-xterm:hover .xterm-viewport::-webkit-scrollbar-thumb,
 .desktop-terminal-xterm:focus-within .xterm-viewport::-webkit-scrollbar-thumb,
 .desktop-terminal-xterm .xterm-viewport.po-scrollbar-active::-webkit-scrollbar-thumb {
-  background: var(--po-scrollbar-thumb);
+  background-color: var(--po-scrollbar-thumb);
 }
 
 .desktop-terminal-xterm .xterm-viewport::-webkit-scrollbar-thumb:hover,
 .desktop-terminal-xterm .xterm-viewport.po-scrollbar-active::-webkit-scrollbar-thumb:hover,
 .desktop-terminal-xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:hover {
-  background: var(--po-scrollbar-thumb-hover);
+  background-color: var(--po-scrollbar-thumb-hover);
   background-clip: padding-box;
 }
 
@@ -114,7 +114,7 @@
   right: 0 !important;
   left: auto !important;
   width: var(--desktop-terminal-scrollbar-thumb-size) !important;
-  border-radius: var(--po-scrollbar-radius, 3px) !important;
+  border-radius: var(--po-scrollbar-radius, 999px) !important;
   background: transparent !important;
   transition: background-color var(--po-scrollbar-transition, 0.16s ease) !important;
 }

--- a/src/features/source-control/GitStatusView.tsx
+++ b/src/features/source-control/GitStatusView.tsx
@@ -224,8 +224,10 @@ function GitHistoryPanel({
   const beginTreeResize = usePaneResizeDrag({
     bodyClassName: "desktop-history-resizing",
     onDragStart: (event) => {
-      const treeElement = event.currentTarget.parentElement;
-      const startWidth = treeElement?.getBoundingClientRect().width ?? treeWidth ?? HISTORY_TREE_DEFAULT_WIDTH;
+      const treeElement = event.currentTarget.previousElementSibling;
+      const startWidth = treeElement instanceof HTMLElement
+        ? treeElement.getBoundingClientRect().width
+        : treeWidth ?? HISTORY_TREE_DEFAULT_WIDTH;
       const startX = event.clientX;
       const maxWidth = Math.min(
         HISTORY_TREE_MAX_WIDTH,
@@ -265,10 +267,12 @@ function GitHistoryPanel({
   }
 
   return (
-    <section className="desktop-utility-view desktop-history-detail-view desktop-history-panel">
+    <section
+      className="desktop-utility-view desktop-history-detail-view desktop-history-panel"
+      style={getHistoryTreeStyle(treeWidth)}
+    >
       <aside
         className="desktop-history-panel-tree"
-        style={getHistoryTreeStyle(treeWidth)}
         aria-label={t("source-control.history.ariaLabel")}
       >
         <VirtualSidebarList
@@ -289,21 +293,22 @@ function GitHistoryPanel({
             />
           )}
         />
-        <SidebarResizeHandle
-          className="desktop-history-panel-tree-resizer"
-          label={t("source-control.history.resizeAriaLabel")}
-          orientation="vertical"
-          min={HISTORY_TREE_MIN_WIDTH}
-          max={HISTORY_TREE_MAX_WIDTH}
-          value={treeWidth ?? HISTORY_TREE_DEFAULT_WIDTH}
-          title={t("source-control.history.resizeTitle")}
-          onPointerDown={beginTreeResize}
-          onKeyboardResize={resizeTreeByKeyboard}
-          onDoubleClick={() => setTreeWidth(null)}
-        >
-          <GripVertical size={12} aria-hidden="true" />
-        </SidebarResizeHandle>
       </aside>
+      <SidebarResizeHandle
+        className="desktop-history-panel-tree-resizer"
+        paneEdge
+        label={t("source-control.history.resizeAriaLabel")}
+        orientation="vertical"
+        min={HISTORY_TREE_MIN_WIDTH}
+        max={HISTORY_TREE_MAX_WIDTH}
+        value={treeWidth ?? HISTORY_TREE_DEFAULT_WIDTH}
+        title={t("source-control.history.resizeTitle")}
+        onPointerDown={beginTreeResize}
+        onKeyboardResize={resizeTreeByKeyboard}
+        onDoubleClick={() => setTreeWidth(null)}
+      >
+        <GripVertical size={12} aria-hidden="true" />
+      </SidebarResizeHandle>
       <div className="desktop-history-panel-detail">
         <div className="desktop-history-detail-scroll">
           {selectedCommit ? (

--- a/src/features/source-control/styles/history-detail.css
+++ b/src/features/source-control/styles/history-detail.css
@@ -3,6 +3,7 @@
 }
 
 .desktop-history-panel {
+  position: relative;
   display: flex;
   flex-direction: row;
 }
@@ -51,12 +52,11 @@ body.desktop-history-resizing .desktop-history-panel-tree {
 }
 
 .desktop-history-panel-tree-resizer {
-  position: absolute;
-  z-index: 3;
-  inset-block: 0;
-  inset-inline-end: -4px;
+  --po-pane-resizer-line-size: 2px;
+  --po-pane-resizer-z-index: 3;
+
+  inset-inline-start: var(--desktop-history-tree-width, clamp(260px, 28vw, 380px));
   display: flex;
-  width: 8px;
   align-items: center;
   justify-content: center;
   border: 0;
@@ -67,13 +67,7 @@ body.desktop-history-resizing .desktop-history-panel-tree {
 }
 
 .desktop-history-panel-tree-resizer::after {
-  position: absolute;
-  inset-block: 0;
-  inset-inline-start: 3px;
-  width: 2px;
   border-radius: 999px;
-  background: transparent;
-  content: "";
 }
 
 .desktop-history-panel-tree-resizer svg {

--- a/src/features/source-control/styles/sidebar-base.css
+++ b/src/features/source-control/styles/sidebar-base.css
@@ -9,7 +9,7 @@
 .desktop-git-sidebar {
   --git-sidebar-left-gap: var(--desktop-sidebar-row-left-gap);
   --git-sidebar-right-gap: var(--desktop-sidebar-row-right-gap);
-  --git-sidebar-scrollbar-width: var(--desktop-sidebar-scrollbar-width, 4px);
+  --git-sidebar-scrollbar-width: var(--desktop-sidebar-scrollbar-width, 8px);
   --git-sidebar-control-left-gap: var(--desktop-sidebar-row-left-gap);
   --git-sidebar-control-right-gap: var(--desktop-sidebar-row-right-gap);
   --git-sidebar-control-width: calc(100% - var(--git-sidebar-control-left-gap) - var(--git-sidebar-control-right-gap));

--- a/src/features/source-control/styles/sidebar-resources.css
+++ b/src/features/source-control/styles/sidebar-resources.css
@@ -110,7 +110,7 @@
   .po-sidebar-empty.compact:not(.desktop-git-section-empty)
 )::-webkit-scrollbar-thumb {
   border-radius: 999px;
-  background: var(--po-scrollbar-thumb);
+  background-color: var(--desktop-sidebar-scrollbar-thumb, var(--po-scrollbar-thumb));
 }
 
 .desktop-git-section-resizer {
@@ -166,12 +166,15 @@ body.desktop-git-sidebar-resizing {
 .desktop-git-changes-scroll::-webkit-scrollbar-thumb,
 .desktop-git-history-scroll::-webkit-scrollbar-thumb {
   border-radius: 999px;
-  background: var(--po-scrollbar-thumb);
+  background-color: var(--desktop-sidebar-scrollbar-thumb, var(--po-scrollbar-thumb));
 }
 
 .desktop-git-changes-scroll::-webkit-scrollbar-thumb:hover,
 .desktop-git-history-scroll::-webkit-scrollbar-thumb:hover {
-  background: var(--po-scrollbar-thumb-hover);
+  background-color: var(
+    --desktop-sidebar-scrollbar-thumb-hover,
+    var(--po-scrollbar-thumb-hover)
+  );
 }
 
 .desktop-git-sidebar-tabs {
@@ -550,7 +553,7 @@ body.desktop-git-sidebar-resizing {
 
 .desktop-git-remote-preview::-webkit-scrollbar-thumb {
   border-radius: 999px;
-  background: var(--po-scrollbar-thumb);
+  background-color: var(--desktop-sidebar-scrollbar-thumb, var(--po-scrollbar-thumb));
 }
 
 .desktop-git-operation-error {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -102,14 +102,6 @@ h2 {
   background: linear-gradient(270deg, transparent, color-mix(in srgb, var(--po-shadow) 42%, transparent));
 }
 
-[dir="rtl"] .desktop-right-sidebar-resizer {
-  transform: translateX(4px);
-}
-
-[dir="rtl"] .data-explorer-resizer {
-  transform: translateX(-4px);
-}
-
 [dir="rtl"] .po-directional-icon,
 [dir="rtl"] .desktop-cloud-directional-icon {
   transform: scaleX(-1);

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -111,23 +111,14 @@ body.desktop-right-sidebar-resizing .desktop-right-sidebar {
 }
 
 .desktop-right-sidebar-resizer {
-  position: absolute;
-  inset-block: 0;
+  /*
+   * This lane starts at the editor/panel boundary and extends into the
+   * auxiliary panel. It must never translate into the editor scrollbar.
+   */
   inset-inline-start: 0;
-  z-index: 35;
-  width: 9px;
-  transform: translateX(-4px);
-  cursor: col-resize;
-  touch-action: none;
 }
 
 .desktop-right-sidebar-resizer::after {
-  position: absolute;
-  inset-block: 0;
-  inset-inline-start: 4px;
-  width: 1px;
-  background: transparent;
-  content: "";
   transition: background 120ms ease, box-shadow 120ms ease;
 }
 

--- a/src/styles/macos-tiger.css
+++ b/src/styles/macos-tiger.css
@@ -43,6 +43,8 @@
   --po-menu-item-padding-inline: 8px;
   --po-menu-item-gap: 7px;
   --po-scrollbar-size: 15px;
+  --po-scrollbar-thumb-size: 11px;
+  --po-scrollbar-thumb-inset: 2px;
   --po-scrollbar-radius: 8px;
   --po-scrollbar-transition: 0s;
   --po-tree-row-height: 27px;

--- a/src/styles/menus.css
+++ b/src/styles/menus.css
@@ -24,14 +24,14 @@
 .desktop-titlebar-menu::-webkit-scrollbar-thumb,
 .desktop-node-action-menu::-webkit-scrollbar-thumb {
   border: 1px solid var(--po-menu-bg);
-  background: var(--po-scrollbar-thumb);
+  background-color: var(--po-scrollbar-thumb);
   background-clip: padding-box;
 }
 
 .desktop-menu-surface::-webkit-scrollbar-thumb:hover,
 .desktop-titlebar-menu::-webkit-scrollbar-thumb:hover,
 .desktop-node-action-menu::-webkit-scrollbar-thumb:hover {
-  background: var(--po-scrollbar-thumb-hover);
+  background-color: var(--po-scrollbar-thumb-hover);
   background-clip: padding-box;
 }
 

--- a/src/styles/minimal-mode.css
+++ b/src/styles/minimal-mode.css
@@ -215,7 +215,6 @@
 
   .desktop-minimal-mode-controls {
     overflow-x: auto;
-    scrollbar-width: none;
   }
 
   .desktop-minimal-mode-controls::-webkit-scrollbar {

--- a/src/styles/onboarding.css
+++ b/src/styles/onboarding.css
@@ -269,7 +269,7 @@
 }
 
 .onboarding-project-list::-webkit-scrollbar {
-  width: 6px;
+  width: var(--po-scrollbar-size, 8px);
 }
 
 .onboarding-project-list::-webkit-scrollbar-track {
@@ -278,11 +278,11 @@
 
 .onboarding-project-list::-webkit-scrollbar-thumb {
   border-radius: 999px;
-  background: color-mix(in srgb, var(--po-text-muted) 24%, transparent);
+  background-color: color-mix(in srgb, var(--po-text-muted) 24%, transparent);
 }
 
 .onboarding-project-list::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--po-text-muted) 38%, transparent);
+  background-color: color-mix(in srgb, var(--po-text-muted) 38%, transparent);
 }
 
 .onboarding-project-row {

--- a/src/styles/scrollbars.css
+++ b/src/styles/scrollbars.css
@@ -12,8 +12,8 @@
  */
 
 *::-webkit-scrollbar {
-  width: var(--po-scrollbar-size, 6px);
-  height: var(--po-scrollbar-size, 6px);
+  width: var(--po-scrollbar-size, 8px);
+  height: var(--po-scrollbar-size, 8px);
 }
 
 *::-webkit-scrollbar-track {
@@ -21,18 +21,20 @@
 }
 
 *::-webkit-scrollbar-thumb {
-  background: var(--po-scrollbar-thumb);
-  border-radius: var(--po-scrollbar-radius, 3px);
+  border: var(--po-scrollbar-thumb-inset, 1px) solid transparent;
+  background-color: var(--po-scrollbar-thumb);
+  background-clip: padding-box;
+  border-radius: var(--po-scrollbar-radius, 999px);
   transition: background-color var(--po-scrollbar-transition, 0.16s ease);
 }
 
 .po-scrollbar-active::-webkit-scrollbar-thumb {
-  background: var(--po-scrollbar-thumb);
+  background-color: var(--po-scrollbar-thumb);
 }
 
 *::-webkit-scrollbar-thumb:hover,
 .po-scrollbar-active::-webkit-scrollbar-thumb:hover {
-  background: var(--po-scrollbar-thumb-hover);
+  background-color: var(--po-scrollbar-thumb-hover);
 }
 
 *::-webkit-scrollbar-corner {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -88,9 +88,24 @@
   --desktop-sidebar-font-weight-emphasis: 650;
   --desktop-sidebar-line-height: 18px;
   --desktop-sidebar-icon-label-gap: 4px;
-  --po-scrollbar-size: 6px;
-  --po-scrollbar-radius: 3px;
+  /*
+   * Modern scrollbar contract: an 8px interaction track containing a 6px
+   * visible thumb. Feature surfaces share these tokens instead of choosing
+   * their own CSV / Markdown / sidebar widths.
+   */
+  --po-scrollbar-size: 8px;
+  --po-scrollbar-thumb-size: 6px;
+  --po-scrollbar-thumb-inset: 1px;
+  --po-scrollbar-radius: 999px;
   --po-scrollbar-transition: 0.16s ease;
+  /*
+   * Pane boundaries use two adjacent interaction lanes: the scrollbar owns
+   * the final 8px inside its scroll pane and the resize handle owns the next
+   * 8px in the neighboring pane. Neither lane may straddle the boundary.
+   */
+  --po-pane-resizer-hit-size: 8px;
+  --po-pane-resizer-line-size: 1px;
+  --po-pane-resizer-z-index: 35;
   --desktop-sidebar-scrollbar-width: var(--po-scrollbar-size);
   /*
    * Right gap for content inside sidebar scroll containers that reserve a
@@ -236,9 +251,11 @@
  * - Future per-region user customization = overriding exactly these tokens
  *   inline on the shell root, which beats any stylesheet rule.
  *
- * Current design: content surfaces and local-workspace chrome share one quiet
- * material. Cloud workspaces opt into the dedicated sky-blue titlebar tokens.
- * Use --po-inset or explicit mixes where a region needs to read as recessed.
+ * Current design: the editor stays on the quiet content material while the
+ * local titlebar and sidebar use a restrained blend of chrome and editor
+ * materials. That keeps the frame legible without creating a heavy contrast:
+ * subtly darker in light themes and subtly lighter in dark themes. Cloud
+ * workspaces still opt into the dedicated sky-blue titlebar tokens.
  */
 :root,
 :where(.app-shell, .onboarding-shell, .desktop-overlay-root, .desktop-theme-preview-surface, .dark) {
@@ -273,13 +290,28 @@
   --desktop-sidebar-section-title-line-height: 18px;
   --desktop-sidebar-section-title-color: var(--po-text-subtle);
   --desktop-sidebar-section-title-disabled-color: var(--po-text-disabled);
+  /*
+   * Chrome sits on a slightly darker material than the editor. Compensate
+   * the thumb alpha so sidebar and editor scrollbars have the same perceived
+   * lightness instead of merely sharing the same raw color.
+   */
+  --desktop-sidebar-scrollbar-thumb: color-mix(
+    in srgb,
+    var(--po-scrollbar-thumb) 76%,
+    transparent
+  );
+  --desktop-sidebar-scrollbar-thumb-hover: color-mix(
+    in srgb,
+    var(--po-scrollbar-thumb-hover) 88%,
+    transparent
+  );
 
   --po-surface-editor: var(--po-surface-panel);
   --po-surface-terminal: var(--po-surface-editor);
 
   --po-canvas: var(--po-surface-editor);
-  --po-header: var(--po-surface-editor);
-  --po-sidebar: var(--po-surface-editor);
+  --po-header: color-mix(in srgb, var(--po-surface-chrome) 40%, var(--po-surface-editor));
+  --po-sidebar: color-mix(in srgb, var(--po-surface-chrome) 40%, var(--po-surface-editor));
   --po-chrome: var(--po-surface-chrome);
   --po-panel: var(--po-surface-panel);
   --po-panel-raised: var(--po-surface-panel-raised);

--- a/src/styles/windows-xp.css
+++ b/src/styles/windows-xp.css
@@ -41,6 +41,8 @@
   --po-menu-item-padding-inline: 7px;
   --po-menu-item-gap: 7px;
   --po-scrollbar-size: 13px;
+  --po-scrollbar-thumb-size: 9px;
+  --po-scrollbar-thumb-inset: 2px;
   --po-scrollbar-radius: 0;
   --po-scrollbar-transition: 0s;
   --po-tree-row-height: 27px;

--- a/tests/dataWorkspaceMove.test.tsx
+++ b/tests/dataWorkspaceMove.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DataNode, DataPort } from "../packages/shared-ui/src/core/types";
+import { DataWorkspace } from "../packages/shared-ui/src/data/DataWorkspace";
+import { withTestLocalization } from "./testLocalization";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("DataWorkspace explorer moves", () => {
+  it("moves a nested file to its parent folder through the workspace port", async () => {
+    let moved = false;
+    const sourcePath = "parent/child/drag-me.txt";
+    const targetPath = "parent/drag-me.txt";
+    const moveNode = vi.fn(async (from: string, to: string) => {
+      expect(from).toBe(sourcePath);
+      expect(to).toBe(targetPath);
+      moved = true;
+    });
+    const dataPort: DataPort = {
+      listChildren: vi.fn(async (folderPath) => listFixtureChildren(folderPath, moved)),
+      moveNode,
+    };
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(withTestLocalization(
+        <DataWorkspace
+          workspace={{ id: "workspace", name: "Workspace", path: "/workspace", status: "recording" }}
+          dataPort={dataPort}
+          capabilities={{ move: true }}
+          defaultActivePath={sourcePath}
+          showHeader={false}
+          showPreviewHeader={false}
+          enableMarkdownLinkContentIndexing={false}
+        />,
+      ));
+      await Promise.resolve();
+    });
+
+    const sourceRow = container.querySelector<HTMLElement>(`[data-explorer-path="${sourcePath}"]`);
+    const parentRow = container.querySelector<HTMLElement>('[data-explorer-path="parent"]');
+    if (!sourceRow || !parentRow) throw new Error("Nested move fixture did not render.");
+    mockRowBounds(parentRow);
+    const transfer = fakeDataTransfer();
+
+    await act(async () => {
+      sourceRow.dispatchEvent(dragEvent("dragstart", transfer));
+      parentRow.dispatchEvent(dragEvent("dragover", transfer));
+      parentRow.dispatchEvent(dragEvent("drop", transfer));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(moveNode).toHaveBeenCalledOnce();
+    expect(container.querySelector(`[data-explorer-path="${sourcePath}"]`)).toBeNull();
+    expect(container.querySelector(`[data-explorer-path="${targetPath}"]`)).not.toBeNull();
+  });
+
+  it("shows move failures while the explorer still contains files", async () => {
+    const sourcePath = "parent/child/drag-me.txt";
+    const dataPort: DataPort = {
+      listChildren: vi.fn(async (folderPath) => listFixtureChildren(folderPath, false)),
+      moveNode: vi.fn(async () => {
+        throw new Error("An item with that name already exists.");
+      }),
+    };
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(withTestLocalization(
+        <DataWorkspace
+          workspace={{ id: "workspace", name: "Workspace", path: "/workspace", status: "recording" }}
+          dataPort={dataPort}
+          capabilities={{ move: true }}
+          defaultActivePath={sourcePath}
+          showHeader={false}
+          showPreviewHeader={false}
+          enableMarkdownLinkContentIndexing={false}
+        />,
+      ));
+      await Promise.resolve();
+    });
+
+    const sourceRow = container.querySelector<HTMLElement>(`[data-explorer-path="${sourcePath}"]`);
+    const parentRow = container.querySelector<HTMLElement>('[data-explorer-path="parent"]');
+    if (!sourceRow || !parentRow) throw new Error("Nested move fixture did not render.");
+    mockRowBounds(parentRow);
+    const transfer = fakeDataTransfer();
+
+    await act(async () => {
+      sourceRow.dispatchEvent(dragEvent("dragstart", transfer));
+      parentRow.dispatchEvent(dragEvent("dragover", transfer));
+      parentRow.dispatchEvent(dragEvent("drop", transfer));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector(".explorer-tree-error-banner")?.textContent)
+      .toContain("An item with that name already exists.");
+  });
+});
+
+function listFixtureChildren(folderPath: string | null, moved: boolean): DataNode[] {
+  const source: DataNode = {
+    id: moved ? "parent/drag-me.txt" : "parent/child/drag-me.txt",
+    name: "drag-me.txt",
+    path: moved ? "parent/drag-me.txt" : "parent/child/drag-me.txt",
+    type: "text",
+  };
+  const child: DataNode = {
+    id: "parent/child",
+    name: "child",
+    path: "parent/child",
+    type: "folder",
+    children: moved ? [] : [source],
+  };
+  const parent: DataNode = {
+    id: "parent",
+    name: "parent",
+    path: "parent",
+    type: "folder",
+    children: moved ? [child, source] : [child],
+  };
+
+  if (folderPath === null) return [parent];
+  if (folderPath === parent.path) return parent.children ?? [];
+  if (folderPath === child.path) return child.children ?? [];
+  return [];
+}
+
+function fakeDataTransfer(): DataTransfer {
+  const values = new Map<string, string>();
+  const types: string[] = [];
+  return {
+    effectAllowed: "none",
+    dropEffect: "none",
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    types,
+    getData: (type: string) => values.get(type) ?? "",
+    setData: (type: string, value: string) => {
+      values.set(type, value);
+      types.splice(0, types.length, ...values.keys());
+    },
+    clearData: (type?: string) => type ? values.delete(type) : values.clear(),
+    setDragImage: () => undefined,
+  } as DataTransfer;
+}
+
+function dragEvent(type: string, dataTransfer: DataTransfer): MouseEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: 12,
+    clientY: 5,
+  });
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+  return event;
+}
+
+function mockRowBounds(row: HTMLElement) {
+  Object.defineProperty(row, "getBoundingClientRect", {
+    value: () => ({
+      top: 0,
+      bottom: 30,
+      left: 0,
+      right: 240,
+      width: 240,
+      height: 30,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    }),
+  });
+}

--- a/tests/desktopBuildIdentity.test.mjs
+++ b/tests/desktopBuildIdentity.test.mjs
@@ -12,6 +12,12 @@ import {
   createDesktopElectronBuilderConfig,
   prepareDesktopBuild,
 } from "../scripts/release-support/desktop-build-preparation.mjs";
+import {
+  DESKTOP_INTERNAL_UPDATE_FEED_URL,
+  DESKTOP_SHIPPED_STABLE_UPDATE_CONTRACTS,
+  DESKTOP_STABLE_UPDATE_FEED_URL,
+  DESKTOP_SUPPORTED_STABLE_UPDATE_FEED_URLS,
+} from "../shared/desktop-distribution-contract.mjs";
 
 const commitSha = "a".repeat(40);
 const temporaryDirectories = [];
@@ -135,8 +141,13 @@ describe("desktop build identity", () => {
     expect(new Set([dev.applicationId, internal.applicationId, stable.applicationId])).toHaveLength(3);
     expect(new Set([dev.userDataName, internal.userDataName, stable.userDataName])).toHaveLength(3);
     expect(dev.updateFeedUrl).toBeNull();
-    expect(internal.updateFeedUrl).toContain("/internal/");
-    expect(stable.updateFeedUrl).toContain("/stable/");
+    expect(internal.updateFeedUrl).toBe(DESKTOP_INTERNAL_UPDATE_FEED_URL);
+    expect(stable.updateFeedUrl).toBe(DESKTOP_STABLE_UPDATE_FEED_URL);
+    expect(DESKTOP_SUPPORTED_STABLE_UPDATE_FEED_URLS).toContain(stable.updateFeedUrl);
+    expect(DESKTOP_SHIPPED_STABLE_UPDATE_CONTRACTS).toContainEqual({
+      feedUrl: DESKTOP_STABLE_UPDATE_FEED_URL,
+      introducedInVersion: "0.1.4",
+    });
   });
 
   it("derives electron-builder configuration from the same immutable identity", () => {
@@ -167,7 +178,7 @@ describe("desktop build identity", () => {
       buildVersion: "42",
       publish: [{
         channel: "internal",
-        url: "https://updates.puppyone.ai/desktop/internal/mac/latest",
+        url: DESKTOP_INTERNAL_UPDATE_FEED_URL,
       }],
       mac: {
         bundleShortVersion: "1.4.0",

--- a/tests/desktopReleaseMetadata.test.mjs
+++ b/tests/desktopReleaseMetadata.test.mjs
@@ -112,6 +112,48 @@ describe("desktop release metadata", () => {
     expect(() => mergeReleaseCatalog(catalog, conflicting)).toThrow(/different immutable release/);
   });
 
+  it("enforces channel-specific catalogs and removes legacy channel pollution", async () => {
+    const fixture = await createFixture();
+    const internal = await internalManifest(fixture.assets);
+    const internalCatalog = mergeReleaseCatalog(
+      null,
+      internal,
+      "2026-07-24T12:30:00.000Z",
+      ["internal"],
+    );
+
+    const archive = await createDesktopReleaseManifest({
+      ...baseMetadata(),
+      assetPaths: [fixture.assets[1]],
+      channel: "archive",
+      commitSha: null,
+      developerIdSigned: false,
+      notarized: false,
+      prerelease: false,
+      provenance: "archive",
+      r2Prefix: "desktop/archive/mac/v0.1.0-legacy.0",
+      tag: "v0.1.0-legacy.0",
+      version: "0.1.0",
+      workflowRunUrl: null,
+    });
+    const publicCatalog = mergeReleaseCatalog(
+      internalCatalog,
+      archive,
+      "2026-07-24T12:31:00.000Z",
+      ["stable", "archive"],
+    );
+
+    expect(publicCatalog.releases.map((release) => release.tag)).toEqual([
+      "v0.1.0-legacy.0",
+    ]);
+    expect(() => mergeReleaseCatalog(
+      publicCatalog,
+      internal,
+      "2026-07-24T12:32:00.000Z",
+      ["stable", "archive"],
+    )).toThrow(/not allowed in this catalog/);
+  });
+
   it("rejects non-canonical timestamps and credential-bearing release URLs", async () => {
     const fixture = await createFixture();
     const manifest = await internalManifest(fixture.assets);

--- a/tests/desktopUpdateFeedVerifier.test.mjs
+++ b/tests/desktopUpdateFeedVerifier.test.mjs
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  parseDesktopUpdaterMetadata,
+  verifyDesktopStableUpdateFeeds,
+} from "../scripts/release-support/desktop-update-feed-verifier.mjs";
+import {
+  parseDesktopUpdateFeedVerifierArguments,
+} from "../scripts/verify-desktop-stable-update-feed.mjs";
+
+const VERSION = "1.2.3";
+const ZIP_SHA512 = Buffer.alloc(64, 1).toString("base64");
+const DMG_SHA512 = Buffer.alloc(64, 2).toString("base64");
+const METADATA = [
+  `version: ${VERSION}`,
+  "files:",
+  "  - url: PuppyOne-1.2.3-arm64.zip",
+  `    sha512: ${ZIP_SHA512}`,
+  "    size: 9",
+  "  - url: PuppyOne-1.2.3-arm64.dmg",
+  `    sha512: ${DMG_SHA512}`,
+  "    size: 11",
+  "path: PuppyOne-1.2.3-arm64.zip",
+  `sha512: ${ZIP_SHA512}`,
+  "releaseDate: '2026-07-30T08:00:00.000Z'",
+  "",
+].join("\n");
+
+describe("Desktop Stable update feed verifier", () => {
+  it("parses the controlled electron-builder metadata contract", () => {
+    expect(parseDesktopUpdaterMetadata(METADATA)).toEqual({
+      version: VERSION,
+      files: [
+        {
+          url: "PuppyOne-1.2.3-arm64.zip",
+          sha512: ZIP_SHA512,
+          size: 9,
+        },
+        {
+          url: "PuppyOne-1.2.3-arm64.dmg",
+          sha512: DMG_SHA512,
+          size: 11,
+        },
+      ],
+      path: "PuppyOne-1.2.3-arm64.zip",
+      sha512: ZIP_SHA512,
+      releaseDate: "2026-07-30T08:00:00.000Z",
+    });
+  });
+
+  it("rejects malformed metadata instead of trusting YAML-like fields", () => {
+    expect(() => parseDesktopUpdaterMetadata(
+      METADATA
+        .replace(ZIP_SHA512, "not-a-sha512")
+        .replace("releaseDate: '2026-07-30T08:00:00.000Z'", ""),
+    )).toThrow(/base64 SHA-512 digest[\s\S]*valid timestamp/);
+  });
+
+  it("verifies every registered feed, version alignment, and byte ranges", async () => {
+    const feedUrls = [
+      "https://updates-one.example/desktop/stable/mac/latest",
+      "https://updates-two.example/desktop/stable/mac/latest",
+    ];
+    const fetchImpl = createFeedFetch();
+
+    const result = await verifyDesktopStableUpdateFeeds({
+      attempts: 1,
+      expectedVersion: VERSION,
+      feedUrls,
+      fetchImpl,
+      latestPointerUrl: "https://downloads.example/desktop/stable/mac/latest/latest.json",
+      retryDelayMs: 0,
+      timeoutMs: 1_000,
+    });
+
+    expect(result.version).toBe(VERSION);
+    expect(result.reports).toHaveLength(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(7);
+    expect(fetchImpl.mock.calls.filter(([, init]) => init?.headers?.Range === "bytes=0-0"))
+      .toHaveLength(4);
+  });
+
+  it("rejects a latest pointer that does not match the release being published", async () => {
+    await expect(verifyDesktopStableUpdateFeeds({
+      attempts: 1,
+      expectedVersion: "1.2.4",
+      feedUrls: ["https://updates.example/desktop/stable/mac/latest"],
+      fetchImpl: createFeedFetch(),
+      latestPointerUrl: "https://downloads.example/desktop/stable/mac/latest/latest.json",
+      retryDelayMs: 0,
+      timeoutMs: 1_000,
+    })).rejects.toThrow("reports 1.2.3, expected 1.2.4");
+  });
+
+  it("rejects origins that do not support exact byte ranges", async () => {
+    await expect(verifyDesktopStableUpdateFeeds({
+      attempts: 1,
+      feedUrls: ["https://updates.example/desktop/stable/mac/latest"],
+      fetchImpl: createFeedFetch({ rangeStatus: 200 }),
+      latestPointerUrl: "https://downloads.example/desktop/stable/mac/latest/latest.json",
+      retryDelayMs: 0,
+      timeoutMs: 1_000,
+    })).rejects.toThrow("HTTP 200");
+  });
+
+  it("rejects payload size drift between metadata and storage", async () => {
+    await expect(verifyDesktopStableUpdateFeeds({
+      attempts: 1,
+      feedUrls: ["https://updates.example/desktop/stable/mac/latest"],
+      fetchImpl: createFeedFetch({ sizeOffset: 1 }),
+      latestPointerUrl: "https://downloads.example/desktop/stable/mac/latest/latest.json",
+      retryDelayMs: 0,
+      timeoutMs: 1_000,
+    })).rejects.toThrow("reports 10 bytes, expected 9");
+  });
+
+  it("accepts only the explicit expected-version CLI option", () => {
+    expect(parseDesktopUpdateFeedVerifierArguments([
+      "--expected-version",
+      VERSION,
+    ])).toEqual({
+      expectedVersion: VERSION,
+    });
+    expect(() => parseDesktopUpdateFeedVerifierArguments(["--feed", "unexpected"]))
+      .toThrow("Unknown argument");
+    expect(() => parseDesktopUpdateFeedVerifierArguments(["--expected-version"]))
+      .toThrow("requires a value");
+  });
+
+  it("rejects duplicate feed contracts and invalid retry bounds", async () => {
+    await expect(verifyDesktopStableUpdateFeeds({
+      feedUrls: [
+        "https://updates.example/desktop/stable/mac/latest",
+        "https://updates.example/desktop/stable/mac/latest",
+      ],
+      fetchImpl: createFeedFetch(),
+    })).rejects.toThrow("must be unique");
+    await expect(verifyDesktopStableUpdateFeeds({
+      attempts: 0,
+      feedUrls: ["https://updates.example/desktop/stable/mac/latest"],
+      fetchImpl: createFeedFetch(),
+    })).rejects.toThrow("attempts must be an integer");
+  });
+});
+
+function createFeedFetch({ rangeStatus = 206, sizeOffset = 0 } = {}) {
+  return vi.fn(async (input, init = {}) => {
+    const url = String(input);
+    if (url.endsWith("/latest.json")) {
+      return new Response(JSON.stringify({
+        channel: "stable",
+        tag: `v${VERSION}`,
+        version: VERSION,
+      }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    }
+    if (url.endsWith("/stable-mac.yml")) {
+      return new Response(METADATA, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/yaml",
+        },
+      });
+    }
+    if (init.headers?.Range === "bytes=0-0") {
+      const expectedSize = url.endsWith(".zip") ? 9 : 11;
+      return new Response(new Uint8Array([1]), {
+        status: rangeStatus,
+        headers: {
+          "Content-Length": rangeStatus === 206 ? "1" : String(expectedSize),
+          "Content-Range": `bytes 0-0/${expectedSize + sizeOffset}`,
+        },
+      });
+    }
+    return new Response("not found", { status: 404 });
+  });
+}

--- a/tests/electron.feedback-ipc.test.mjs
+++ b/tests/electron.feedback-ipc.test.mjs
@@ -26,6 +26,7 @@ describe("feedback IPC", () => {
     expect(request).toMatchObject({
       method: "POST",
       headers: {
+        accept: "application/json",
         "user-agent": "puppyone-desktop/0.1.2",
       },
     });
@@ -36,8 +37,12 @@ describe("feedback IPC", () => {
       appVersion: "0.1.2",
       locale: "zh-Hans",
       platform: "darwin",
-      website: "",
+      source: "PuppyOne Desktop",
+      subject: "PuppyOne Desktop Feedback · v0.1.2",
+      timestamp: expect.any(String),
+      _gotcha: "",
     });
+    expect(Number.isNaN(Date.parse(request.body.get("timestamp")))).toBe(false);
   });
 
   it("rejects empty and oversized feedback before making a network request", async () => {
@@ -72,8 +77,9 @@ describe("feedback IPC", () => {
     })).resolves.toEqual({ ok: true });
 
     const request = fetchImpl.mock.calls[0][1];
-    const screenshot = request.body.get("screenshot");
+    const screenshot = request.body.get("attachment");
     expect(request.body.get("message")).toBe("");
+    expect(request.body.get("appVersion")).toBe("0.1.2");
     expect(screenshot).toBeInstanceOf(Blob);
     expect(screenshot.type).toBe("image/png");
     expect(screenshot.name).toBe("feedback-screenshot.png");
@@ -107,12 +113,27 @@ describe("feedback IPC", () => {
       "could not accept",
     );
   });
+
+  it("uses the dedicated public Formspree feedback form by default", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ next: "/thanks" }),
+    });
+    const handler = createHandler({ fetchImpl, endpoint: null });
+
+    await expect(handler({}, { message: "A useful message" })).resolves.toEqual({
+      ok: true,
+    });
+
+    expect(fetchImpl.mock.calls[0][0]).toBe("https://formspree.io/f/mlgqvydy");
+  });
 });
 
 function createHandler({
   fetchImpl = vi.fn(),
   appVersion = "0.1.2",
   platform = "darwin",
+  endpoint = "https://feedback.example/api",
 } = {}) {
   const handlers = new Map();
   registerFeedbackIpcHandlers({
@@ -124,7 +145,7 @@ function createHandler({
     fetchImpl,
     appVersion,
     platform,
-    endpoint: "https://feedback.example/api",
+    ...(endpoint === null ? {} : { endpoint }),
   });
   return handlers.get("feedback:submit");
 }

--- a/tests/electron.update-service.test.mjs
+++ b/tests/electron.update-service.test.mjs
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { resolveDesktopUpdateConfiguration } from "../electron/update-service.mjs";
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createUpdateService,
+  resolveDesktopUpdateConfiguration,
+} from "../electron/update-service.mjs";
 import { resolveDesktopBuildIdentity } from "../shared/desktop-build-identity.mjs";
 
 const commitSha = "d".repeat(40);
@@ -25,7 +29,7 @@ describe("Desktop updater channel isolation", () => {
       allowPrerelease: true,
       channel: "internal",
       currentVersion: "1.4.0-internal.72",
-      feedUrl: "https://updates.puppyone.ai/desktop/internal/mac/latest",
+      feedUrl: "https://downloads.puppyone.ai/desktop/internal/mac/latest",
       forceDevUpdateConfig: false,
       updateChannel: "internal",
     });
@@ -103,5 +107,73 @@ describe("Desktop updater channel isolation", () => {
       forceDevUpdateConfig: false,
       updateChannel: null,
     });
+  });
+
+  it("checks Stable updates after startup and on a bounded interval while retaining the Settings command", async () => {
+    vi.useFakeTimers();
+    let service;
+    try {
+      const buildInfo = resolveDesktopBuildIdentity({
+        baseVersion: "1.4.0",
+        buildNumber: 74,
+        channel: "stable",
+        commitSha,
+      });
+      const handlers = new Map();
+      const autoUpdater = new EventEmitter();
+      let checkCount = 0;
+      Object.assign(autoUpdater, {
+        checkForUpdates: async () => {
+          checkCount += 1;
+          return { updateInfo: null };
+        },
+        setFeedURL: () => {},
+      });
+      service = createUpdateService({
+        app: { isPackaged: true },
+        autoUpdater,
+        buildInfo,
+        checkSchedule: {
+          startupDelayMs: 15_000,
+          startupJitterMs: 0,
+          intervalMs: 4 * 60 * 60 * 1000,
+          intervalJitterMs: 0,
+        },
+        getRestartBlockers: () => [],
+        getWindows: () => [],
+        ipcMain: {
+          handle: (channel, handler) => handlers.set(channel, handler),
+        },
+        platform: "linux",
+        random: () => 0,
+      });
+
+      service.start();
+      service.start();
+      await vi.advanceTimersByTimeAsync(14_999);
+
+      expect(checkCount).toBe(0);
+      expect(service.getState().status).toBe("idle");
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(checkCount).toBe(1);
+      expect(service.getState().status).toBe("not-available");
+
+      await vi.advanceTimersByTimeAsync(4 * 60 * 60 * 1000);
+      expect(checkCount).toBe(2);
+
+      const checkFromSettings = handlers.get("updates:check");
+      expect(checkFromSettings).toBeTypeOf("function");
+      await checkFromSettings();
+
+      expect(checkCount).toBe(3);
+      expect(service.getState().status).toBe("not-available");
+      service.dispose();
+      await vi.advanceTimersByTimeAsync(8 * 60 * 60 * 1000);
+      expect(checkCount).toBe(3);
+    } finally {
+      service?.dispose();
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/explorerTreeSemantics.test.tsx
+++ b/tests/explorerTreeSemantics.test.tsx
@@ -107,6 +107,167 @@ describe("ExplorerTree interactive semantics", () => {
     expect(classifyReferenceDataTransfer(transfer)).toMatchObject({ kind: "workspace-entries", typed: true });
   });
 
+  it("keeps the internal move session across same-frame native events and window blur", () => {
+    const source: DataNode = {
+      id: "drag-me",
+      name: "drag-me.txt",
+      path: "drag-me.txt",
+      type: "text",
+    };
+    const target: DataNode = {
+      id: "target",
+      name: "target",
+      path: "target",
+      type: "folder",
+      children: [],
+    };
+    const onMoveNode = vi.fn(async () => undefined);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => renderWithTestLocalization(root,
+      <ExplorerTree
+        nodes={[source, target]}
+        activePath={null}
+        expandedPaths={new Set()}
+        showRoot={false}
+        dragWorkspaceId="workspace-1"
+        canMoveNodes
+        onSelectNode={vi.fn()}
+        onMoveNode={onMoveNode}
+      />,
+    ));
+
+    const sourceRow = container.querySelector<HTMLElement>(`[data-explorer-path="${source.path}"]`)!;
+    const targetRow = container.querySelector<HTMLElement>(`[data-explorer-path="${target.path}"]`)!;
+    mockRowBounds(targetRow);
+    const transfer = fakeDataTransfer();
+
+    act(() => {
+      sourceRow.dispatchEvent(dragEvent("dragstart", transfer));
+      window.dispatchEvent(new Event("blur"));
+      targetRow.dispatchEvent(dragEvent("dragover", transfer));
+      targetRow.dispatchEvent(dragEvent("drop", transfer));
+    });
+
+    expect(onMoveNode).toHaveBeenCalledWith(source, target.path);
+  });
+
+  it("moves a nested file back to its parent folder through the batch callback", async () => {
+    const source: DataNode = {
+      id: "parent-child-drag-me",
+      name: "drag-me.txt",
+      path: "parent/child/drag-me.txt",
+      type: "text",
+    };
+    const child: DataNode = {
+      id: "parent-child",
+      name: "child",
+      path: "parent/child",
+      type: "folder",
+      children: [source],
+    };
+    const parent: DataNode = {
+      id: "parent",
+      name: "parent",
+      path: "parent",
+      type: "folder",
+      children: [child],
+    };
+    const onMoveNodes = vi.fn(async () => undefined);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => renderWithTestLocalization(root,
+      <ExplorerTree
+        nodes={[parent]}
+        activePath={source.path}
+        selectedPaths={new Set([source.path])}
+        expandedPaths={new Set([parent.path, child.path])}
+        showRoot={false}
+        dragWorkspaceId="workspace-1"
+        canMoveNodes
+        onSelectNode={vi.fn()}
+        onMoveNodes={onMoveNodes}
+      />,
+    ));
+
+    const sourceRow = container.querySelector<HTMLElement>(`[data-explorer-path="${source.path}"]`)!;
+    const parentRow = container.querySelector<HTMLElement>(`[data-explorer-path="${parent.path}"]`)!;
+    mockRowBounds(parentRow);
+    const transfer = fakeDataTransfer();
+
+    await act(async () => {
+      sourceRow.dispatchEvent(dragEvent("dragstart", transfer));
+      parentRow.dispatchEvent(dragEvent("dragover", transfer));
+      parentRow.dispatchEvent(dragEvent("drop", transfer));
+      await Promise.resolve();
+    });
+
+    expect(onMoveNodes).toHaveBeenCalledWith([source], parent.path);
+  });
+
+  it("recovers an internal move from the typed native drag payload", async () => {
+    const source: DataNode = {
+      id: "payload-source",
+      name: "drag-me.txt",
+      path: "parent/child/drag-me.txt",
+      type: "text",
+    };
+    const child: DataNode = {
+      id: "payload-child",
+      name: "child",
+      path: "parent/child",
+      type: "folder",
+      children: [source],
+    };
+    const parent: DataNode = {
+      id: "payload-parent",
+      name: "parent",
+      path: "parent",
+      type: "folder",
+      children: [child],
+    };
+    const onMoveNodes = vi.fn(async () => undefined);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => renderWithTestLocalization(root,
+      <ExplorerTree
+        nodes={[parent]}
+        activePath={source.path}
+        selectedPaths={new Set([source.path])}
+        expandedPaths={new Set([parent.path, child.path])}
+        showRoot={false}
+        dragWorkspaceId="workspace-1"
+        canMoveNodes
+        onSelectNode={vi.fn()}
+        onMoveNodes={onMoveNodes}
+      />,
+    ));
+
+    const parentRow = container.querySelector<HTMLElement>(`[data-explorer-path="${parent.path}"]`)!;
+    mockRowBounds(parentRow);
+    const transfer = fakeDataTransfer();
+    transfer.setData(EXPLORER_REFERENCE_DRAG_TYPE, JSON.stringify({
+      version: 1,
+      workspaceId: "workspace-1",
+      entries: [{
+        path: source.path,
+        name: source.name,
+        entryType: "file",
+      }],
+    }));
+
+    await act(async () => {
+      parentRow.dispatchEvent(dragEvent("dragover", transfer));
+      parentRow.dispatchEvent(dragEvent("drop", transfer));
+      await Promise.resolve();
+    });
+
+    expect(onMoveNodes).toHaveBeenCalledWith([source], parent.path);
+  });
+
   it("clears external-file drop feedback when the drag leaves the tree", () => {
     const folder: DataNode = {
       id: "recordings",

--- a/tests/macosReleasePolicy.test.mjs
+++ b/tests/macosReleasePolicy.test.mjs
@@ -7,6 +7,7 @@ import {
   inspectLegacyArchiveWorkflow,
   inspectReleasePublisherWorkflow,
   inspectStableReleaseWorkflow,
+  inspectUpdateFeedMonitorWorkflow,
 } from "../scripts/release-support/internal-release-workflow-policy.mjs";
 import {
   getStableReleaseCoordinates,
@@ -181,6 +182,34 @@ describe("desktop release publisher workflow", () => {
       "the final GitHub release verification must receive the caller's draft/public policy explicitly",
     );
   });
+
+  it("requires every machine-origin verification stage to remain Stable-only", () => {
+    const workflow = readFileSync(
+      new URL("../.github/workflows/desktop-release-publish.yml", import.meta.url),
+      "utf8",
+    ).replace(
+      "      - name: Verify existing Stable update origin before publication\n        if: ${{ inputs.channel == 'stable' }}",
+      "      - name: Verify existing Stable update origin before publication",
+    );
+
+    expect(inspectReleasePublisherWorkflow(workflow)).toContain(
+      'the "Verify existing Stable update origin before publication" stage must run only for Stable publication',
+    );
+  });
+
+  it("keeps the distribution preflight read-only and ahead of deployment authority", () => {
+    const workflow = readFileSync(
+      new URL("../.github/workflows/desktop-release-publish.yml", import.meta.url),
+      "utf8",
+    ).replace(
+      "    permissions:\n      contents: read",
+      "    permissions:\n      contents: write",
+    );
+
+    expect(inspectReleasePublisherWorkflow(workflow)).toContain(
+      "the distribution preflight must override publication authority with a read-only token",
+    );
+  });
 });
 
 describe("desktop legacy archive workflow", () => {
@@ -190,5 +219,21 @@ describe("desktop legacy archive workflow", () => {
       "utf8",
     );
     expect(inspectLegacyArchiveWorkflow(workflow)).toEqual([]);
+  });
+});
+
+describe("desktop Stable update feed monitor workflow", () => {
+  it("checks every shipped feed on a schedule without deployment authority", () => {
+    const workflow = readFileSync(
+      new URL("../.github/workflows/desktop-update-feed-monitor.yml", import.meta.url),
+      "utf8",
+    );
+    expect(inspectUpdateFeedMonitorWorkflow(workflow)).toEqual([]);
+    expect(inspectUpdateFeedMonitorWorkflow(
+      workflow.replace("permissions:\n  contents: read", "permissions:\n  contents: write"),
+    )).toEqual(expect.arrayContaining([
+      expect.stringMatching(/read-only token/),
+      expect.stringMatching(/must not receive repository write permission/),
+    ]));
   });
 });

--- a/tests/packagedDesktopBuildVerifier.test.mjs
+++ b/tests/packagedDesktopBuildVerifier.test.mjs
@@ -9,6 +9,9 @@ import {
   getDesktopBuildChannelPolicy,
   resolveDesktopBuildIdentity,
 } from "../shared/desktop-build-identity.mjs";
+import {
+  DESKTOP_STABLE_UPDATE_FEED_URL,
+} from "../shared/desktop-distribution-contract.mjs";
 
 const { createPackage } = asarPackage;
 const { build: buildPlist } = plistPackage;
@@ -35,7 +38,7 @@ describe("packaged Desktop Build Identity verification", () => {
     const fixture = await createFixture();
     await fs.writeFile(
       path.join(fixture.applicationPath, "Contents", "Resources", "app-update.yml"),
-      "provider: generic\nurl: https://updates.puppyone.ai/desktop/stable/mac/latest\nchannel: stable\n",
+      `provider: generic\nurl: ${DESKTOP_STABLE_UPDATE_FEED_URL}\nchannel: stable\n`,
     );
 
     await expect(verifyPackagedDesktopBuild({

--- a/tests/scrollbarArchitecture.test.ts
+++ b/tests/scrollbarArchitecture.test.ts
@@ -1,0 +1,205 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const tokensCss = readCss("src/styles/tokens.css");
+const scrollbarsCss = readCss("src/styles/scrollbars.css");
+const dataWorkspaceCss = readCss("packages/shared-ui/src/styles/data-workspace.css");
+const dataWorkspaceSource = readCss("packages/shared-ui/src/data/DataWorkspace.tsx");
+const desktopDataShellCss = readCss("src/features/data-workspace/data-shell.css");
+const sidebarPrimitivesCss = readCss("packages/shared-ui/src/styles/sidebar-primitives.css");
+const sidebarResizeHandleSource = readCss(
+  "packages/shared-ui/src/sidebar/SidebarResizeHandle.tsx",
+);
+const auxiliaryPanelSource = readCss(
+  "src/features/app-shell/auxiliary/AuxiliaryPanelHost.tsx",
+);
+const gitStatusSource = readCss("src/features/source-control/GitStatusView.tsx");
+const historyDetailCss = readCss("src/features/source-control/styles/history-detail.css");
+const layoutCss = readCss("src/styles/layout.css");
+const baseCss = readCss("src/styles/base.css");
+const csvTableCss = readCss("packages/shared-ui/src/styles/editor/csv-table-editor.css");
+const markdownEditorCss = readCss("packages/shared-ui/src/styles/editor/markdown-editor.css");
+const markdownTableCss = readCss("packages/shared-ui/src/styles/editor/markdown-table-widget.css");
+
+describe("scrollbar architecture", () => {
+  it("defines one modern track and thumb geometry", () => {
+    expect(tokensCss).toContain("--po-scrollbar-size: 8px;");
+    expect(tokensCss).toContain("--po-scrollbar-thumb-size: 6px;");
+    expect(tokensCss).toContain("--po-scrollbar-thumb-inset: 1px;");
+    expect(tokensCss).toContain("--po-scrollbar-radius: 999px;");
+    expect(scrollbarsCss).toContain("width: var(--po-scrollbar-size, 8px);");
+    expect(scrollbarsCss).toContain("height: var(--po-scrollbar-size, 8px);");
+    expect(scrollbarsCss).toContain(
+      "border: var(--po-scrollbar-thumb-inset, 1px) solid transparent;",
+    );
+    expect(scrollbarsCss).toContain("background-clip: padding-box;");
+  });
+
+  it("keeps the sidebar thumb thin and perceptually as light as the editor thumb", () => {
+    expect(tokensCss).toContain("--desktop-sidebar-scrollbar-thumb: color-mix(");
+    expect(tokensCss).toContain("--desktop-sidebar-scrollbar-thumb-hover: color-mix(");
+    expect(dataWorkspaceCss).toContain(
+      "border: var(--po-scrollbar-thumb-inset, 1px) solid transparent;",
+    );
+    expect(dataWorkspaceCss).toContain("background-clip: padding-box;");
+    expect(dataWorkspaceCss).toContain("background-color: var(--tree-scrollbar-thumb);");
+    expect(dataWorkspaceCss).toContain(
+      "background-color: var(--tree-scrollbar-thumb-hover);",
+    );
+  });
+
+  it("defines one collision-safe pane-edge resize lane", () => {
+    expect(tokensCss).toContain("--po-pane-resizer-hit-size: 8px;");
+    expect(tokensCss).toContain("--po-pane-resizer-line-size: 1px;");
+    expect(sidebarResizeHandleSource).toContain(
+      'paneEdge && "po-pane-edge-resize-handle"',
+    );
+
+    const sharedResizerRule = readRule(
+      sidebarPrimitivesCss,
+      ".po-pane-edge-resize-handle",
+    );
+    expect(sharedResizerRule).toContain("inset-block: 0;");
+    expect(sharedResizerRule).toContain(
+      "width: var(--po-pane-resizer-hit-size, 8px);",
+    );
+    expect(sharedResizerRule).toContain("transform: none;");
+  });
+
+  it("requires every vertical SidebarResizeHandle to opt into the pane-edge contract", () => {
+    const verticalHandlePattern =
+      /<SidebarResizeHandle\b(?:(?!<SidebarResizeHandle\b)[\s\S])*?orientation="vertical"/g;
+    const violations = [
+      ...listFiles(path.join(repositoryRoot, "src"), ".tsx"),
+      ...listFiles(path.join(repositoryRoot, "packages/shared-ui/src"), ".tsx"),
+    ].flatMap((filePath) => {
+      const relativePath = path.relative(repositoryRoot, filePath);
+      return Array.from(readFileSync(filePath, "utf8").matchAll(verticalHandlePattern))
+        .filter((match) => !/\bpaneEdge\b/.test(match[0]))
+        .map(() => relativePath);
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps Data and History pane resizers after their sidebar scroll lanes", () => {
+    for (const css of [dataWorkspaceCss, desktopDataShellCss]) {
+      const resizerRule = readRule(css, ".data-explorer-resizer");
+      expect(resizerRule).toContain(
+        "inset-inline-start: var(--data-explorer-width, clamp(282px, 26vw, 360px));",
+      );
+      expect(resizerRule).not.toContain("transform:");
+      expect(resizerRule).not.toContain("inset-inline-end:");
+    }
+
+    expect(dataWorkspaceSource.indexOf('className="data-explorer-resizer"')).toBeGreaterThan(
+      dataWorkspaceSource.indexOf("</aside>"),
+    );
+    expect(dataWorkspaceSource).toMatch(
+      /className="data-explorer-resizer"\s+paneEdge/,
+    );
+
+    const historyResizerRule = readRule(
+      historyDetailCss,
+      ".desktop-history-panel-tree-resizer",
+    );
+    expect(historyResizerRule).toContain(
+      "inset-inline-start: var(--desktop-history-tree-width, clamp(260px, 28vw, 380px));",
+    );
+    expect(historyResizerRule).not.toContain("inset-inline-end:");
+    expect(historyResizerRule).not.toContain("transform:");
+    expect(gitStatusSource).toMatch(
+      /<\/aside>\s+<SidebarResizeHandle\s+className="desktop-history-panel-tree-resizer"\s+paneEdge/,
+    );
+    expect(gitStatusSource).toContain(
+      "const treeElement = event.currentTarget.previousElementSibling;",
+    );
+    expect(baseCss).not.toContain('[dir="rtl"] .data-explorer-resizer');
+  });
+
+  it("keeps the auxiliary resizer on the panel side of the Markdown scroll lane", () => {
+    expect(markdownEditorCss).toMatch(
+      /\.markdown-codemirror-editor \.cm-scroller\s*\{[^}]*overflow:\s*auto;/s,
+    );
+    expect(auxiliaryPanelSource).toMatch(
+      /className="desktop-right-sidebar-resizer"\s+paneEdge/,
+    );
+
+    const rightResizerRule = readRule(layoutCss, ".desktop-right-sidebar-resizer");
+    expect(rightResizerRule).toContain("inset-inline-start: 0;");
+    expect(rightResizerRule).not.toContain("transform:");
+    expect(rightResizerRule).not.toContain("inset-inline-end:");
+    expect(baseCss).not.toContain('[dir="rtl"] .desktop-right-sidebar-resizer');
+  });
+
+  it("keeps CSV and Markdown table scrollbars on the shared geometry", () => {
+    for (const css of [csvTableCss, markdownTableCss]) {
+      expect(css).toContain("var(--po-scrollbar-size, 8px)");
+      expect(css).toContain(
+        "border: var(--po-scrollbar-thumb-inset, 1px) solid transparent;",
+      );
+      expect(css).toContain("border-radius: var(--po-scrollbar-radius, 999px);");
+    }
+  });
+
+  it("does not opt any app stylesheet back into platform-native scrollbar rendering", () => {
+    const violations = [
+      ...listCssFiles(path.join(repositoryRoot, "src")),
+      ...listCssFiles(path.join(repositoryRoot, "packages/shared-ui/src")),
+    ].filter((filePath) => (
+      /(?<![-\w])scrollbar-(?:width|color)\s*:/.test(readFileSync(filePath, "utf8"))
+    ));
+
+    expect(violations.map((filePath) => path.relative(repositoryRoot, filePath))).toEqual([]);
+  });
+
+  it("does not reset modern thumb clipping with the background shorthand", () => {
+    const legacySkinFiles = new Set([
+      "src/styles/interface-skin-contract.css",
+      "src/styles/macos-tiger.css",
+      "src/styles/windows-xp.css",
+    ]);
+    const violations = [
+      ...listCssFiles(path.join(repositoryRoot, "src")),
+      ...listCssFiles(path.join(repositoryRoot, "packages/shared-ui/src")),
+    ].flatMap((filePath) => {
+      const relativePath = path.relative(repositoryRoot, filePath);
+      if (legacySkinFiles.has(relativePath)) return [];
+
+      const css = readFileSync(filePath, "utf8");
+      const thumbRule = /([^{}]*::-webkit-scrollbar-thumb[^{}]*)\{([^{}]*)\}/g;
+      return Array.from(css.matchAll(thumbRule))
+        .filter((match) => /(?:^|[;\s])background\s*:/.test(match[2] ?? ""))
+        .map((match) => `${relativePath}: ${match[1]?.trim()}`);
+    });
+
+    expect(violations).toEqual([]);
+  });
+});
+
+function readCss(relativePath: string): string {
+  return readFileSync(path.join(repositoryRoot, relativePath), "utf8");
+}
+
+function readRule(css: string, selector: string): string {
+  const ruleStart = css.indexOf(`${selector} {`);
+  expect(ruleStart).toBeGreaterThanOrEqual(0);
+  const ruleEnd = css.indexOf("}", ruleStart);
+  expect(ruleEnd).toBeGreaterThan(ruleStart);
+  return css.slice(ruleStart, ruleEnd + 1);
+}
+
+function listCssFiles(directory: string): string[] {
+  return listFiles(directory, ".css");
+}
+
+function listFiles(directory: string, extension: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return listFiles(entryPath, extension);
+    return entry.isFile() && entry.name.endsWith(extension) ? [entryPath] : [];
+  });
+}

--- a/tests/sidebarPrimitives.test.tsx
+++ b/tests/sidebarPrimitives.test.tsx
@@ -52,6 +52,7 @@ describe("Sidebar primitives", () => {
       <SidebarResizeHandle
         label="Resize project sidebar"
         orientation="vertical"
+        paneEdge
         min={220}
         max={520}
         value={320}
@@ -61,6 +62,7 @@ describe("Sidebar primitives", () => {
     const handle = container.querySelector<HTMLElement>('[role="separator"]');
     expect(handle?.getAttribute("aria-valuenow")).toBe("320");
     expect(handle?.getAttribute("aria-orientation")).toBe("vertical");
+    expect(handle?.classList.contains("po-pane-edge-resize-handle")).toBe(true);
 
     act(() => handle?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
     act(() => handle?.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true })));

--- a/tests/sidebarSpacingArchitecture.test.ts
+++ b/tests/sidebarSpacingArchitecture.test.ts
@@ -96,6 +96,9 @@ describe("sidebar spacing architecture", () => {
     expect(semanticThemeScope).toContain(
       "--desktop-sidebar-section-title-disabled-color: var(--po-text-disabled);",
     );
+    expect(semanticThemeScope).toContain(
+      "--po-sidebar: color-mix(in srgb, var(--po-surface-chrome) 40%, var(--po-surface-editor));",
+    );
     expect(root).toContain("--desktop-sidebar-font-weight: var(--po-text-weight-medium);");
     expect(root).toContain("--desktop-sidebar-font-weight-emphasis: 650;");
     expect(root).toContain("--desktop-sidebar-line-height: 18px;");

--- a/tests/titlebarTypographyArchitecture.test.ts
+++ b/tests/titlebarTypographyArchitecture.test.ts
@@ -20,7 +20,9 @@ describe("titlebar typography architecture", () => {
       '.desktop-titlebar[data-workspace-kind="cloud"]',
     );
 
-    expect(tokensCss).toContain("--po-header: var(--po-surface-editor);");
+    expect(tokensCss).toContain(
+      "--po-header: color-mix(in srgb, var(--po-surface-chrome) 40%, var(--po-surface-editor));",
+    );
     expect(tokensCss).toContain("--po-cloud-titlebar-bg: #dbeaf1;");
     expect(tokensCss).toContain("--po-cloud-titlebar-bg: #263a45;");
     expect(titlebarRule).toContain("--desktop-titlebar-bg: var(--po-header);");

--- a/tests/workspace.fs.integration.test.mjs
+++ b/tests/workspace.fs.integration.test.mjs
@@ -473,6 +473,25 @@ describe("rename / move / delete", () => {
     expect(await readFile(path.join(root, "docs", "a.txt"), "utf8")).toBe("a");
   });
 
+  it("moves a nested file back into its parent folder", async () => {
+    await createWorkspaceEntry(root, { parentPath: null, name: "parent", kind: "folder" });
+    await createWorkspaceEntry(root, { parentPath: "parent", name: "child", kind: "folder" });
+    await createWorkspaceEntry(root, {
+      parentPath: "parent/child",
+      name: "nested.txt",
+      kind: "file",
+      content: "nested",
+    });
+
+    const result = await moveWorkspaceEntry(root, {
+      fromPath: "parent/child/nested.txt",
+      toPath: "parent/nested.txt",
+    });
+
+    expect(result.path).toBe("parent/nested.txt");
+    expect(await readFile(path.join(root, "parent", "nested.txt"), "utf8")).toBe("nested");
+  });
+
   it("refuses to move a folder into itself", async () => {
     await createWorkspaceEntry(root, { parentPath: null, name: "dir", kind: "folder" });
     await expect(moveWorkspaceEntry(root, { fromPath: "dir", toPath: "dir/sub" })).rejects.toThrow(/into itself/i);


### PR DESCRIPTION
## What changed

- bump the canonical Desktop release version to `0.1.5`
- connect in-app Feedback to the dedicated Formspree endpoint, including screenshots and automatic app-version/platform/locale metadata
- keep update discovery user-initiated from Settings and harden the permanent Stable update-feed compatibility contract
- add read-only Stable feed verification and scheduled monitoring
- harden GitHub/R2 release publication, channel-specific catalogs, and Internal-to-Stable promotion evidence
- refine workspace move behavior, explorer semantics, pane-edge interactions, scrollbars, and related sidebar/editor layout details

## Why

The previous feedback endpoint did not exist in production, and the release/update path needed an explicit compatibility contract so already-installed clients keep discovering future Stable releases safely. This PR packages the completed product and release-pipeline work as the `v0.1.5` candidate.

## User impact

Users can submit text or screenshot feedback from the Desktop app, with the exact installed version attached automatically. Updates remain manual from Settings. The Stable release pipeline continues to Developer ID sign, notarize, verify, and publish update metadata for existing installations.

## Validation

- `npm test` — 248 files, 1,606 tests passed
- `npm run lint`
- `npm run check:shared-ui`
- `npm exec -- tsc --noEmit`
- production `npm run build` with release cloud origins
- `node scripts/check-desktop-build-identity-architecture.mjs`
- `node scripts/check-macos-release-config.mjs`
- live Stable feed verification for `0.1.4`
- live Formspree text and PNG attachment submissions returned HTTP 200