### PR TITLE
release: prepare PuppyOne Desktop 0.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppyone/desktop",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppyone/desktop",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puppyone/desktop",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.3.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump the Desktop package and lockfile release identity from 0.3.5 to 0.3.6
- prepare the verified main source for the Internal and Stable release pipelines

## Verification
- npm test -- tests/terminalPreviewLauncher.test.mjs tests/desktopReleaseMetadata.test.mjs tests/macosReleasePolicy.test.mjs
- npm run check:boundaries