### PR TITLE
fix: stabilize editor source switching for Desktop 0.3.5

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -57,6 +57,7 @@ import { createNativeSurfaceOcclusionCoordinator } from "./main/native-surfaces/
 import { createNativeSurfacePointerPassthroughCoordinator } from "./main/native-surfaces/pointer-passthrough-coordinator.mjs";
 import { registerFeedbackIpcHandlers } from "./main/ipc/feedback-ipc.mjs";
 import { registerSystemIpcHandlers } from "./main/ipc/system-ipc.mjs";
+import { resolveDockIconResource } from "./main/dock-icon-resources.mjs";
 import { registerTerminalIpcHandlers } from "./main/ipc/terminal-ipc.mjs";
 import { registerWorkspaceFileIpcHandlers } from "./main/ipc/workspace-files-ipc.mjs";
 import { registerWorkspaceGitIpcHandlers } from "./main/ipc/workspace-git-ipc.mjs";
@@ -131,16 +132,6 @@ const viewerPackFeatureProfile = resolveViewerPackFeatureProfile({
   isPackaged: app.isPackaged,
 });
 const workspaceStateFilename = "desktop-workspace-state.json";
-const dockIconResources = Object.freeze({
-  polished: "logo-square.png",
-  light: "dock-icon-light.png",
-  matte: "dock-icon-matte.png",
-});
-const developmentDockIconResources = Object.freeze({
-  polished: "logo-square-dev.png",
-  light: "dock-icon-light-dev.png",
-  matte: "dock-icon-matte-dev.png",
-});
 const macTitlebarOptions = process.platform === "darwin"
   ? {
       titleBarStyle: "hiddenInset",
@@ -500,24 +491,12 @@ function resolveAppIconPath() {
 }
 
 function resolveDockIconPath(iconId) {
-  const normalizedIconId = Object.hasOwn(dockIconResources, iconId) ? iconId : "polished";
-  const developmentBuild = desktopBuildInfo.channel === "dev";
-  const resourceFilename = developmentBuild
-    ? developmentDockIconResources[normalizedIconId]
-    : dockIconResources[normalizedIconId];
-  const sourceFilename = normalizedIconId === "light"
-    ? `logo-square-v0.1.3-light${developmentBuild ? "-dev" : ""}.png`
-    : normalizedIconId === "matte"
-      ? `logo-square-v0.1.3-dark${developmentBuild ? "-dev" : ""}.png`
-      : `logo-square${developmentBuild ? "-dev" : ""}.png`;
-  const candidates = [
-    path.join(process.resourcesPath ?? projectRoot, resourceFilename),
-    path.join(projectRoot, "public", sourceFilename),
-  ];
-  return {
-    iconId: normalizedIconId,
-    path: candidates.find((candidate) => fs.existsSync(candidate)) ?? null,
-  };
+  return resolveDockIconResource({
+    iconId,
+    developmentBuild: desktopBuildInfo.channel === "dev",
+    resourcesPath: process.resourcesPath,
+    projectRoot,
+  });
 }
 
 function setDockIcon(iconId = "polished") {

--- a/electron/main/dock-icon-resources.mjs
+++ b/electron/main/dock-icon-resources.mjs
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const DOCK_ICON_RESOURCE_FILENAMES = Object.freeze({
+  polished: "logo-square.png",
+  light: "dock-icon-light.png",
+  matte: "dock-icon-matte.png",
+});
+
+export const DEVELOPMENT_DOCK_ICON_RESOURCE_FILENAMES = Object.freeze({
+  polished: "logo-square-dev.png",
+  light: "dock-icon-light-dev.png",
+  matte: "dock-icon-matte-dev.png",
+});
+
+const DOCK_ICON_SOURCE_FILENAMES = Object.freeze({
+  polished: "logo-square.png",
+  light: "logo-square-v0.1.3-light.png",
+  matte: "logo-square-v0.1.3-dark.png",
+});
+
+const DEVELOPMENT_DOCK_ICON_SOURCE_FILENAMES = Object.freeze({
+  polished: "logo-square-dev.png",
+  light: "logo-square-v0.1.3-light-dev.png",
+  matte: "logo-square-v0.1.3-dark-dev.png",
+});
+
+export function resolveDockIconResource({
+  iconId,
+  developmentBuild,
+  resourcesPath,
+  projectRoot,
+  existsSync = fs.existsSync,
+}) {
+  const normalizedIconId = Object.hasOwn(DOCK_ICON_RESOURCE_FILENAMES, iconId)
+    ? iconId
+    : "polished";
+  const resourceFilename = (developmentBuild
+    ? DEVELOPMENT_DOCK_ICON_RESOURCE_FILENAMES
+    : DOCK_ICON_RESOURCE_FILENAMES)[normalizedIconId];
+  const sourceFilename = (developmentBuild
+    ? DEVELOPMENT_DOCK_ICON_SOURCE_FILENAMES
+    : DOCK_ICON_SOURCE_FILENAMES)[normalizedIconId];
+  const candidates = [
+    path.join(resourcesPath ?? projectRoot, resourceFilename),
+    // Vite copies every renderer public asset into dist/. Unlike public/, dist/
+    // is included inside app.asar in packaged builds, so this is a real
+    // production fallback as well as a useful unpackaged-build fallback.
+    path.join(projectRoot, "dist", sourceFilename),
+    path.join(projectRoot, "public", sourceFilename),
+  ];
+
+  return Object.freeze({
+    iconId: normalizedIconId,
+    path: candidates.find((candidate) => existsSync(candidate)) ?? null,
+  });
+}

--- a/scripts/release-support/packaged-desktop-build-verifier.mjs
+++ b/scripts/release-support/packaged-desktop-build-verifier.mjs
@@ -9,6 +9,11 @@ import {
 
 const { extractFile } = asarPackage;
 const { parse: parsePlist } = plistPackage;
+const packagedDockIconAssets = Object.freeze({
+  "logo-square.png": "dist/logo-square.png",
+  "dock-icon-light.png": "dist/logo-square-v0.1.3-light.png",
+  "dock-icon-matte.png": "dist/logo-square-v0.1.3-dark.png",
+});
 
 export async function verifyPackagedDesktopBuild({
   releaseDirectory,
@@ -46,6 +51,27 @@ export async function verifyPackagedDesktopBuild({
       throw new Error(
         `${path.basename(application.path)} package version ${applicationPackage.version} must equal ${identity.version}.`,
       );
+    }
+
+    for (const [resourceFilename, rendererAssetPath] of Object.entries(packagedDockIconAssets)) {
+      const nativeIcon = await fs.readFile(path.join(resourcesDirectory, resourceFilename)).catch((error) => {
+        if (error?.code === "ENOENT") {
+          throw new Error(`${path.basename(application.path)} is missing Dock icon resource ${resourceFilename}.`);
+        }
+        throw error;
+      });
+      assertPng(nativeIcon, `${path.basename(application.path)} ${resourceFilename}`);
+
+      let rendererIcon;
+      try {
+        rendererIcon = extractFile(
+          path.join(resourcesDirectory, "app.asar"),
+          rendererAssetPath,
+        );
+      } catch {
+        throw new Error(`${path.basename(application.path)} is missing renderer Dock icon ${rendererAssetPath}.`);
+      }
+      assertPng(rendererIcon, `${path.basename(application.path)} ${rendererAssetPath}`);
     }
 
     const plist = parsePlist(
@@ -119,6 +145,16 @@ export async function verifyPackagedDesktopBuild({
     distributables: distributableFiles.map((entry) => entry.path),
     updaterMetadata: updaterMetadata.map((entry) => entry.path),
   });
+}
+
+function assertPng(contents, label) {
+  const pngSignature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  if (
+    contents.length < pngSignature.length
+    || pngSignature.some((byte, index) => contents[index] !== byte)
+  ) {
+    throw new Error(`${label} is not a valid PNG resource.`);
+  }
 }
 
 async function collectReleaseEntries(releaseDirectory) {

--- a/src/features/editor-workbench/runtime/useEditorPaneSource.ts
+++ b/src/features/editor-workbench/runtime/useEditorPaneSource.ts
@@ -19,7 +19,11 @@ export function useEditorPaneSource(
   const [content, setContent] = useState<FileContent | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const lastContentReadPathRef = useRef<string | null>(null);
+  // Track every selected source, not only sources that require a text read.
+  // Otherwise CSV -> image -> the same CSV leaves the ref pinned to the CSV
+  // while the image transition clears its content, so returning to the CSV is
+  // incorrectly treated as already loaded and remains pending forever.
+  const lastObservedPathRef = useRef<string | null>(null);
   const nodePath = node?.path ?? null;
   const needsContent = Boolean(node && dataPort.readFile && shouldReadEditorContent(node));
   const sourceRequirement = node ? getEditorSourceRequirement(node) : "none";
@@ -35,13 +39,13 @@ export function useEditorPaneSource(
   }, [nodePath]);
 
   useEffect(() => {
-    const firstReadForPath = Boolean(nodePath && lastContentReadPathRef.current !== nodePath);
-    if (!firstReadForPath && !workspaceContentChangeMatchesPath(refreshKey, nodePath)) return undefined;
+    const pathChanged = lastObservedPathRef.current !== nodePath;
+    lastObservedPathRef.current = nodePath;
+    if (!pathChanged && !workspaceContentChangeMatchesPath(refreshKey, nodePath)) return undefined;
     if (!nodePath || !needsContent || !dataPort.readFile) {
       setLoading(false);
       return undefined;
     }
-    lastContentReadPathRef.current = nodePath;
     const controller = new AbortController();
     setError(null);
     setLoading(true);

--- a/src/features/settings/SettingsView.tsx
+++ b/src/features/settings/SettingsView.tsx
@@ -242,9 +242,69 @@ export function SettingsView({
                 onDarkThemePresetChange={onDarkThemePresetChange}
               />
               <div className="desktop-settings-row desktop-settings-row-control desktop-settings-wide-control-row">
+                <span>{t("settings.appearance.textSize.title")}</span>
+                <div className="desktop-theme-segment desktop-appearance-option-segment" aria-label={t("settings.appearance.textSize.ariaLabel")}>
+                  {TEXT_SIZE_PRESETS.map((option) => (
+                    <button
+                      key={option.value}
+                      className={textSize === option.value ? "active" : ""}
+                      type="button"
+                      title={t(`settings.appearance.textSize.${option.value}.description`)}
+                      aria-pressed={textSize === option.value}
+                      onClick={() => onTextSizeChange(option.value)}
+                    >
+                      <span>{t(`settings.appearance.textSize.${option.value}.label`)}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <ContentFontSetting
+                preferences={typographyPreferences}
+                onChange={onTypographyPreferencesChange}
+              />
+              <div className="desktop-settings-row desktop-settings-row-control desktop-settings-wide-control-row">
+                <span>{t("settings.appearance.fileIcons.title")}</span>
+                <div className="desktop-theme-segment desktop-appearance-option-segment" aria-label={t("settings.appearance.fileIcons.ariaLabel")}>
+                  {FILE_ICON_THEMES.map((theme) => (
+                    <button
+                      key={theme.id}
+                      className={fileIconTheme === theme.id ? "active" : ""}
+                      type="button"
+                      title={t(`settings.appearance.fileIcons.${theme.id}.description`)}
+                      onClick={() => onFileIconThemeChange(theme.id)}
+                    >
+                      <FileGlyphIcon name="document.md" size={14} theme={theme.id} />
+                      <span>{t(`settings.appearance.fileIcons.${theme.id}.label`)}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="desktop-settings-row desktop-settings-row-control desktop-settings-wide-control-row">
+                <span>{t("settings.appearance.navigation.title")}</span>
+                <div className="desktop-theme-segment desktop-appearance-option-segment" aria-label={t("settings.appearance.navigation.ariaLabel")}>
+                  {SIDEBAR_NAVIGATION_LAYOUT_OPTIONS.map((option) => {
+                    const Icon = option.placement === "top"
+                      ? PanelTop
+                      : option.placement === "left" ? PanelLeft : PanelBottom;
+                    return (
+                      <button
+                        className={sidebarNavigationLayout === option.value ? "active" : ""}
+                        type="button"
+                        key={option.value}
+                        title={t(`settings.appearance.navigation.${option.placement}.description`)}
+                        onClick={() => onSidebarNavigationLayoutChange(option.value)}
+                      >
+                        <Icon size={14} />
+                        <span>{t(`settings.appearance.navigation.${option.placement}.label`)}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              <div className="desktop-settings-row desktop-settings-row-control desktop-settings-wide-control-row">
                 <span>{t("settings.appearance.loadingAnimation.title")}</span>
                 <div
-                  className="desktop-theme-segment desktop-loading-animation-segment"
+                  className="desktop-theme-segment desktop-appearance-option-segment"
                   aria-label={t("settings.appearance.loadingAnimation.ariaLabel")}
                 >
                   {PULSE_GRID_PRESET_IDS.map((presetId) => (
@@ -267,66 +327,6 @@ export function SettingsView({
                       <span>{t(`settings.appearance.loadingAnimation.${presetId}.label`)}</span>
                     </button>
                   ))}
-                </div>
-              </div>
-              <div className="desktop-settings-row desktop-settings-row-control desktop-settings-wide-control-row">
-                <span>{t("settings.appearance.textSize.title")}</span>
-                <div className="desktop-theme-segment desktop-text-size-segment" aria-label={t("settings.appearance.textSize.ariaLabel")}>
-                  {TEXT_SIZE_PRESETS.map((option) => (
-                    <button
-                      key={option.value}
-                      className={textSize === option.value ? "active" : ""}
-                      type="button"
-                      title={t(`settings.appearance.textSize.${option.value}.description`)}
-                      aria-pressed={textSize === option.value}
-                      onClick={() => onTextSizeChange(option.value)}
-                    >
-                      <span>{t(`settings.appearance.textSize.${option.value}.label`)}</span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <ContentFontSetting
-                preferences={typographyPreferences}
-                onChange={onTypographyPreferencesChange}
-              />
-              <div className="desktop-settings-row desktop-settings-row-control desktop-settings-wide-control-row">
-                <span>{t("settings.appearance.fileIcons.title")}</span>
-                <div className="desktop-theme-segment desktop-file-icon-theme-segment" aria-label={t("settings.appearance.fileIcons.ariaLabel")}>
-                  {FILE_ICON_THEMES.map((theme) => (
-                    <button
-                      key={theme.id}
-                      className={fileIconTheme === theme.id ? "active" : ""}
-                      type="button"
-                      title={t(`settings.appearance.fileIcons.${theme.id}.description`)}
-                      onClick={() => onFileIconThemeChange(theme.id)}
-                    >
-                      <FileGlyphIcon name="document.md" size={14} theme={theme.id} />
-                      <span>{t(`settings.appearance.fileIcons.${theme.id}.label`)}</span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div className="desktop-settings-row desktop-settings-row-control desktop-settings-wide-control-row">
-                <span>{t("settings.appearance.navigation.title")}</span>
-                <div className="desktop-theme-segment desktop-sidebar-layout-segment" aria-label={t("settings.appearance.navigation.ariaLabel")}>
-                  {SIDEBAR_NAVIGATION_LAYOUT_OPTIONS.map((option) => {
-                    const Icon = option.placement === "top"
-                      ? PanelTop
-                      : option.placement === "left" ? PanelLeft : PanelBottom;
-                    return (
-                      <button
-                        className={sidebarNavigationLayout === option.value ? "active" : ""}
-                        type="button"
-                        key={option.value}
-                        title={t(`settings.appearance.navigation.${option.placement}.description`)}
-                        onClick={() => onSidebarNavigationLayoutChange(option.value)}
-                      >
-                        <Icon size={14} />
-                        <span>{t(`settings.appearance.navigation.${option.placement}.label`)}</span>
-                      </button>
-                    );
-                  })}
                 </div>
               </div>
               {experimentalSettings.enableViewerPlugins && (
@@ -440,7 +440,7 @@ export function SettingsView({
               <div className="desktop-settings-row desktop-settings-row-control desktop-settings-wide-control-row">
                 <span id="desktop-dock-icon-label">{t("settings.appearance.dockIcon.title")}</span>
                 <div
-                  className="desktop-theme-segment desktop-dock-icon-segment"
+                  className="desktop-theme-segment desktop-appearance-option-segment desktop-dock-icon-segment"
                   aria-labelledby="desktop-dock-icon-label"
                 >
                   {DOCK_ICON_OPTIONS.map((option) => (

--- a/src/styles/settings-controls.css
+++ b/src/styles/settings-controls.css
@@ -314,18 +314,24 @@
   border-radius: 2px;
 }
 
-.desktop-text-size-segment button {
-  min-width: 70px;
+.desktop-appearance-option-segment {
+  display: grid;
+  width: min(100%, 360px);
+  min-width: 0;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-auto-flow: column;
 }
 
-.desktop-loading-animation-segment {
-  max-width: 520px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
+.desktop-appearance-option-segment button {
+  min-width: 0;
+  padding-inline: 6px;
+  white-space: nowrap;
 }
 
-.desktop-loading-animation-segment button {
-  min-width: 132px;
+.desktop-appearance-option-segment button > span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .desktop-loading-animation-preview {
@@ -344,14 +350,4 @@
 
 .desktop-dock-icon-segment span {
   color: inherit;
-}
-
-.desktop-sidebar-layout-segment {
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  max-width: 410px;
-}
-
-.desktop-sidebar-layout-segment button {
-  min-width: 112px;
 }

--- a/tests/editorPaneSourceSwitching.test.tsx
+++ b/tests/editorPaneSourceSwitching.test.tsx
@@ -1,0 +1,86 @@
+/** @vitest-environment happy-dom */
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DataNode, DataPort } from "@puppyone/shared-ui";
+import { useEditorPaneSource } from "../src/features/editor-workbench/runtime/useEditorPaneSource";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("editor pane source switching", () => {
+  it("re-reads a content document after visiting a resource-only image", async () => {
+    const readFile = vi.fn(async (path: string) => ({
+      path,
+      name: path,
+      type: "spreadsheet" as const,
+      mimeType: "text/csv",
+      content: "name,value\nalpha,1",
+      version: `version:${readFile.mock.calls.length}`,
+    }));
+    const dataPort: DataPort = {
+      readFile,
+      getFileUrl: vi.fn(async (path: string) => `blob:${path}`),
+      listChildren: vi.fn(async () => []),
+    };
+    const csv = node("style-list.csv", "spreadsheet", "text/csv");
+    const image = node("styles.png", "image", "image/png");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await renderSource(csv, dataPort);
+    await waitFor(() => container.dataset.contentPath === csv.path);
+    expect(readFile).toHaveBeenCalledTimes(1);
+
+    await renderSource(image, dataPort);
+    await waitFor(() => container.dataset.contentPath === "");
+
+    await renderSource(csv, dataPort);
+    await waitFor(() => container.dataset.contentPath === csv.path);
+    expect(readFile).toHaveBeenCalledTimes(2);
+    expect(container.dataset.loading).toBe("false");
+
+    async function renderSource(activeNode: DataNode, port: DataPort) {
+      await act(async () => root?.render(<SourceProbe node={activeNode} dataPort={port} />));
+    }
+
+    function SourceProbe({ node: activeNode, dataPort: port }: {
+      node: DataNode;
+      dataPort: DataPort;
+    }) {
+      const source = useEditorPaneSource(activeNode, port);
+      container.dataset.contentPath = source.content?.path ?? "";
+      container.dataset.loading = String(source.loading);
+      return null;
+    }
+  });
+});
+
+function node(path: string, type: DataNode["type"], mimeType: string): DataNode {
+  return {
+    id: path,
+    path,
+    name: path,
+    type,
+    mimeType,
+    source: "local",
+  };
+}
+
+async function waitFor(assertion: () => boolean, attempts = 100) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (assertion()) return;
+    await act(async () => new Promise((resolve) => window.setTimeout(resolve, 2)));
+  }
+  throw new Error("Timed out waiting for editor source state.");
+}

--- a/tests/editorPaneSourceSwitching.test.tsx
+++ b/tests/editorPaneSourceSwitching.test.tsx
@@ -2,7 +2,7 @@
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { DataNode, DataPort } from "@puppyone/shared-ui";
+import type { DataNode, DataPort, FileContent } from "@puppyone/shared-ui";
 import { useEditorPaneSource } from "../src/features/editor-workbench/runtime/useEditorPaneSource";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
@@ -18,53 +18,215 @@ afterEach(() => {
 });
 
 describe("editor pane source switching", () => {
-  it("re-reads a content document after visiting a resource-only image", async () => {
-    const readFile = vi.fn(async (path: string) => ({
-      path,
-      name: path,
-      type: "spreadsheet" as const,
-      mimeType: "text/csv",
-      content: "name,value\nalpha,1",
-      version: `version:${readFile.mock.calls.length}`,
-    }));
-    const dataPort: DataPort = {
-      readFile,
-      getFileUrl: vi.fn(async (path: string) => `blob:${path}`),
-      listChildren: vi.fn(async () => []),
-    };
-    const csv = node("style-list.csv", "spreadsheet", "text/csv");
-    const image = node("styles.png", "image", "image/png");
-    const container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+  it.each([
+    {
+      label: "spreadsheet -> image -> spreadsheet",
+      contentNode: node("style-list.csv", "spreadsheet", "text/csv"),
+      resourceNode: node("styles.png", "image", "image/png"),
+    },
+    {
+      label: "markdown -> PDF -> markdown",
+      contentNode: node("notes.md", "markdown", "text/markdown"),
+      resourceNode: node("reference.pdf", "document", "application/pdf"),
+    },
+    {
+      label: "code -> video -> code",
+      contentNode: node("worker.ts", "code", "text/typescript"),
+      resourceNode: node("demo.mp4", "video", "video/mp4"),
+    },
+  ])("re-reads the same content source across $label", async ({ contentNode, resourceNode }) => {
+    const readFile = createReadFile();
+    const dataPort = createDataPort(readFile);
+    const container = createContainer();
 
-    await renderSource(csv, dataPort);
-    await waitFor(() => container.dataset.contentPath === csv.path);
+    await renderSinglePane(container, contentNode, dataPort);
+    await waitFor(() => paneState(container).contentPath === contentNode.path);
     expect(readFile).toHaveBeenCalledTimes(1);
 
-    await renderSource(image, dataPort);
-    await waitFor(() => container.dataset.contentPath === "");
+    await renderSinglePane(container, resourceNode, dataPort);
+    await waitFor(() => (
+      paneState(container).contentPath === ""
+      && paneState(container).fileUrl === `blob:${resourceNode.path}`
+    ));
 
-    await renderSource(csv, dataPort);
-    await waitFor(() => container.dataset.contentPath === csv.path);
+    await renderSinglePane(container, contentNode, dataPort);
+    await waitFor(() => paneState(container).contentPath === contentNode.path);
     expect(readFile).toHaveBeenCalledTimes(2);
-    expect(container.dataset.loading).toBe("false");
+    expect(paneState(container).loading).toBe("false");
+  });
 
-    async function renderSource(activeNode: DataNode, port: DataPort) {
-      await act(async () => root?.render(<SourceProbe node={activeNode} dataPort={port} />));
-    }
+  it("re-reads a document after its pane becomes empty", async () => {
+    const readFile = createReadFile();
+    const dataPort = createDataPort(readFile);
+    const contentNode = node("style-list.csv", "spreadsheet", "text/csv");
+    const container = createContainer();
 
-    function SourceProbe({ node: activeNode, dataPort: port }: {
-      node: DataNode;
-      dataPort: DataPort;
-    }) {
-      const source = useEditorPaneSource(activeNode, port);
-      container.dataset.contentPath = source.content?.path ?? "";
-      container.dataset.loading = String(source.loading);
-      return null;
-    }
+    await renderSinglePane(container, contentNode, dataPort);
+    await waitFor(() => paneState(container).contentPath === contentNode.path);
+
+    await renderSinglePane(container, null, dataPort);
+    await waitFor(() => paneState(container).contentPath === "");
+
+    await renderSinglePane(container, contentNode, dataPort);
+    await waitFor(() => paneState(container).contentPath === contentNode.path);
+    expect(readFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps three pane source lifecycles isolated across mixed viewer transitions", async () => {
+    const readFile = createReadFile();
+    const dataPort = createDataPort(readFile);
+    const csv = node("report.csv", "spreadsheet", "text/csv");
+    const image = node("diagram.png", "image", "image/png");
+    const markdown = node("notes.md", "markdown", "text/markdown");
+    const photo = node("photo.jpg", "image", "image/jpeg");
+    const code = node("script.ts", "code", "text/typescript");
+    const container = createContainer();
+
+    await renderPanes(container, { left: csv, upperRight: image, lowerRight: markdown }, dataPort);
+    await waitFor(() => (
+      paneState(container, "left").contentPath === csv.path
+      && paneState(container, "upperRight").fileUrl === `blob:${image.path}`
+      && paneState(container, "lowerRight").contentPath === markdown.path
+    ));
+
+    await renderPanes(container, { left: photo, upperRight: code, lowerRight: markdown }, dataPort);
+    await waitFor(() => (
+      paneState(container, "left").fileUrl === `blob:${photo.path}`
+      && paneState(container, "upperRight").contentPath === code.path
+      && paneState(container, "lowerRight").contentPath === markdown.path
+    ));
+
+    await renderPanes(container, { left: csv, upperRight: code, lowerRight: markdown }, dataPort);
+    await waitFor(() => paneState(container, "left").contentPath === csv.path);
+
+    expect(readCount(readFile, csv.path)).toBe(2);
+    expect(readCount(readFile, code.path)).toBe(1);
+    expect(readCount(readFile, markdown.path)).toBe(1);
+    expect(readCount(readFile, image.path)).toBe(0);
+    expect(readCount(readFile, photo.path)).toBe(0);
+    expect(paneState(container, "left").loading).toBe("false");
+    expect(paneState(container, "upperRight").contentPath).toBe(code.path);
+    expect(paneState(container, "lowerRight").contentPath).toBe(markdown.path);
+  });
+
+  it("commits concurrent pane reads to the pane that requested them regardless of completion order", async () => {
+    const pending = new Map<string, ReturnType<typeof deferred<FileContent>>>();
+    const readFile = vi.fn((path: string) => {
+      const request = deferred<FileContent>();
+      pending.set(path, request);
+      return request.promise;
+    });
+    const dataPort = createDataPort(readFile);
+    const nodes = {
+      left: node("a.csv", "spreadsheet", "text/csv"),
+      upperRight: node("b.md", "markdown", "text/markdown"),
+      lowerRight: node("c.ts", "code", "text/typescript"),
+    };
+    const container = createContainer();
+
+    await renderPanes(container, nodes, dataPort);
+    await waitFor(() => pending.size === 3);
+
+    await resolveRead(pending, nodes.lowerRight);
+    expect(paneState(container, "lowerRight").contentPath).toBe(nodes.lowerRight.path);
+    expect(paneState(container, "left").contentPath).toBe("");
+
+    await resolveRead(pending, nodes.left);
+    await resolveRead(pending, nodes.upperRight);
+    expect(paneState(container, "left").contentPath).toBe(nodes.left.path);
+    expect(paneState(container, "upperRight").contentPath).toBe(nodes.upperRight.path);
+    expect(paneState(container, "lowerRight").contentPath).toBe(nodes.lowerRight.path);
+  });
+
+  it("cancels only the pane that changes while sibling pane reads remain active", async () => {
+    const requests = new Map<string, {
+      signal: AbortSignal | undefined;
+      request: ReturnType<typeof deferred<FileContent>>;
+    }>();
+    const readFile = vi.fn((path: string, options?: { signal?: AbortSignal }) => {
+      const request = deferred<FileContent>();
+      requests.set(path, { signal: options?.signal, request });
+      return request.promise;
+    });
+    const dataPort = createDataPort(readFile);
+    const first = {
+      left: node("a.csv", "spreadsheet", "text/csv"),
+      upperRight: node("b.md", "markdown", "text/markdown"),
+      lowerRight: node("c.ts", "code", "text/typescript"),
+    };
+    const replacement = node("d.json", "code", "application/json");
+    const container = createContainer();
+
+    await renderPanes(container, first, dataPort);
+    await waitFor(() => requests.size === 3);
+    await renderPanes(container, { ...first, left: replacement }, dataPort);
+    await waitFor(() => requests.size === 4);
+
+    expect(requests.get(first.left.path)?.signal?.aborted).toBe(true);
+    expect(requests.get(first.upperRight.path)?.signal?.aborted).toBe(false);
+    expect(requests.get(first.lowerRight.path)?.signal?.aborted).toBe(false);
+    expect(requests.get(replacement.path)?.signal?.aborted).toBe(false);
+
+    await act(async () => {
+      requests.get(first.left.path)!.request.resolve(fileContent(first.left));
+      requests.get(first.upperRight.path)!.request.resolve(fileContent(first.upperRight));
+      requests.get(first.lowerRight.path)!.request.resolve(fileContent(first.lowerRight));
+      requests.get(replacement.path)!.request.resolve(fileContent(replacement));
+    });
+    await waitFor(() => (
+      paneState(container, "left").contentPath === replacement.path
+      && paneState(container, "upperRight").contentPath === first.upperRight.path
+      && paneState(container, "lowerRight").contentPath === first.lowerRight.path
+    ));
+  });
+
+  it("aborts and ignores a stale read when one pane switches rapidly", async () => {
+    const requests: Array<{
+      path: string;
+      signal: AbortSignal | undefined;
+      request: ReturnType<typeof deferred<FileContent>>;
+    }> = [];
+    const readFile = vi.fn((path: string, options?: { signal?: AbortSignal }) => {
+      const request = deferred<FileContent>();
+      requests.push({ path, signal: options?.signal, request });
+      return request.promise;
+    });
+    const dataPort = createDataPort(readFile);
+    const first = node("first.csv", "spreadsheet", "text/csv");
+    const second = node("second.md", "markdown", "text/markdown");
+    const container = createContainer();
+
+    await renderSinglePane(container, first, dataPort);
+    await waitFor(() => requests.length === 1);
+    await renderSinglePane(container, second, dataPort);
+    await waitFor(() => requests.length === 2);
+    expect(requests[0]!.signal?.aborted).toBe(true);
+
+    await act(async () => requests[1]!.request.resolve(fileContent(second)));
+    await waitFor(() => paneState(container).contentPath === second.path);
+    await act(async () => requests[0]!.request.resolve(fileContent(first)));
+
+    expect(paneState(container).contentPath).toBe(second.path);
+    expect(paneState(container).loading).toBe("false");
   });
 });
+
+function SourceProbe({ paneId, node: activeNode, dataPort }: {
+  paneId: string;
+  node: DataNode | null;
+  dataPort: DataPort;
+}) {
+  const source = useEditorPaneSource(activeNode, dataPort);
+  return (
+    <output
+      data-pane-id={paneId}
+      data-content-path={source.content?.path ?? ""}
+      data-file-url={source.fileUrl ?? ""}
+      data-loading={String(source.loading || source.fileUrlLoading)}
+      data-error={source.error ?? source.fileUrlError ?? ""}
+    />
+  );
+}
 
 function node(path: string, type: DataNode["type"], mimeType: string): DataNode {
   return {
@@ -75,6 +237,100 @@ function node(path: string, type: DataNode["type"], mimeType: string): DataNode 
     mimeType,
     source: "local",
   };
+}
+
+function fileContent(source: DataNode): FileContent {
+  return {
+    path: source.path,
+    name: source.name,
+    type: source.type,
+    mimeType: source.mimeType,
+    content: `content:${source.path}`,
+    version: `version:${source.path}`,
+  };
+}
+
+function createReadFile() {
+  const readFile = vi.fn(async (path: string) => ({
+    path,
+    name: path,
+    type: path.endsWith(".csv") ? "spreadsheet" as const : "text" as const,
+    content: `content:${path}`,
+    version: `version:${path}:${readFile.mock.calls.length}`,
+  }));
+  return readFile;
+}
+
+function createDataPort(readFile: NonNullable<DataPort["readFile"]>): DataPort {
+  return {
+    readFile,
+    getFileUrl: vi.fn(async (path: string) => `blob:${path}`),
+    revokeFileUrl: vi.fn(async () => undefined),
+    listChildren: vi.fn(async () => []),
+  };
+}
+
+function createContainer() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  return container;
+}
+
+async function renderSinglePane(
+  container: HTMLElement,
+  activeNode: DataNode | null,
+  dataPort: DataPort,
+) {
+  await renderPanes(container, { pane: activeNode }, dataPort);
+}
+
+async function renderPanes(
+  _container: HTMLElement,
+  panes: Readonly<Record<string, DataNode | null>>,
+  dataPort: DataPort,
+) {
+  await act(async () => root?.render(
+    <>
+      {Object.entries(panes).map(([paneId, activeNode]) => (
+        <SourceProbe key={paneId} paneId={paneId} node={activeNode} dataPort={dataPort} />
+      ))}
+    </>,
+  ));
+}
+
+function paneState(container: HTMLElement, paneId = "pane") {
+  const output = container.querySelector<HTMLOutputElement>(`[data-pane-id="${paneId}"]`);
+  if (!output) throw new Error(`Missing source probe for pane: ${paneId}`);
+  return {
+    contentPath: output.dataset.contentPath ?? "",
+    fileUrl: output.dataset.fileUrl ?? "",
+    loading: output.dataset.loading ?? "",
+    error: output.dataset.error ?? "",
+  };
+}
+
+function readCount(readFile: ReturnType<typeof createReadFile>, path: string) {
+  return readFile.mock.calls.filter(([readPath]) => readPath === path).length;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function resolveRead(
+  pending: ReadonlyMap<string, ReturnType<typeof deferred<FileContent>>>,
+  source: DataNode,
+) {
+  const request = pending.get(source.path);
+  if (!request) throw new Error(`Missing read request for: ${source.path}`);
+  await act(async () => request.resolve(fileContent(source)));
 }
 
 async function waitFor(assertion: () => boolean, attempts = 100) {

--- a/tests/editorSplitPanes.test.tsx
+++ b/tests/editorSplitPanes.test.tsx
@@ -9,6 +9,7 @@ import {
   EXPLORER_REFERENCE_DRAG_TYPE,
   activateEditorPane,
   assignEditorToActivePane,
+  assignEditorToPane,
   createEditorInput,
   createEditorPaneLayout,
   openEditor,
@@ -301,6 +302,81 @@ describe("DesktopEditorSplitView", () => {
     expect(onFocusPane).toHaveBeenCalledWith("editor-pane-1");
   });
 
+  it("keeps mixed source transitions isolated inside a real three-pane split", async () => {
+    const csv = "report.csv";
+    const image = "diagram.png";
+    const markdown = "notes.md";
+    let group = openEditor(EMPTY_EDITOR_GROUP, createEditorInput(csv));
+    group = openEditor(group, createEditorInput(image));
+    group = openEditor(group, createEditorInput(markdown));
+    let initialLayout = splitEditorPane(createEditorPaneLayout(csv), "editor-pane-1", "horizontal");
+    initialLayout = assignEditorToActivePane(initialLayout, image);
+    initialLayout = splitEditorPane(initialLayout, initialLayout.activePaneId, "vertical");
+    initialLayout = assignEditorToActivePane(initialLayout, markdown);
+    const tree: DataNode[] = [
+      { id: csv, path: csv, name: csv, type: "spreadsheet", mimeType: "text/csv", source: "local" },
+      { id: image, path: image, name: image, type: "image", mimeType: "image/png", source: "local" },
+      { id: markdown, path: markdown, name: markdown, type: "markdown", mimeType: "text/markdown", source: "local" },
+    ];
+    const readFile = vi.fn(async (path: string) => ({
+      path,
+      name: path,
+      type: path === csv ? "spreadsheet" as const : "markdown" as const,
+      mimeType: path === csv ? "text/csv" : "text/markdown",
+      content: `content:${path}`,
+      version: `version:${path}:${readFile.mock.calls.length}`,
+    }));
+    const getFileUrl = vi.fn(async (path: string) => `blob:${path}`);
+    const dataPort = { listChildren: async () => tree, readFile, getFileUrl };
+    const state = { ...emptyWorkspaceState(), tree };
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    let updateLayout!: React.Dispatch<React.SetStateAction<EditorPaneLayoutState>>;
+
+    function Harness() {
+      const [layout, setLayout] = React.useState(initialLayout);
+      updateLayout = setLayout;
+      return withTestLocalization(
+        <DesktopEditorSplitView
+          aiEditRequest={null}
+          dataPort={dataPort}
+          editorGroup={group}
+          editorInteractionPreferences={{ showSaveStatus: false, markdownBlockDragEnabled: false }}
+          fileIconTheme="default"
+          layout={layout}
+          state={state}
+          workspace={{ id: "workspace", name: "Workspace", path: "/workspace", status: "recording" }}
+          onClosePane={vi.fn()}
+          onFocusPane={vi.fn()}
+          onMovePane={vi.fn()}
+          onOpenAtPaneEdge={vi.fn()}
+          onResizeSplit={vi.fn()}
+        />,
+      );
+    }
+
+    await act(async () => root?.render(<Harness />));
+    await waitForCondition(() => (
+      readCount(readFile, csv) === 1
+      && readCount(readFile, markdown) === 1
+      && getFileUrl.mock.calls.some(([path]) => path === image)
+    ));
+    expect(container.querySelectorAll(".desktop-editor-pane")).toHaveLength(3);
+
+    await act(async () => updateLayout((layout) => assignEditorToPane(layout, "editor-pane-1", image)));
+    await waitForCondition(() => (
+      container.querySelector('[data-editor-pane-id="editor-pane-1"] img') !== null
+      || getFileUrl.mock.calls.filter(([path]) => path === image).length >= 1
+    ));
+    await act(async () => updateLayout((layout) => assignEditorToPane(layout, "editor-pane-1", csv)));
+    await waitForCondition(() => readCount(readFile, csv) === 2);
+
+    expect(readCount(readFile, markdown)).toBe(1);
+    expect(readCount(readFile, image)).toBe(0);
+    expect(container.querySelectorAll(".desktop-editor-pane")).toHaveLength(3);
+  });
+
   it("keeps three CodeMirror focus and selection states isolated across pane activation", async () => {
     const { group, layout } = createThreePaneWorkspace("txt");
     const state = {
@@ -458,6 +534,10 @@ function dragEvent(type: string, dataTransfer: DataTransfer, clientX: number, cl
     clientY: { value: clientY },
   });
   return event;
+}
+
+function readCount(readFile: ReturnType<typeof vi.fn>, path: string) {
+  return readFile.mock.calls.filter(([readPath]) => readPath === path).length;
 }
 
 async function waitForCondition(condition: () => boolean, attempts = 200) {

--- a/tests/electron.dock-icon-resources.test.mjs
+++ b/tests/electron.dock-icon-resources.test.mjs
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveDockIconResource } from "../electron/main/dock-icon-resources.mjs";
+
+const temporaryDirectories = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => (
+    fsPromises.rm(directory, { force: true, recursive: true })
+  )));
+});
+
+describe("dock icon resource resolution", () => {
+  it("uses native extraResources first in a packaged production build", async () => {
+    const fixture = await createFixture();
+    const expected = path.join(fixture.resourcesPath, "dock-icon-light.png");
+    await fsPromises.writeFile(expected, "native");
+
+    expect(resolveDockIconResource({
+      iconId: "light",
+      developmentBuild: false,
+      resourcesPath: fixture.resourcesPath,
+      projectRoot: fixture.projectRoot,
+    })).toEqual({ iconId: "light", path: expected });
+  });
+
+  it("falls back to packaged renderer assets instead of an absent public directory", async () => {
+    const fixture = await createFixture();
+    const expected = path.join(fixture.projectRoot, "dist", "logo-square-v0.1.3-dark.png");
+    await fsPromises.mkdir(path.dirname(expected), { recursive: true });
+    await fsPromises.writeFile(expected, "renderer");
+
+    expect(resolveDockIconResource({
+      iconId: "matte",
+      developmentBuild: false,
+      resourcesPath: fixture.resourcesPath,
+      projectRoot: fixture.projectRoot,
+    })).toEqual({ iconId: "matte", path: expected });
+  });
+
+  it("keeps source assets as the final development fallback and normalizes unknown ids", async () => {
+    const fixture = await createFixture();
+    const expected = path.join(fixture.projectRoot, "public", "logo-square-dev.png");
+    await fsPromises.mkdir(path.dirname(expected), { recursive: true });
+    await fsPromises.writeFile(expected, "source");
+
+    expect(resolveDockIconResource({
+      iconId: "unknown",
+      developmentBuild: true,
+      resourcesPath: fixture.resourcesPath,
+      projectRoot: fixture.projectRoot,
+    })).toEqual({ iconId: "polished", path: expected });
+  });
+});
+
+async function createFixture() {
+  const root = await fsPromises.mkdtemp(path.join(os.tmpdir(), "puppyone-dock-icon-"));
+  temporaryDirectories.push(root);
+  const resourcesPath = path.join(root, "PuppyOne.app", "Contents", "Resources");
+  const projectRoot = path.join(resourcesPath, "app.asar");
+  await fsPromises.mkdir(resourcesPath, { recursive: true });
+  return { projectRoot, resourcesPath };
+}

--- a/tests/packagedDesktopBuildVerifier.test.mjs
+++ b/tests/packagedDesktopBuildVerifier.test.mjs
@@ -46,6 +46,21 @@ describe("packaged Desktop Build Identity verification", () => {
       buildInfo: fixture.buildInfo,
     })).rejects.toThrow(/canonical update feed/);
   });
+
+  it("fails when a native Dock icon resource is absent", async () => {
+    const fixture = await createFixture();
+    await fs.rm(path.join(
+      fixture.applicationPath,
+      "Contents",
+      "Resources",
+      "dock-icon-light.png",
+    ));
+
+    await expect(verifyPackagedDesktopBuild({
+      releaseDirectory: fixture.releaseDirectory,
+      buildInfo: fixture.buildInfo,
+    })).rejects.toThrow(/missing Dock icon resource dock-icon-light\.png/);
+  });
 });
 
 async function createFixture() {
@@ -73,7 +88,24 @@ async function createFixture() {
     path.join(sourceDirectory, "package.json"),
     JSON.stringify({ name: "@puppyone/desktop", version: buildInfo.version }),
   );
+  const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  for (const rendererAssetPath of [
+    "dist/logo-square.png",
+    "dist/logo-square-v0.1.3-light.png",
+    "dist/logo-square-v0.1.3-dark.png",
+  ]) {
+    const target = path.join(sourceDirectory, rendererAssetPath);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, png);
+  }
   await createPackage(sourceDirectory, path.join(resourcesDirectory, "app.asar"));
+  for (const resourceFilename of [
+    "logo-square.png",
+    "dock-icon-light.png",
+    "dock-icon-matte.png",
+  ]) {
+    await fs.writeFile(path.join(resourcesDirectory, resourceFilename), png);
+  }
   await fs.writeFile(
     path.join(resourcesDirectory, "build-info.json"),
     `${JSON.stringify(buildInfo, null, 2)}\n`,

--- a/tests/settingsVisualArchitecture.test.ts
+++ b/tests/settingsVisualArchitecture.test.ts
@@ -109,6 +109,8 @@ describe("settings visual architecture", () => {
     expect(view).toContain("PULSE_GRID_PRESET_IDS.map");
     expect(view).toContain("PULSE_GRID_PRESET_FRAMES[presetId]");
     expect(view).toContain("onLoadingAnimationPresetChange(presetId)");
+    expect(view.indexOf('settings.appearance.loadingAnimation.title'))
+      .toBeGreaterThan(view.indexOf('settings.appearance.navigation.title'));
     expect(preferences).toContain('LOADING_ANIMATION_STORAGE_KEY = "puppyone.desktop.loadingAnimation"');
 
     for (const { locale } of manifest.locales) {
@@ -168,6 +170,7 @@ describe("settings visual architecture", () => {
   });
 
   it("locks the compact Appearance-derived dimensions and responsive rules", () => {
+    const view = source("src/features/settings/SettingsView.tsx");
     const settings = source("src/styles/settings.css");
     const controls = source("src/styles/settings-controls.css");
     const language = source("src/styles/settings-view.css");
@@ -182,6 +185,11 @@ describe("settings visual architecture", () => {
     expect(controls).toMatch(/\.desktop-settings-action\s*{[^}]*height:\s*28px;[^}]*border-radius:\s*6px;[^}]*font-size:\s*12px;[^}]*font-weight:\s*650;/s);
     expect(controls).toMatch(/\.desktop-theme-segment\s*{[^}]*border-radius:\s*7px;/s);
     expect(controls).toMatch(/\.desktop-theme-segment button\s*{[^}]*height:\s*26px;[^}]*border-radius:\s*5px;/s);
+    expect(controls).toMatch(/\.desktop-appearance-option-segment\s*{[^}]*width:\s*min\(100%, 360px\);[^}]*grid-auto-columns:\s*minmax\(0, 1fr\);/s);
+    expect(view.match(/desktop-theme-segment desktop-appearance-option-segment/g)).toHaveLength(5);
+    expect(controls).not.toContain(".desktop-loading-animation-segment");
+    expect(controls).not.toContain(".desktop-text-size-segment");
+    expect(controls).not.toContain(".desktop-sidebar-layout-segment");
     expect(settings).toContain("@media (max-width: 760px)");
     expect(settings).toContain(".desktop-settings-wide-control-row");
 


### PR DESCRIPTION
## Summary
- fix editor source identity across content and resource viewer transitions
- add multi-pane, mixed-viewer, cancellation, and stale-read regression coverage
- align Appearance controls and package Dock icon resources reliably

## Verification
- 334 test files / 2247 tests passed
- lint passed
- production build and architecture boundary checks passed