### PR TITLE
release: prepare PuppyOne Desktop 0.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppyone/desktop",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppyone/desktop",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puppyone/desktop",
   "private": true,
-  "version": "0.3.4",
+  "version": "0.3.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release
- bump Desktop version from 0.3.4 to 0.3.5
- publish the editor source lifecycle fix and expanded split-pane regression suite
- include Appearance alignment and packaged Dock icon fixes

## Promotion plan
1. merge after CI
2. tag the immutable merge commit as v0.3.5
3. build and publish an Internal candidate from the same commit
4. promote that exact candidate through signed and notarized Stable release
5. verify the public update feed