### PR TITLE
Release PuppyOne Desktop 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppyone/desktop",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppyone/desktop",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puppyone/desktop",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- advance the PuppyOne Desktop release train from 0.1.7 to 0.2.0
- align package and lockfile release coordinates
- prepare the exact main commit for Internal verification and Stable promotion

## Included product changes
- terminal runtime and running-state tab experience
- app preview runtime surface
- systematic Markdown HTML, MDX, media, and image rendering architecture

## Verification
- release metadata, macOS policy, and Terminal launcher: 29 tests passed
- architecture boundaries and TypeScript checks passed
- production build and bundle/artifact budgets passed