### PR TITLE
release: prepare PuppyOne Desktop 0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppyone/desktop",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppyone/desktop",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puppyone/desktop",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prepare the canonical PuppyOne Desktop 0.3.3 release identity after Qbase integration.

Changes:
- bump package version from 0.3.2 to 0.3.3
- keep package-lock root metadata aligned

Verification:
- 29 release policy and metadata tests passed
- production build, TypeScript, architecture boundaries, and bundle budgets passed
- Qbase integration CI passed before this version bump