### PR TITLE
release: prepare PuppyOne Desktop 0.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppyone/desktop",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppyone/desktop",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puppyone/desktop",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prepare the canonical PuppyOne Desktop 0.3.4 release identity after the packaged renderer asset and Agent logo fixes landed through PR #34.

Changes:
- bump package version from 0.3.3 to 0.3.4
- keep package-lock root metadata aligned

Verification:
- npm test: 332 files, 2234 tests passed
- 29 release policy and metadata tests passed
- production build, TypeScript, architecture boundaries, renderer asset validation, and bundle budgets passed
- existing Stable 0.3.3 updater contract passed before publication