### PR TITLE
release: prepare PuppyOne Desktop 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppyone/desktop",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppyone/desktop",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puppyone/desktop",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 发布内容

- 将 Desktop 应用版本从 0.3.1 提升到 0.3.2
- 锁定 PR #30 合入后的编辑器一致性、顶部菜单、onboarding 与发布门禁改动
- 不包含额外功能代码变化

## 本地验证

- 4 个发布专项测试文件、41 个测试通过
- npm run check:boundaries
- git diff --check