### PR TITLE
release: PuppyOne Desktop v0.1.6

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -379,8 +379,8 @@ Prepare a Stable release by first publishing and approving an Internal build
 for the exact commit. Then point the exact matching Stable tag at that commit:
 
 ```bash
-git tag v0.1.5
-git push origin v0.1.5
+git tag v0.1.6
+git push origin v0.1.6
 ```
 
 The tag and package version must match exactly. The stable workflow prepares the
@@ -391,7 +391,7 @@ credentials to only the signing/notarization step.
 Local verification is supported:
 
 ```bash
-PUPPYONE_BUILD_NUMBER=1843 PUPPYONE_RELEASE_TAG=v0.1.5 npm run dist:mac:release
+PUPPYONE_BUILD_NUMBER=1843 PUPPYONE_RELEASE_TAG=v0.1.6 npm run dist:mac:release
 ```
 
 Local publication is not supported. Only the tagged GitHub workflow can publish

--- a/electron/update-service.mjs
+++ b/electron/update-service.mjs
@@ -9,13 +9,6 @@ import {
 
 const UPDATE_STATE_CHANNEL = "updates:state";
 
-export const DESKTOP_UPDATE_CHECK_SCHEDULE = Object.freeze({
-  startupDelayMs: 15 * 1000,
-  startupJitterMs: 15 * 1000,
-  intervalMs: 4 * 60 * 60 * 1000,
-  intervalJitterMs: 30 * 60 * 1000,
-});
-
 const UPDATE_ACTION_STATES = new Set([
   "idle",
   "not-available",
@@ -57,8 +50,6 @@ export function createUpdateService({
   environment = process.env,
   platform = process.platform,
   autoUpdater = updaterPackage.autoUpdater,
-  checkSchedule = DESKTOP_UPDATE_CHECK_SCHEDULE,
-  random = Math.random,
 }) {
   const configuration = resolveDesktopUpdateConfiguration({
     buildInfo,
@@ -69,10 +60,7 @@ export function createUpdateService({
   const currentVersion = configuration.currentVersion;
   const disabledReason = getDisabledReason(app, configuration, platform);
   const canUseUpdater = !disabledReason;
-  const schedule = normalizeCheckSchedule(checkSchedule);
 
-  let backgroundCheckTimer = null;
-  let disposed = false;
   let started = false;
   let operationPromise = null;
   let latestUpdateInfo = null;
@@ -97,14 +85,10 @@ export function createUpdateService({
       });
       return;
     }
-
-    scheduleBackgroundCheck(schedule.startupDelayMs, schedule.startupJitterMs);
   }
 
   function dispose() {
-    disposed = true;
-    if (backgroundCheckTimer) clearTimeout(backgroundCheckTimer);
-    backgroundCheckTimer = null;
+    // Updates are manual-only, so the service owns no background timer.
   }
 
   function registerIpcHandlers() {
@@ -207,19 +191,6 @@ export function createUpdateService({
         progress: null,
       });
     });
-  }
-
-  function scheduleBackgroundCheck(baseDelayMs, jitterMs) {
-    if (disposed || !canUseUpdater) return;
-    if (backgroundCheckTimer) clearTimeout(backgroundCheckTimer);
-    const delayMs = baseDelayMs + Math.floor(normalizeRandomValue(random()) * (jitterMs + 1));
-    backgroundCheckTimer = setTimeout(() => {
-      backgroundCheckTimer = null;
-      void checkForUpdates().finally(() => {
-        scheduleBackgroundCheck(schedule.intervalMs, schedule.intervalJitterMs);
-      });
-    }, delayMs);
-    backgroundCheckTimer.unref?.();
   }
 
   async function checkForUpdates() {
@@ -516,37 +487,6 @@ function normalizeUpdateFeedUrl(value) {
 
 function isTruthyEnvironmentValue(value) {
   return value === "1" || value === "true" || value === "yes";
-}
-
-function normalizeCheckSchedule(value) {
-  const schedule = value && typeof value === "object" ? value : {};
-  return Object.freeze({
-    startupDelayMs: normalizeScheduleNumber(
-      schedule.startupDelayMs,
-      DESKTOP_UPDATE_CHECK_SCHEDULE.startupDelayMs,
-    ),
-    startupJitterMs: normalizeScheduleNumber(
-      schedule.startupJitterMs,
-      DESKTOP_UPDATE_CHECK_SCHEDULE.startupJitterMs,
-    ),
-    intervalMs: normalizeScheduleNumber(
-      schedule.intervalMs,
-      DESKTOP_UPDATE_CHECK_SCHEDULE.intervalMs,
-    ),
-    intervalJitterMs: normalizeScheduleNumber(
-      schedule.intervalJitterMs,
-      DESKTOP_UPDATE_CHECK_SCHEDULE.intervalJitterMs,
-    ),
-  });
-}
-
-function normalizeScheduleNumber(value, fallback) {
-  return Number.isSafeInteger(value) && value >= 0 ? value : fallback;
-}
-
-function normalizeRandomValue(value) {
-  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
-  return Math.max(0, Math.min(0.999999999, value));
 }
 
 function normalizeUpdateInfo(info) {

--- a/locales/renderer/de/terminal.json
+++ b/locales/renderer/de/terminal.json
@@ -1,8 +1,7 @@
 {
   "title": "Terminal",
   "actions": "Terminalaktionen",
-  "clear": "Terminal leeren",
-  "reset": "Terminal zurücksetzen",
+  "restart": "Terminal neu starten",
   "bridgeUnavailable": "Die Terminal-Bridge ist nicht verfügbar. Öffne diesen Arbeitsbereich in puppyone.",
   "processExitedSignal": "Der Prozess wurde mit Signal {signal} beendet.",
   "processExitedCode": "Der Prozess wurde mit Code {code} beendet.",

--- a/locales/renderer/en/terminal.json
+++ b/locales/renderer/en/terminal.json
@@ -1,8 +1,7 @@
 {
   "title": "Terminal",
   "actions": "Terminal actions",
-  "clear": "Clear terminal",
-  "reset": "Reset terminal",
+  "restart": "Restart terminal",
   "bridgeUnavailable": "Terminal bridge unavailable. Open this workspace in puppyone.",
   "processExitedSignal": "Process exited with signal {signal}.",
   "processExitedCode": "Process exited with code {code}.",

--- a/locales/renderer/es/terminal.json
+++ b/locales/renderer/es/terminal.json
@@ -1,8 +1,7 @@
 {
   "title": "Terminal",
   "actions": "Acciones del terminal",
-  "clear": "Limpiar terminal",
-  "reset": "Restablecer terminal",
+  "restart": "Reiniciar terminal",
   "bridgeUnavailable": "El puente del terminal no está disponible. Abre este espacio de trabajo en puppyone.",
   "processExitedSignal": "El proceso terminó con la señal {signal}.",
   "processExitedCode": "El proceso terminó con el código {code}.",

--- a/locales/renderer/fr/terminal.json
+++ b/locales/renderer/fr/terminal.json
@@ -1,8 +1,7 @@
 {
   "title": "Terminal",
   "actions": "Actions du terminal",
-  "clear": "Effacer le terminal",
-  "reset": "Réinitialiser le terminal",
+  "restart": "Redémarrer le terminal",
   "bridgeUnavailable": "Pont du terminal indisponible. Ouvrez cet espace de travail dans PuppyOne.",
   "processExitedSignal": "Processus terminé avec le signal {signal}.",
   "processExitedCode": "Processus terminé avec le code {code}.",

--- a/locales/renderer/ja/terminal.json
+++ b/locales/renderer/ja/terminal.json
@@ -1,8 +1,7 @@
 {
   "title": "ターミナル",
   "actions": "ターミナル操作",
-  "clear": "ターミナルを消去",
-  "reset": "ターミナルをリセット",
+  "restart": "ターミナルを再起動",
   "bridgeUnavailable": "ターミナルブリッジを利用できません。このワークスペースを puppyone で開いてください。",
   "processExitedSignal": "プロセスはシグナル {signal} で終了しました。",
   "processExitedCode": "プロセスはコード {code} で終了しました。",

--- a/locales/renderer/ko/terminal.json
+++ b/locales/renderer/ko/terminal.json
@@ -1,8 +1,7 @@
 {
   "title": "터미널",
   "actions": "터미널 작업",
-  "clear": "터미널 지우기",
-  "reset": "터미널 재설정",
+  "restart": "터미널 다시 시작",
   "bridgeUnavailable": "터미널 브리지를 사용할 수 없습니다. 이 작업 영역을 puppyone에서 여세요.",
   "processExitedSignal": "프로세스가 신호 {signal}(으)로 종료되었습니다.",
   "processExitedCode": "프로세스가 코드 {code}(으)로 종료되었습니다.",

--- a/locales/renderer/pt-BR/terminal.json
+++ b/locales/renderer/pt-BR/terminal.json
@@ -1,8 +1,7 @@
 {
   "title": "Terminal",
   "actions": "Ações do terminal",
-  "clear": "Limpar terminal",
-  "reset": "Redefinir terminal",
+  "restart": "Reiniciar terminal",
   "bridgeUnavailable": "A ponte do terminal não está disponível. Abra este espaço de trabalho no puppyone.",
   "processExitedSignal": "O processo foi encerrado com o sinal {signal}.",
   "processExitedCode": "O processo foi encerrado com o código {code}.",

--- a/locales/renderer/zh-Hans/terminal.json
+++ b/locales/renderer/zh-Hans/terminal.json
@@ -1,8 +1,7 @@
 {
   "title": "终端",
   "actions": "终端操作",
-  "clear": "清空终端",
-  "reset": "重置终端",
+  "restart": "重启终端",
   "bridgeUnavailable": "终端桥接不可用。请在 puppyone 中打开此工作区。",
   "processExitedSignal": "进程因信号 {signal} 退出。",
   "processExitedCode": "进程已退出，退出码为 {code}。",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppyone/desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppyone/desktop",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puppyone/desktop",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/scripts/check-desktop-build-identity-architecture.mjs
+++ b/scripts/check-desktop-build-identity-architecture.mjs
@@ -138,8 +138,16 @@ if (mainSource.includes("app.getVersion()")) {
 
 const updaterSource = await readText("electron/update-service.mjs");
 requireSource(updaterSource, "getDesktopBuildChannelPolicy", "the updater must derive its feed from channel policy");
-requireSource(updaterSource, "DESKTOP_UPDATE_CHECK_SCHEDULE", "the Stable updater must retain bounded automatic discovery");
-requireSource(updaterSource, "scheduleBackgroundCheck", "the Stable updater must schedule non-overlapping background checks");
+requireSource(
+  updaterSource,
+  'ipcMain.handle("updates:check"',
+  "the Stable updater must retain the Settings-owned manual check command",
+);
+for (const forbidden of ["DESKTOP_UPDATE_CHECK_SCHEDULE", "scheduleBackgroundCheck"]) {
+  if (updaterSource.includes(forbidden)) {
+    errors.push(`the manual-only updater must not retain background discovery through ${forbidden}`);
+  }
+}
 for (const forbidden of [
   "PUPPYONE_DESKTOP_UPDATE_CHANNEL",
   "PUPPYONE_DESKTOP_UPDATE_URL",
@@ -169,12 +177,15 @@ requireSource(
   "<DesktopBuildVersionSettingsRow />",
   "Settings General must own the user-facing Build Identity",
 );
-const titlebarActionsSource = await readText("src/features/app-shell/DesktopTitlebarActions.tsx");
 requireSource(
-  titlebarActionsSource,
-  "<DesktopUpdateTitlebarButton",
-  "actionable Desktop updates must remain visible outside Settings",
+  generalSettingsSource,
+  "<DesktopUpdateSettingsRow",
+  "Settings General must own the user-facing update workflow",
 );
+const titlebarActionsSource = await readText("src/features/app-shell/DesktopTitlebarActions.tsx");
+if (/DesktopUpdate|desktopUpdates|onUpdateNow/.test(titlebarActionsSource)) {
+  errors.push("Desktop update status and actions must not render in the Header");
+}
 const sidebarSources = [
   await readText("src/features/app-shell/DesktopDataWorkspaceSurface.tsx"),
   await readText("src/features/app-shell/navigation/DesktopSidebarFooterNavigation.tsx"),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -800,7 +800,6 @@ export function App() {
 
   const titlebarActions = (
     <DesktopTitlebarActions
-      desktopUpdates={desktopUpdates}
       canOpenActiveFileExternal={activeExternalOpen.canOpen}
       activeFileExternalOpenTitle={activeExternalOpen.title}
       activeFileExternalOpenAppName={activeExternalOpen.appName}
@@ -818,17 +817,12 @@ export function App() {
         setRightSidebarOpen(!terminalIsOpen);
         setSwitcherOpen(false);
       }}
-      onClearTerminal={() => terminalPanelRef.current?.clear()}
-      onResetTerminal={() => terminalPanelRef.current?.reset()}
+      onRestartTerminal={() => terminalPanelRef.current?.restart()}
       onToggleAgentChat={() => {
         if (!desktopAgentChatEnabled) return;
         const chatIsOpen = rightSidebarOpen && rightSidebarSurface === "chat";
         setRightSidebarSurface("chat");
         setRightSidebarOpen(!chatIsOpen);
-        setSwitcherOpen(false);
-      }}
-      onUpdateNow={() => {
-        void desktopUpdates.updateNow();
         setSwitcherOpen(false);
       }}
     />

--- a/src/components/DesktopUpdateControls.tsx
+++ b/src/components/DesktopUpdateControls.tsx
@@ -70,43 +70,6 @@ export function useDesktopUpdates(): DesktopUpdatesController {
   return { state, checkForUpdates, updateNow };
 }
 
-export function DesktopUpdateTitlebarButton({
-  state,
-  onUpdateNow,
-}: {
-  state: DesktopUpdateState;
-  onUpdateNow: () => void;
-}) {
-  const { t, formatNumber } = useLocalization();
-  const visible = state.status === "available"
-    || state.status === "downloading"
-    || state.status === "downloaded"
-    || state.status === "blocked"
-    || state.status === "error";
-
-  if (!visible) return null;
-
-  const Icon = getUpdateIcon(state.status);
-  const busy = state.status === "checking"
-    || state.status === "downloading"
-    || state.status === "installing";
-  const title = getUpdateTitle(state, t, formatNumber);
-
-  return (
-    <button
-      className={`desktop-titlebar-action desktop-update-titlebar-action ${state.status}`}
-      type="button"
-      title={title}
-      aria-label={title}
-      disabled={busy}
-      onClick={onUpdateNow}
-    >
-      <Icon size={15} className={busy ? "spin" : undefined} />
-      {state.status === "available" && <span className="desktop-update-dot" aria-hidden />}
-    </button>
-  );
-}
-
 export function DesktopUpdateSettingsRow({
   state,
   onCheckForUpdates,
@@ -197,29 +160,6 @@ function getSettingsAction(
     return { kind: "update", label: t("updates.action.tryAgain"), disabled: false, spinning: false, primary: false };
   }
   return { kind: "check", label: t("updates.action.check"), disabled: false, spinning: false, primary: false };
-}
-
-function getUpdateTitle(
-  state: DesktopUpdateState,
-  t: MessageFormatter,
-  formatNumber: (value: number, options?: Intl.NumberFormatOptions) => string,
-): string {
-  if (state.status === "available") {
-    return t("updates.title.available", {
-      version: state.availableVersion ?? t("updates.version.new"),
-    });
-  }
-  if (state.status === "downloaded") return t("updates.action.restart");
-  if (state.status === "downloading") {
-    return t("updates.title.downloading", {
-      progress: formatDownloadProgress(state, formatNumber),
-    });
-  }
-  if (state.status === "blocked") {
-    return state.blockers[0]?.label ?? t("updates.title.blocked");
-  }
-  if (state.status === "error") return t("updates.title.failed");
-  return t("updates.title.appUpdate");
 }
 
 function getUpdateDetail(

--- a/src/features/app-shell/DesktopTitlebarActions.tsx
+++ b/src/features/app-shell/DesktopTitlebarActions.tsx
@@ -1,22 +1,14 @@
 import { Fragment, useEffect, useRef, useState, type ReactNode } from "react";
-import { Eraser, MessageSquare, MoreHorizontal, RotateCcw } from "lucide-react";
+import { MessageSquare, MoreHorizontal, RotateCcw } from "lucide-react";
 import { useLocalization } from "@puppyone/localization";
 import {
   DesktopMenuItem,
-  DesktopMenuSeparator,
   DesktopMenuSurface,
 } from "../../components/DesktopMenu";
-import {
-  DesktopUpdateTitlebarButton,
-  type useDesktopUpdates,
-} from "../../components/DesktopUpdateControls";
 import { getOrderedHeaderElementDefinitions, type HeaderElementRenderContext } from "./headerElements";
 import type { TitlebarActionsSettings } from "../../preferences";
 
-type DesktopUpdatesController = ReturnType<typeof useDesktopUpdates>;
-
 type DesktopTitlebarActionsProps = {
-  desktopUpdates: DesktopUpdatesController;
   activeFileExternalOpenTitle?: string;
   activeFileExternalOpenAppName?: string | null;
   activeFileExternalOpenIconDataUrl?: string | null;
@@ -28,15 +20,12 @@ type DesktopTitlebarActionsProps = {
   agentChatEnabled: boolean;
   agentChatSidebarOpen: boolean;
   onOpenActiveFileExternal: () => void;
-  onClearTerminal: () => void;
-  onResetTerminal: () => void;
+  onRestartTerminal: () => void;
   onToggleAgentChat: () => void;
   onToggleTerminal: () => void;
-  onUpdateNow: () => void;
 };
 
 export function DesktopTitlebarActions({
-  desktopUpdates,
   activeFileExternalOpenTitle,
   activeFileExternalOpenAppName,
   activeFileExternalOpenIconDataUrl,
@@ -48,11 +37,9 @@ export function DesktopTitlebarActions({
   agentChatEnabled,
   agentChatSidebarOpen,
   onOpenActiveFileExternal,
-  onClearTerminal,
-  onResetTerminal,
+  onRestartTerminal,
   onToggleAgentChat,
   onToggleTerminal,
-  onUpdateNow,
 }: DesktopTitlebarActionsProps) {
   const { t } = useLocalization();
 
@@ -96,9 +83,8 @@ export function DesktopTitlebarActions({
         group,
         id: "terminal-menu",
         node: (
-          <TerminalTitlebarActionsMenu
-            onClear={onClearTerminal}
-            onReset={onResetTerminal}
+          <TerminalTitlebarRestartMenu
+            onRestart={onRestartTerminal}
           />
         ),
       });
@@ -127,10 +113,6 @@ export function DesktopTitlebarActions({
 
   return (
     <>
-      <DesktopUpdateTitlebarButton
-        state={desktopUpdates.state}
-        onUpdateNow={onUpdateNow}
-      />
       {titlebarActionItems.map((item, index) => {
         const previousItem = titlebarActionItems[index - 1];
         return (
@@ -146,12 +128,10 @@ export function DesktopTitlebarActions({
   );
 }
 
-function TerminalTitlebarActionsMenu({
-  onClear,
-  onReset,
+function TerminalTitlebarRestartMenu({
+  onRestart,
 }: {
-  onClear: () => void;
-  onReset: () => void;
+  onRestart: () => void;
 }) {
   const { t } = useLocalization();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -205,15 +185,9 @@ function TerminalTitlebarActionsMenu({
           className="desktop-titlebar-menu desktop-titlebar-terminal-menu"
         >
           <DesktopMenuItem
-            icon={<Eraser size={13} strokeWidth={1.8} />}
-            label={t("terminal.clear")}
-            onClick={() => runAction(onClear)}
-          />
-          <DesktopMenuSeparator />
-          <DesktopMenuItem
             icon={<RotateCcw size={13} strokeWidth={1.8} />}
-            label={t("terminal.reset")}
-            onClick={() => runAction(onReset)}
+            label={t("terminal.restart")}
+            onClick={() => runAction(onRestart)}
           />
         </DesktopMenuSurface>
       )}

--- a/src/features/desktop-terminal/ui/RightTerminalPanel.tsx
+++ b/src/features/desktop-terminal/ui/RightTerminalPanel.tsx
@@ -30,8 +30,7 @@ type RightTerminalPanelProps = {
 };
 
 export type RightTerminalPanelHandle = {
-  clear: () => void;
-  reset: () => void;
+  restart: () => void;
 };
 
 type TerminalSize = {
@@ -59,21 +58,13 @@ function RightTerminalPanelComponent(
   const [hasStarted, setHasStarted] = useState(active);
   const [sessionGeneration, setSessionGeneration] = useState(0);
 
-  const handleClearTerminal = useCallback(() => {
-    const terminal = terminalRef.current;
-    if (!terminal) return;
-    terminal.clear();
-    terminal.focus();
-  }, []);
-
-  const handleResetTerminal = useCallback(() => {
+  const handleRestartTerminal = useCallback(() => {
     setSessionGeneration((generation) => generation + 1);
   }, []);
 
   useImperativeHandle(ref, () => ({
-    clear: handleClearTerminal,
-    reset: handleResetTerminal,
-  }), [handleClearTerminal, handleResetTerminal]);
+    restart: handleRestartTerminal,
+  }), [handleRestartTerminal]);
 
   const handleTerminalDragOver = useCallback((event: ReactDragEvent<HTMLDivElement>) => {
     if (!hasTerminalDroppablePaths(event.dataTransfer)) return;

--- a/src/styles/titlebar.css
+++ b/src/styles/titlebar.css
@@ -201,28 +201,6 @@
   animation: spin 900ms linear infinite;
 }
 
-.desktop-update-titlebar-action.available,
-.desktop-update-titlebar-action.downloaded {
-  color: var(--po-accent);
-}
-
-.desktop-update-titlebar-action.blocked,
-.desktop-update-titlebar-action.error {
-  color: var(--po-warning);
-}
-
-.desktop-update-dot {
-  position: absolute;
-  top: 6px;
-  inset-inline-end: 6px;
-  width: 6px;
-  height: 6px;
-  border: 1px solid var(--desktop-titlebar-bg);
-  border-radius: 999px;
-  background: var(--po-accent);
-  pointer-events: none;
-}
-
 .desktop-titlebar-workspace-wrap {
   position: relative;
   display: flex;

--- a/tests/desktop-terminal.architecture.test.ts
+++ b/tests/desktop-terminal.architecture.test.ts
@@ -11,7 +11,9 @@ describe("Desktop Terminal architecture boundaries", () => {
     expect(panel).not.toContain("TerminalSurfaceActions");
     expect(panel).not.toContain("TerminalSurfaceHeader");
     expect(panel).toContain("sessionGeneration");
-    expect(panel).toContain("handleResetTerminal");
+    expect(panel).toContain("handleRestartTerminal");
+    expect(panel).not.toContain("handleClearTerminal");
+    expect(panel).not.toContain("terminal.clear()");
     expect(panel).toContain("useImperativeHandle");
     expect(panel).toContain('import { WebLinksAddon } from "@xterm/addon-web-links"');
     expect(panel).toContain("linkHandler:");
@@ -20,8 +22,9 @@ describe("Desktop Terminal architecture boundaries", () => {
     expect(panel).toContain("bridge.openExternalUrl(href)");
     expect(titlebarActions).toContain('aria-haspopup="menu"');
     expect(titlebarActions).toContain('t("terminal.actions")');
-    expect(titlebarActions).toContain('t("terminal.clear")');
-    expect(titlebarActions).toContain('t("terminal.reset")');
+    expect(titlebarActions).toContain('t("terminal.restart")');
+    expect(titlebarActions).not.toContain('t("terminal.clear")');
+    expect(titlebarActions).not.toContain('t("terminal.reset")');
     expect(app).not.toContain("terminalSessionResetToken");
     expect(app).toContain("terminalPanelRef");
     expect(titlebar).not.toContain("Clear Terminal");
@@ -40,12 +43,14 @@ describe("Desktop Terminal architecture boundaries", () => {
     expect(globalLayout).not.toContain(".desktop-terminal-");
   });
 
-  it("keeps Terminal and overflow as separate titlebar controls", () => {
+  it("keeps Terminal and restart overflow as separate titlebar controls", () => {
     const titlebarActions = source("src/features/app-shell/DesktopTitlebarActions.tsx");
     const titlebarCss = source("src/styles/titlebar.css");
-    expect(titlebarActions).toContain("TerminalTitlebarActionsMenu");
-    expect(titlebarActions).toContain("onClearTerminal");
-    expect(titlebarActions).toContain("onResetTerminal");
+    expect(titlebarActions).toContain("TerminalTitlebarRestartMenu");
+    expect(titlebarActions).toContain("onRestartTerminal");
+    expect(titlebarActions).not.toContain("onClearTerminal");
+    expect(titlebarActions).not.toContain("onResetTerminal");
+    expect(titlebarActions).not.toContain("DesktopMenuSeparator");
     expect(titlebarActions).toContain("onToggleTerminal");
     expect(titlebarActions).toContain('id: "terminal-menu"');
     expect(titlebarActions).not.toContain("desktop-titlebar-terminal-cluster");

--- a/tests/electron.update-service.test.mjs
+++ b/tests/electron.update-service.test.mjs
@@ -109,7 +109,7 @@ describe("Desktop updater channel isolation", () => {
     });
   });
 
-  it("checks Stable updates after startup and on a bounded interval while retaining the Settings command", async () => {
+  it("keeps Stable update checks manual and exposes only the Settings command", async () => {
     vi.useFakeTimers();
     let service;
     try {
@@ -133,44 +133,29 @@ describe("Desktop updater channel isolation", () => {
         app: { isPackaged: true },
         autoUpdater,
         buildInfo,
-        checkSchedule: {
-          startupDelayMs: 15_000,
-          startupJitterMs: 0,
-          intervalMs: 4 * 60 * 60 * 1000,
-          intervalJitterMs: 0,
-        },
         getRestartBlockers: () => [],
         getWindows: () => [],
         ipcMain: {
           handle: (channel, handler) => handlers.set(channel, handler),
         },
         platform: "linux",
-        random: () => 0,
       });
 
       service.start();
       service.start();
-      await vi.advanceTimersByTimeAsync(14_999);
+      await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
 
       expect(checkCount).toBe(0);
       expect(service.getState().status).toBe("idle");
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(checkCount).toBe(1);
-      expect(service.getState().status).toBe("not-available");
-
-      await vi.advanceTimersByTimeAsync(4 * 60 * 60 * 1000);
-      expect(checkCount).toBe(2);
-
       const checkFromSettings = handlers.get("updates:check");
       expect(checkFromSettings).toBeTypeOf("function");
       await checkFromSettings();
 
-      expect(checkCount).toBe(3);
+      expect(checkCount).toBe(1);
       expect(service.getState().status).toBe("not-available");
       service.dispose();
-      await vi.advanceTimersByTimeAsync(8 * 60 * 60 * 1000);
-      expect(checkCount).toBe(3);
+      await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+      expect(checkCount).toBe(1);
     } finally {
       service?.dispose();
       vi.useRealTimers();

--- a/tests/titlebarExternalOpenArchitecture.test.ts
+++ b/tests/titlebarExternalOpenArchitecture.test.ts
@@ -7,6 +7,7 @@ describe("titlebar external-open architecture", () => {
     const actions = source("src/features/app-shell/DesktopTitlebarActions.tsx");
     const app = source("src/App.tsx");
     const titlebarCss = source("src/styles/titlebar.css");
+    const updateControls = source("src/components/DesktopUpdateControls.tsx");
 
     expect(definition).toContain('className="desktop-titlebar-action desktop-titlebar-external-open"');
     expect(definition).toContain("onClick={externalOpen.onOpen}");
@@ -22,6 +23,9 @@ describe("titlebar external-open architecture", () => {
     expect(titlebarCss).toMatch(
       /\.desktop-titlebar-action-divider\s*\{[^}]*height:\s*18px;[^}]*margin-inline:\s*3px;[^}]*background:\s*var\(--desktop-titlebar-divider\);[^}]*\}/s,
     );
+    expect(actions).not.toMatch(/DesktopUpdate|desktopUpdates|onUpdateNow/);
+    expect(updateControls).not.toContain("DesktopUpdateTitlebarButton");
+    expect(titlebarCss).not.toMatch(/desktop-update-titlebar-action|desktop-update-dot/);
   });
 
   it("keeps application choice in Default Apps settings", () => {


### PR DESCRIPTION
## Summary

- Move Desktop update discovery fully into Settings: remove Header update status/actions and remove background polling so users explicitly check for updates.
- Remove the renderer-only terminal Clear action that corrupts full-screen Codex/Claude TUI state.
- Rename the destructive terminal recovery action from Reset to Restart across UI, interfaces, tests, and all eight locales.
- Bump the Desktop package and release documentation to `0.1.6`.

## Root cause and impact

The Header update indicator surfaced transient network/update errors globally even though update discovery is intended to be user-initiated. Separately, `xterm.clear()` erased only the renderer buffer while Codex/Claude retained their own full-screen state, causing partial redraws and an apparently broken terminal. Restarting the PTY is the reliable recovery operation.

Users now see update controls only in Settings, with no background update checks or Header warning state. The terminal overflow contains one accurately named Restart action and no unsafe Clear action.

## Validation

- `npm run lint`
- `npm test` — 248 files, 1606 tests
- release-specific tests — 3 files, 29 tests
- `npm run build`
- current Stable update/download/range contract verified for `0.1.5`

After merge and successful main CI, the repository release flow will publish an Internal build for the exact commit before the matching `v0.1.6` Stable tag is pushed.