### PR TITLE
Prepare Desktop 0.3.7 integration candidate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
         run: npm test
 
       - name: Test MDI focus continuity in Chromium
+        env:
+          # npm-installed Electron cannot provide a root-owned SUID sandbox on
+          # GitHub-hosted runners. Limit the test-only fallback to this local
+          # fixture instead of weakening the application or the whole CI job.
+          ELECTRON_DISABLE_SANDBOX: "1"
         run: xvfb-run --auto-servernum npm run smoke:markdown-pane-focus-continuity
 
       - name: Build

--- a/docs/architecture/desktop-agent/local-agents-and-file-activity.md
+++ b/docs/architecture/desktop-agent/local-agents-and-file-activity.md
@@ -52,7 +52,7 @@ Local Agent inventory ---> Editor Agent picker ---> selected native runtime
                        +---------+---------+
                        v                   v
              Editor presence layer    Terminal Agent Hook adapters
-             eye = read claim         Codex / Claude / future adapters
+             eye = read claim         Codex / Claude / Cursor CLI
              hand = write claim                 |
                        ^                         v
                        +------ neutral activity broker
@@ -84,12 +84,14 @@ Enabling activity visualization does not add that Agent to the Editor picker.
    and capability gates remain owned by each runtime.
 
 Inventory IDs describe installed products; runtime IDs describe concrete
-execution routes. They are equal except where one product has an explicitly
-named route. Today user OpenCode maps as follows:
+execution routes; activity provider IDs describe Hook normalization adapters.
+They are equal except where one product has an explicitly named route. Current
+aliases are centralized as follows:
 
 ```text
-inventory product ID  opencode
-runtime route ID      opencode-native
+inventory product ID  runtime route ID  activity provider ID
+cursor-agent          cursor            cursor
+opencode              opencode-native   opencode
 ```
 
 This mapping is centralized in
@@ -130,6 +132,16 @@ parse terminal output, instrument the shell, monkey-patch filesystem APIs or
 claim to observe arbitrary commands. Unsupported Agents simply produce no
 presence claim.
 
+For Codex, native Hooks are the production integration contract. Codex Hooks
+cover shell commands, unified exec, `apply_patch`, local functions and nested
+Code Mode tool calls. PuppyOne deliberately does not read `transcript_path`:
+the transcript is private session content and is not a stable integration API.
+Codex App Server has richer structured item events, but its WebSocket transport
+is experimental and unsupported for production, so PuppyOne does not proxy the
+native Terminal TUI through App Server merely to obtain presence events. See
+the official [Codex Hooks](https://developers.openai.com/codex/hooks) and
+[Codex App Server](https://developers.openai.com/codex/app-server) contracts.
+
 The neutral broker accepts authenticated, bounded activity frames, normalizes
 them to the shared contract and confines paths to the active workspace. The
 Renderer store projects active claims by file and operation. Editor chrome
@@ -140,6 +152,73 @@ read claim   -> eye indicator
 write claim  -> hand indicator
 no claim     -> no indicator
 ```
+
+### Production event path
+
+```text
+Codex / Claude / Cursor CLI launched inside PuppyOne Terminal
+        |
+        | native PreToolUse / PostToolUse lifecycle
+        v
+PuppyOne-owned Hook command
+        |
+        | payload projector
+        | - structured path fields
+        | - apply_patch headers
+        | - conservative literal shell reads
+        | - discard command, content, output and transcript
+        v
+authenticated per-Terminal Unix socket / named pipe
+        |
+        v
+provider adapter -> normalized activity broker -> canonical path boundary
+        |                                      |
+        | no exact workspace file              | safe relative file target
+        v                                      v
+drop visual claim                       BrowserWindow-owned IPC event
+                                               |
+                                               v
+                                     per-file Renderer store
+                                               |
+                                      +--------+--------+
+                                      v                 v
+                                eye = reading      hand = writing
+```
+
+This path is intentionally one-way and metadata-only. The Hook bridge runs as
+an Electron-as-Node subprocess, receives a short-lived Terminal-scoped endpoint
+and token through environment variables, projects the provider payload before
+transport, and sends one bounded frame. The public event contains only provider
+identity, lifecycle, operation and canonical workspace-relative targets.
+
+### Observation quality contract
+
+| Native operation | Projection | UI result |
+| --- | --- | --- |
+| Structured `Read`, `Write`, `Edit`, search and file tools | Known provider path fields | Exact eye/hand claim |
+| Codex `apply_patch` | Patch file headers only | Exact hand claim |
+| Whitelisted read-only shell commands such as `tail`, `wc`, `cat`, `head`, `sed`, `od`, `rg` and `grep` with literal operands | Literal filenames only; raw command discarded; `sed -i` is rejected | Exact eye claim |
+| Shell paths using variables, globs, command substitution, redirects, a prior `cd`, or an unknown command | Fail closed | No file claim |
+| Arbitrary terminal programs or Agents without a supported Hook | Not observed | No file claim |
+
+The shell projector is deliberately not a general shell parser. It may omit an
+ambiguous read, but it must never guess a file from dynamic shell syntax. OS
+filesystem watching is not a replacement: it can observe writes after the fact
+but cannot reliably attribute reads to one Agent or Terminal session.
+
+### Lifecycle and upgrades
+
+`PreToolUse` opens a claim. Matching `PostToolUse` completes it; terminal or
+source-session shutdown cancels it, and a bounded lease clears lost terminal
+events. Completed and failed claims remain visible for four seconds so short
+file operations remain perceivable without leaving stale UI behind.
+
+The installed Hook bridge is a derived runtime artifact, not the source of
+truth. Before every enrolled Terminal session, the Registrar compares every
+installed bridge module with the app-bundled source and atomically refreshes an
+outdated or incomplete copy. Hook configuration remains stable across app
+updates, and users do not need to toggle the Appearance setting to receive a
+bridge fix.
 
 `puppyone.desktop.agentFileActivityIndicators` is opt-in and globally controls
 whether `.desktop-agent-file-presence` is rendered. Turning the Appearance
@@ -158,6 +237,35 @@ trust-bypass flag and never edits another Agent's internal trust store. A
 provider-native review may therefore appear once when that Agent next starts.
 Hook controls and provider-specific trust state never move into Local Agents.
 
+### Cursor Agent CLI enrollment
+
+Cursor support in this feature means the local `agent` / `cursor-agent` CLI,
+not Cursor's IDE chat surface and not a Cursor Editor backend inside PuppyOne.
+The Registrar merges four owned command Hooks into the official user-level
+`~/.cursor/hooks.json` schema:
+
+```text
+preToolUse          Read|Write|Grep|Delete -> started
+postToolUse         Read|Write|Grep|Delete -> completed
+postToolUseFailure  Read|Write|Grep|Delete -> failed
+sessionEnd                                  -> close source session
+```
+
+Cursor uses the same user Hook file for its CLI and desktop app. Scope is
+therefore enforced at the transport boundary: only a CLI launched in a
+PuppyOne Terminal inherits the authenticated activity endpoint, token and
+Terminal session ID. If Cursor's desktop app invokes the installed command,
+the bridge has no PuppyOne session credentials and exits without emitting an
+event. The Registrar never parses Cursor terminal output or transcripts.
+
+Installation accepts Cursor Hook schema version 1 only, preserves unrelated
+user fields and Hooks, uses compare-and-swap atomic writes, is idempotent, and
+removes only exact PuppyOne-owned entries. An unknown schema version or edited
+PuppyOne entry fails closed and participates in the batch rollback. Cursor
+watches its Hook file and reloads changes automatically. See the official
+[Cursor Hooks contract](https://cursor.com/docs/hooks) and
+[Cursor CLI Hook release notes](https://cursor.com/changelog/cli-jan-08-2026).
+
 ### Source layout
 
 ```text
@@ -173,8 +281,15 @@ electron/main/agent-activity/
 electron/main/terminal-agent/activity/
   terminal-agent-activity-adapter-port.mjs
   adapters/<provider>/descriptor.mjs    provider edge translation only
-  registration/                         owned, reversible Hook mutation
-  bridge/                               generated Hook payload projection
+  registration/
+    bridge-installer.mjs                atomic install + session-time freshness
+    owned-json-file.mjs                 atomic compare-and-swap JSON primitive
+    owned-config-mutation.mjs           Codex / Claude nested Hook format
+    cursor-cli-hook-config.mjs          Cursor CLI flat Hook format
+  bridge/
+    puppyone-agent-hook.mjs             bounded authenticated transport
+    payload-projector.mjs               content-free provider projection
+    shell-file-intent.mjs               fail-closed literal read projection
   bootstrap/                            Terminal adapter composition
 
 src/features/desktop-agent-presence/
@@ -194,6 +309,22 @@ enter the neutral broker, shared contract, Editor workbench or Local Agents.
 Only adapters whose configuration can be mutated safely and reversibly may be
 marked configurable.
 
+### Verification contract
+
+Provider integration tests use sanitized, provider-versioned Hook fixtures.
+Fixtures are rewritten test data, never raw captures: they use `/workspace`,
+generic filenames and synthetic model/session/turn/tool IDs, and remove transcript
+paths, developer usernames, home directories and repository names. The architecture
+check rejects home paths, non-synthetic working directories and retained transcript
+paths before a fixture can enter the build.
+The required Codex regression path covers both the actual `Bash` read shape and
+the `apply_patch` write shape. A socket-level test must run those fixtures
+through the production Hook bridge, authentication, provider adapter, path
+policy and broker, then assert that the Editor receives the correct
+workspace-relative operation without raw commands, absolute paths or content.
+Synthetic calls straight into an adapter are useful unit tests but are not
+sufficient evidence that an installed Terminal Hook works.
+
 ## 5. Invariants
 
 - Local Agents always means installed Editor compute choices, never appearance.
@@ -206,7 +337,22 @@ marked configurable.
   Renderer receives sanitized DTOs only.
 - Terminal output parsing is not an activity source. Hook support is explicit,
   provider-scoped and best effort.
+- Transcript files and Codex App Server's experimental WebSocket transport are
+  not production activity sources.
+- Dynamic or ambiguous shell syntax fails closed; only literal operands from a
+  bounded read-only command allowlist create a file claim.
+- Structured file tools are the primary observation contract. Shell recognition
+  is a deliberately bounded compatibility fallback, not a promise to enumerate
+  every executable or shell grammar corner case.
+- An enrolled Terminal session refreshes stale installed bridge code before it
+  receives activity credentials.
 - All file paths are canonicalized and workspace-confined before reaching the
   Renderer.
+- Relative Editor resources and absolute Explorer resources must project to the
+  same canonical workspace-relative presence key.
+- Both the target and workspace root are canonicalized before containment is
+  evaluated, including macOS system symlink aliases.
+- Completed or failed claims remain visible for the shared four-second
+  perception window.
 - Adding a provider extends descriptor registries and edge adapters; it does
   not add product branches to neutral services or settings UI.

--- a/docs/architecture/desktop-terminal-architecture.md
+++ b/docs/architecture/desktop-terminal-architecture.md
@@ -66,7 +66,10 @@ renderer-supplied UUID (validated server-side). Spawns the user's login
 shell via node-pty with `TERM=xterm-256color`, `COLORTERM=truecolor`, and
 app-identifying env vars. Confines `cwd` to the workspace root, clamps
 cols/rows (20–400 / 8–120), kills sessions when their window closes, and
-reports exit code/signal back to the renderer.
+reports exit code/signal back to the renderer. Default foreground/background
+colors are normalized to RGB at session creation; the service answers OSC
+10/11 queries before forwarding output to xterm so startup color probes do
+not depend on the renderer's paint queue.
 
 **Styles — `src/features/desktop-terminal/ui/desktop-terminal.css`.**
 Co-located `.desktop-terminal-*` rules and `.xterm` overrides: the panel is
@@ -169,6 +172,24 @@ Two adjacent facts worth pinning:
   disagree between the PTY program's wrapping and xterm's grid.
   `@xterm/addon-unicode11` narrows this gap.
 
+### 4.1 Known failure mode: WebGL glyph-atlas mipmaps
+
+The stable `@xterm/addon-webgl` 0.19 bundle calls `generateMipmap` whenever
+it uploads a glyph-atlas page. On affected Chromium/ANGLE GPU paths the
+context can remain alive while terminal cells sample corrupt atlas data.
+The visible result is arbitrary replacement glyphs, black cells, or smeared
+text even though xterm's buffer still contains the correct Unicode. Because
+the context is not lost, `onContextLoss` does not fire and cannot recover.
+
+Upstream removed glyph-atlas mipmaps in xtermjs/xterm.js#5987 and replaced
+them with explicit linear minification/magnification filters. That change is
+targeted at xterm 7 and is not present in the latest stable addon compatible
+with xterm 6. `scripts/patch-xterm-webgl-atlas.mjs` therefore applies the
+same narrow transform after every install. It patches both published bundle
+formats plus any existing Vite optimizer cache, and fails closed if the
+upstream bundle changes shape. Remove the backport only after a stable xterm
+upgrade is verified to contain upstream commit `6471844`.
+
 ## 5. Geometry and resize pipeline
 
 Sizing flows one way: **DOM size → FitAddon → xterm grid → PTY winsize**.
@@ -224,6 +245,13 @@ with `--po-*` fallbacks) resolved via `getComputedStyle` at mount and
 re-applied when the app-shell theme attributes or stylesheets mutate
 (two `MutationObserver`s). ANSI palette, cursor, selection, and scrollbar
 colors all follow the active theme without recreating the terminal.
+
+Terminal programs can discover the mount-time default foreground/background
+with OSC 10/11. These two queries are answered at the PTY boundary from the
+same resolved RGB values supplied to xterm, then removed from display output
+to prevent a duplicate asynchronous reply from xterm. Keep this fast path:
+Codex CLI 0.147 gives its startup color probe only 100ms and removes the
+composer background when either answer misses that deadline.
 
 ## 8. References
 

--- a/docs/architecture/editor/markdown/architecture.md
+++ b/docs/architecture/editor/markdown/architecture.md
@@ -38,5 +38,16 @@ storage replacement 使用专用 annotation，更新投影但不报告本地编�
 5. 回归测试必须覆盖“在 Widget 之前编辑、Widget DOM 未重建、随后执行交互”的
    增量路径，并验证目标内容和无关正文都保持正确。
 
+当前交互采用两种且仅两种坐标生命周期：
+
+- task、image、HTML、MDX source toggle 以及 table structure command 在触发时解析
+  挂载 Widget 的实时 range；
+- code block 在挂载时建立 edit session，Mermaid 和 table cell 在首次编辑时从实时
+  Widget range 建立 edit session；session 此后由每个 `EditorView` 随 transaction
+  映射。取消后再次编辑必须重新从挂载 Widget 建立 session。
+
+纯展示语法和不修改 Markdown 源码的媒体播放不持有交互坐标，因此不创建 edit
+session。新增 Feature 必须选择上述一种生命周期，不得增加第三套坐标所有权。
+
 不能用每次输入后全量重建 projection 来规避坐标问题；那会破坏长文档的增量性能，
 也会重新引入滚动锚点和 pane 闪烁问题。

--- a/docs/architecture/editor/markdown/architecture.md
+++ b/docs/architecture/editor/markdown/architecture.md
@@ -19,3 +19,24 @@ Working Copy 拥有模型身份和生命周期；CodeMirror 持有高效文本�
 storage replacement 使用专用 annotation，更新投影但不报告本地编辑。外部冲突完全由共享 Working Copy 处理，Markdown 特性不能直接保存。
 
 热路径只增量更新；完整字符串读取限于保存快照、导出和必要恢复。
+
+## 增量投影与交互坐标
+
+`DecorationSet.map(...)` 只映射 decoration 的文档位置，不会修改已经创建的
+`WidgetType` 描述对象。因此，Widget 构造时收到的 `from` / `to` 只是渲染快照，
+不能作为后续用户写操作的权威坐标。
+
+交互必须遵守以下不变量：
+
+1. 无草稿的轻量交互（task checkbox、显示源代码、删除媒体等）在激活时通过
+   `getMappedWidgetPosition` / `getMappedWidgetSourceRange` 从挂载 DOM 取得当前位置；
+2. 有草稿或异步生命周期的交互（代码块、Mermaid、表格 cell）使用每个
+   `EditorView` 独立拥有、随 transaction 映射的 edit session；延迟创建 session
+   时，初始 range 也必须来自当前挂载 Widget，而不是构造期坐标；
+3. command 在真正写入前必须针对当前 `EditorState.doc` 重新解析并验证语义 token；
+4. Widget 已卸载或语义已变化时安全取消，不得回退到旧坐标；
+5. 回归测试必须覆盖“在 Widget 之前编辑、Widget DOM 未重建、随后执行交互”的
+   增量路径，并验证目标内容和无关正文都保持正确。
+
+不能用每次输入后全量重建 projection 来规避坐标问题；那会破坏长文档的增量性能，
+也会重新引入滚动锚点和 pane 闪烁问题。

--- a/electron/main/agent-activity/security/activity-path-policy.mjs
+++ b/electron/main/agent-activity/security/activity-path-policy.mjs
@@ -11,10 +11,19 @@ export async function resolvePublicActivityTarget({
   fsService = fs,
   platform = process.platform,
 }) {
-  if (!isSafePath(candidate?.path) || !isSafePath(cwd) || !path.isAbsolute(workspaceRoot)) {
+  const pathModule = platform === "win32" ? path.win32 : path;
+  if (!isSafePath(candidate?.path)
+    || !isSafePath(cwd)
+    || !isSafePath(workspaceRoot)
+    || !pathModule.isAbsolute(workspaceRoot)) {
     return null;
   }
-  const pathModule = platform === "win32" ? path.win32 : path;
+  const canonicalWorkspaceRoot = await canonicalizeWorkspaceRoot({
+    workspaceRoot,
+    fsService,
+    pathModule,
+  });
+  if (!canonicalWorkspaceRoot) return null;
   const absoluteCandidate = pathModule.isAbsolute(candidate.path)
     ? pathModule.normalize(candidate.path)
     : pathModule.resolve(cwd, candidate.path);
@@ -25,16 +34,24 @@ export async function resolvePublicActivityTarget({
     fsService,
     pathModule,
   });
-  if (!canonicalTarget || !isContained(workspaceRoot, canonicalTarget, pathModule, platform)) {
+  if (!canonicalTarget || !isContained(canonicalWorkspaceRoot, canonicalTarget, pathModule, platform)) {
     return null;
   }
-  const relative = pathModule.relative(workspaceRoot, canonicalTarget);
+  const relative = pathModule.relative(canonicalWorkspaceRoot, canonicalTarget);
   if (!relative || relative === "." || !isSafeRelative(relative, pathModule)) return null;
   return Object.freeze({
     workspaceRelativePath: relative.split(pathModule.sep).join("/"),
     access: candidate.access,
     confidence: candidate.confidence,
   });
+}
+
+async function canonicalizeWorkspaceRoot({ workspaceRoot, fsService, pathModule }) {
+  try {
+    return pathModule.normalize(await fsService.realpath(workspaceRoot));
+  } catch {
+    return null;
+  }
 }
 
 async function canonicalizeTarget({ absoluteCandidate, access, fsService, pathModule }) {

--- a/electron/main/terminal-agent/activity/adapters/cursor/descriptor.mjs
+++ b/electron/main/terminal-agent/activity/adapters/cursor/descriptor.mjs
@@ -10,9 +10,12 @@ const phaseFor = createPhaseResolver({
 
 export const cursorActivityAdapter = Object.freeze({
   providerId: "cursor",
-  displayName: "Cursor Agent",
-  registrationKind: "manual",
+  displayName: "Cursor Agent CLI",
+  registrationKind: "cursor-json-hooks",
   normalize(payload, context) {
+    if (String(payload.eventName).toLowerCase() === "sessionend") {
+      return Object.freeze({ kind: "source-session-ended", sourceSessionId: payload.sessionId ?? null });
+    }
     return normalizeProjectedToolEvent({
       payload,
       providerId: "cursor",

--- a/electron/main/terminal-agent/activity/adapters/normalize-tool-event.mjs
+++ b/electron/main/terminal-agent/activity/adapters/normalize-tool-event.mjs
@@ -9,7 +9,10 @@ export function normalizeProjectedToolEvent({
   occurredAt = Date.now(),
 }) {
   if (!payload || !phase) return null;
-  const operation = classifyTool(payload.toolName, toolGroups);
+  const classifiedOperation = classifyTool(payload.toolName, toolGroups);
+  const operation = classifiedOperation === "command" && Array.isArray(payload.input?.read_paths)
+    ? "file.read"
+    : classifiedOperation;
   const targets = operation === "command" || operation === "subagent" || operation === "tool"
     ? []
     : createTargets(payload.input, operation);

--- a/electron/main/terminal-agent/activity/bridge/payload-projector.mjs
+++ b/electron/main/terminal-agent/activity/bridge/payload-projector.mjs
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { projectShellReadPaths } from "./shell-file-intent.mjs";
 
 const PROJECTOR_LIMITS = Object.freeze({
   frameBytes: 64 * 1024,
@@ -30,6 +31,8 @@ export function projectAgentHookPayload(rawValue) {
   if (!eventName || !cwd) return null;
   const nativeInput = firstRecord(rawValue.tool_input, rawValue.input, rawValue.args) ?? {};
   const input = projectPathInput(nativeInput, toolName);
+  const shellReadPaths = projectShellReadPaths(toolName, nativeInput);
+  if (shellReadPaths.length > 0) input.read_paths = shellReadPaths;
   const sessionId = nullableString(firstString(
     rawValue.session_id,
     rawValue.conversation_id,

--- a/electron/main/terminal-agent/activity/bridge/shell-file-intent.mjs
+++ b/electron/main/terminal-agent/activity/bridge/shell-file-intent.mjs
@@ -1,0 +1,333 @@
+const MAX_COMMAND_LENGTH = 64 * 1024;
+const MAX_PATHS = 32;
+
+const SHELL_TOOL_NAMES = new Set([
+  "bash",
+  "exec_command",
+  "shell",
+  "terminal",
+  "unified_exec",
+]);
+
+const SIMPLE_READ_COMMANDS = new Set([
+  "cat",
+  "file",
+  "nl",
+  "stat",
+  "strings",
+  "wc",
+]);
+
+/**
+ * Project only literal file operands from a deliberately small set of
+ * read-only shell commands. This is an observability hint, not a shell parser:
+ * any syntax whose path depends on expansion or process state fails closed.
+ */
+export function projectShellReadPaths(toolName, toolInput) {
+  if (!SHELL_TOOL_NAMES.has(String(toolName).toLowerCase())) return [];
+  if (!isRecord(toolInput) || typeof toolInput.command !== "string") return [];
+  return extractShellReadPaths(toolInput.command);
+}
+
+export function extractShellReadPaths(command) {
+  const tokens = tokenizeLiteralShell(command);
+  if (!tokens) return [];
+  const segments = splitCommandSegments(tokens);
+  if (segments.some((segment) => commandName(segment) === "cd")) return [];
+
+  const paths = [];
+  for (const segment of segments) {
+    paths.push(...readPathsForSegment(segment));
+    if (paths.length >= MAX_PATHS) break;
+  }
+  return Array.from(new Set(paths)).slice(0, MAX_PATHS);
+}
+
+function readPathsForSegment(segment) {
+  const tokens = stripLeadingAssignments(segment);
+  const name = commandName(tokens);
+  if (!name) return [];
+  if (SIMPLE_READ_COMMANDS.has(name)) {
+    return literalPaths(simpleOperands(tokens, name));
+  }
+  if (name === "head" || name === "tail") {
+    return literalPaths(headOrTailOperands(tokens));
+  }
+  if (name === "od") {
+    return literalPaths(odOperands(tokens));
+  }
+  if (name === "grep" || name === "rg") {
+    return literalPaths(searchOperands(tokens));
+  }
+  if (name === "sed") {
+    return literalPaths(sedOperands(tokens));
+  }
+  return [];
+}
+
+function simpleOperands(tokens, name) {
+  const operands = [];
+  let optionsEnded = false;
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!optionsEnded && token === "--") {
+      optionsEnded = true;
+      continue;
+    }
+    if (!optionsEnded && token.startsWith("-")) {
+      if (name === "stat" && ["-f", "--format", "--printf"].includes(token)) index += 1;
+      continue;
+    }
+    operands.push(token);
+  }
+  return operands;
+}
+
+function headOrTailOperands(tokens) {
+  const operands = [];
+  let optionsEnded = false;
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!optionsEnded && token === "--") {
+      optionsEnded = true;
+      continue;
+    }
+    if (!optionsEnded && ["-c", "-n", "--bytes", "--lines", "--sleep-interval", "--pid"].includes(token)) {
+      index += 1;
+      continue;
+    }
+    if (!optionsEnded && token.startsWith("-")) continue;
+    operands.push(token);
+  }
+  return operands;
+}
+
+function odOperands(tokens) {
+  const operands = [];
+  let optionsEnded = false;
+  const valueOptions = new Set(["-A", "-j", "-N", "-S", "-t", "-w", "--address-radix", "--skip-bytes", "--read-bytes", "--strings", "--format", "--width"]);
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!optionsEnded && token === "--") {
+      optionsEnded = true;
+      continue;
+    }
+    if (!optionsEnded && valueOptions.has(token)) {
+      index += 1;
+      continue;
+    }
+    if (!optionsEnded && token.startsWith("-")) continue;
+    operands.push(token);
+  }
+  return operands;
+}
+
+function searchOperands(tokens) {
+  const name = commandName(tokens);
+  const flagOptions = new Set([
+    "-c", "-h", "-H", "-i", "-l", "-L", "-n", "-q", "-s", "-v", "-w", "-x",
+    "--count", "--files-with-matches", "--files-without-match", "--fixed-strings",
+    "--hidden", "--ignore-case", "--line-number", "--no-heading", "--quiet", "--word-regexp",
+  ]);
+  const valueOptions = new Set([
+    "-A", "-B", "-C", "-e", "-f", "-g", "-m", "-t", "-T",
+    "--after-context", "--before-context", "--context", "--file", "--glob",
+    "--max-count", "--regexp", "--type", "--type-not",
+  ]);
+  const positional = [];
+  let optionsEnded = false;
+  let patternProvidedByOption = false;
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!optionsEnded && token === "--") {
+      optionsEnded = true;
+      continue;
+    }
+    if (!optionsEnded && flagOptions.has(token)) continue;
+    if (!optionsEnded && valueOptions.has(token)) {
+      if (token === "-e" || token === "--regexp" || token === "-f" || token === "--file") {
+        patternProvidedByOption = true;
+      }
+      index += 1;
+      continue;
+    }
+    if (!optionsEnded && token.startsWith("-")) return [];
+    positional.push(token);
+  }
+  if (!patternProvidedByOption) positional.shift();
+  if (name === "rg" && positional.length === 0) return [];
+  return positional;
+}
+
+function sedOperands(tokens) {
+  const paths = [];
+  const positional = [];
+  let optionsEnded = false;
+  let scriptProvidedByOption = false;
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!optionsEnded && token === "--") {
+      optionsEnded = true;
+      continue;
+    }
+    if (!optionsEnded && (/^-i/u.test(token) || token.startsWith("--in-place"))) return [];
+    if (!optionsEnded && /^-[nErsuz]+$/u.test(token)) continue;
+    if (!optionsEnded && ["--quiet", "--silent", "--regexp-extended", "--separate", "--unbuffered", "--null-data"].includes(token)) {
+      continue;
+    }
+    if (!optionsEnded && (token === "-e" || token === "--expression")) {
+      if (tokens[index + 1] === undefined) return [];
+      scriptProvidedByOption = true;
+      index += 1;
+      continue;
+    }
+    if (!optionsEnded && (/^-e.+/u.test(token) || token.startsWith("--expression="))) {
+      scriptProvidedByOption = true;
+      continue;
+    }
+    if (!optionsEnded && (token === "-f" || token === "--file")) {
+      const scriptPath = tokens[index + 1];
+      if (scriptPath === undefined) return [];
+      paths.push(scriptPath);
+      scriptProvidedByOption = true;
+      index += 1;
+      continue;
+    }
+    if (!optionsEnded && /^-f.+/u.test(token)) {
+      paths.push(token.slice(2));
+      scriptProvidedByOption = true;
+      continue;
+    }
+    if (!optionsEnded && token.startsWith("--file=")) {
+      paths.push(token.slice("--file=".length));
+      scriptProvidedByOption = true;
+      continue;
+    }
+    if (!optionsEnded && token.startsWith("-")) return [];
+    positional.push(token);
+  }
+  if (!scriptProvidedByOption) positional.shift();
+  return [...paths, ...positional];
+}
+
+function literalPaths(values) {
+  return values.filter((value) => (
+    typeof value === "string"
+    && value.length > 0
+    && value.length <= 4_096
+    && value !== "-"
+    && value !== "/dev/null"
+    && !value.startsWith("-")
+    && !value.includes("://")
+    && !/[\0-\x1f\x7f$`*?\[\]{}~]/u.test(value)
+  ));
+}
+
+function tokenizeLiteralShell(command) {
+  if (typeof command !== "string" || command.length === 0 || command.length > MAX_COMMAND_LENGTH) {
+    return null;
+  }
+  const tokens = [];
+  let current = "";
+  let quote = null;
+  const pushCurrent = () => {
+    if (!current) return;
+    tokens.push(current);
+    current = "";
+  };
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index];
+    if (quote === "'") {
+      if (character === "'") quote = null;
+      else current += character;
+      continue;
+    }
+    if (quote === '"') {
+      if (character === '"') {
+        quote = null;
+        continue;
+      }
+      if (character === "$" || character === "`") return null;
+      if (character === "\\") {
+        const next = command[index + 1];
+        if (next === undefined) return null;
+        current += next;
+        index += 1;
+        continue;
+      }
+      current += character;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (character === "\\") {
+      const next = command[index + 1];
+      if (next === undefined || next === "\n") return null;
+      current += next;
+      index += 1;
+      continue;
+    }
+    if (character === "$" || character === "`" || character === "(" || character === ")" || character === "<" || character === ">") {
+      return null;
+    }
+    if (/\s/u.test(character)) {
+      pushCurrent();
+      if (character === "\n") tokens.push(";");
+      continue;
+    }
+    if (character === ";" || character === "|") {
+      pushCurrent();
+      if (command[index + 1] === character) {
+        tokens.push(character + character);
+        index += 1;
+      } else {
+        tokens.push(character);
+      }
+      continue;
+    }
+    if (character === "&") {
+      pushCurrent();
+      if (command[index + 1] !== "&") return null;
+      tokens.push("&&");
+      index += 1;
+      continue;
+    }
+    current += character;
+  }
+  if (quote) return null;
+  pushCurrent();
+  return tokens;
+}
+
+function splitCommandSegments(tokens) {
+  const segments = [];
+  let segment = [];
+  for (const token of tokens) {
+    if ([";", "|", "||", "&&"].includes(token)) {
+      if (segment.length > 0) segments.push(segment);
+      segment = [];
+      continue;
+    }
+    segment.push(token);
+  }
+  if (segment.length > 0) segments.push(segment);
+  return segments;
+}
+
+function stripLeadingAssignments(tokens) {
+  const result = [...tokens];
+  while (/^[A-Za-z_][A-Za-z0-9_]*=[^$`]*$/u.test(result[0] ?? "")) result.shift();
+  return result;
+}
+
+function commandName(tokens) {
+  const token = stripLeadingAssignments(tokens)[0];
+  return typeof token === "string" ? token.split("/").at(-1)?.toLowerCase() ?? null : null;
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/electron/main/terminal-agent/activity/registration/bridge-installer.mjs
+++ b/electron/main/terminal-agent/activity/registration/bridge-installer.mjs
@@ -1,7 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-const BRIDGE_FILES = Object.freeze(["puppyone-agent-hook.mjs", "payload-projector.mjs"]);
+const BRIDGE_FILES = Object.freeze([
+  "puppyone-agent-hook.mjs",
+  "payload-projector.mjs",
+  "shell-file-intent.mjs",
+]);
 
 export function createAgentActivityBridgeInstaller({
   sourceDirectory,
@@ -12,6 +16,7 @@ export function createAgentActivityBridgeInstaller({
 }) {
   const installDirectory = path.join(userDataPath, "agent-activity", "bridge", "current");
   const bridgePath = path.join(installDirectory, "puppyone-agent-hook.mjs");
+  let ensurePromise = null;
 
   async function install() {
     await fsService.mkdir(installDirectory, { recursive: true, mode: 0o700 });
@@ -23,10 +28,46 @@ export function createAgentActivityBridgeInstaller({
   }
 
   async function exists() {
-    return fsService.access(bridgePath).then(() => true, () => false);
+    return Promise.all(BRIDGE_FILES.map((fileName) => (
+      fsService.access(path.join(installDirectory, fileName)).then(() => true, () => false)
+    ))).then((results) => results.every(Boolean));
   }
 
-  return Object.freeze({ install, exists, bridgePath, command: createBridgeCommand({ bridgePath, executablePath, platform }) });
+  async function isCurrent() {
+    try {
+      for (const fileName of BRIDGE_FILES) {
+        const [source, installed] = await Promise.all([
+          fsService.readFile(path.join(sourceDirectory, fileName)),
+          fsService.readFile(path.join(installDirectory, fileName)),
+        ]);
+        if (!Buffer.from(source).equals(Buffer.from(installed))) return false;
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async function ensureCurrent() {
+    if (!ensurePromise) {
+      ensurePromise = (async () => {
+        if (!(await isCurrent())) await install();
+        return Object.freeze({ bridgePath, command: createBridgeCommand({ bridgePath, executablePath, platform }) });
+      })().finally(() => {
+        ensurePromise = null;
+      });
+    }
+    return ensurePromise;
+  }
+
+  return Object.freeze({
+    install,
+    exists,
+    isCurrent,
+    ensureCurrent,
+    bridgePath,
+    command: createBridgeCommand({ bridgePath, executablePath, platform }),
+  });
 }
 
 export function createBridgeCommand({ bridgePath, executablePath, platform = process.platform }) {

--- a/electron/main/terminal-agent/activity/registration/cursor-cli-hook-config.mjs
+++ b/electron/main/terminal-agent/activity/registration/cursor-cli-hook-config.mjs
@@ -1,0 +1,141 @@
+import fs from "node:fs/promises";
+import {
+  isRecord,
+  readOwnedJsonFile,
+  writeOwnedJsonFileIfUnchanged,
+} from "./owned-json-file.mjs";
+
+const CURSOR_CONFIG_VERSION = 1;
+const CURSOR_TOOL_MATCHER = "Read|Write|Grep|Delete";
+const CURSOR_EVENTS = Object.freeze([
+  Object.freeze({ name: "preToolUse", matcher: CURSOR_TOOL_MATCHER }),
+  Object.freeze({ name: "postToolUse", matcher: CURSOR_TOOL_MATCHER }),
+  Object.freeze({ name: "postToolUseFailure", matcher: CURSOR_TOOL_MATCHER }),
+  Object.freeze({ name: "sessionEnd", matcher: null }),
+]);
+
+export function createOwnedCursorCliHookConfig({ configPath, command, fsService = fs }) {
+  async function inspect() {
+    const source = await readOwnedJsonFile(configPath, fsService);
+    if (source.error) return state("needs-repair", "invalid-json");
+    const schemaError = validateSchema(source.value);
+    if (schemaError) return state("needs-repair", schemaError);
+    const counts = countOwnedHandlers(source.value, command);
+    if (!counts.conflicting
+        && counts.exact === CURSOR_EVENTS.length
+        && counts.related === CURSOR_EVENTS.length) {
+      return state("enabled");
+    }
+    if (counts.exact === 0 && counts.related === 0) return state("not-configured");
+    return state("needs-repair", "owned-entry-changed");
+  }
+
+  async function enable() {
+    const before = await readOwnedJsonFile(configPath, fsService);
+    if (before.error) throw new Error("AGENT_ACTIVITY_CONFIG_INVALID_JSON");
+    const schemaError = validateSchema(before.value);
+    if (schemaError) throw new Error(`AGENT_ACTIVITY_CURSOR_CONFIG_${schemaError.toUpperCase().replaceAll("-", "_")}`);
+    const counts = countOwnedHandlers(before.value, command);
+    if (counts.conflicting) throw new Error("AGENT_ACTIVITY_CONFIG_CONFLICT");
+
+    const next = structuredClone(before.value);
+    next.version = CURSOR_CONFIG_VERSION;
+    if (!isRecord(next.hooks)) next.hooks = {};
+    for (const event of CURSOR_EVENTS) {
+      const handlers = Array.isArray(next.hooks[event.name]) ? next.hooks[event.name] : [];
+      const expected = createHandler(command, event.matcher);
+      if (!handlers.some((handler) => isExactHandler(handler, expected))) handlers.push(expected);
+      next.hooks[event.name] = handlers;
+    }
+    await writeOwnedJsonFileIfUnchanged({
+      configPath,
+      originalSource: before.source,
+      value: next,
+      fsService,
+    });
+    return inspect();
+  }
+
+  async function disable() {
+    const before = await readOwnedJsonFile(configPath, fsService);
+    if (before.error) throw new Error("AGENT_ACTIVITY_CONFIG_INVALID_JSON");
+    const schemaError = validateSchema(before.value);
+    if (schemaError) throw new Error(`AGENT_ACTIVITY_CURSOR_CONFIG_${schemaError.toUpperCase().replaceAll("-", "_")}`);
+    const counts = countOwnedHandlers(before.value, command);
+    if (counts.conflicting) throw new Error("AGENT_ACTIVITY_CONFIG_CONFLICT");
+
+    const next = structuredClone(before.value);
+    for (const event of CURSOR_EVENTS) {
+      if (!Array.isArray(next.hooks?.[event.name])) continue;
+      const expected = createHandler(command, event.matcher);
+      next.hooks[event.name] = next.hooks[event.name]
+        .filter((handler) => !isExactHandler(handler, expected));
+      if (next.hooks[event.name].length === 0) delete next.hooks[event.name];
+    }
+    if (isRecord(next.hooks) && Object.keys(next.hooks).length === 0) delete next.hooks;
+    await writeOwnedJsonFileIfUnchanged({
+      configPath,
+      originalSource: before.source,
+      value: next,
+      fsService,
+    });
+    return inspect();
+  }
+
+  return Object.freeze({ inspect, enable, disable, configPath });
+}
+
+function validateSchema(value) {
+  if (value.version !== undefined && value.version !== CURSOR_CONFIG_VERSION) return "unsupported-version";
+  if (value.hooks !== undefined && !isRecord(value.hooks)) return "invalid-schema";
+  for (const event of CURSOR_EVENTS) {
+    if (value.hooks?.[event.name] !== undefined && !Array.isArray(value.hooks[event.name])) {
+      return "invalid-schema";
+    }
+  }
+  return null;
+}
+
+function countOwnedHandlers(value, command) {
+  let exact = 0;
+  let related = 0;
+  let conflicting = false;
+  for (const event of CURSOR_EVENTS) {
+    const handlers = Array.isArray(value.hooks?.[event.name]) ? value.hooks[event.name] : [];
+    const expected = createHandler(command, event.matcher);
+    const exactHandlers = handlers.filter((handler) => isExactHandler(handler, expected));
+    const relatedHandlers = handlers.filter(isRelatedHandler);
+    exact += exactHandlers.length;
+    related += relatedHandlers.length;
+    if (exactHandlers.length > 1 || relatedHandlers.length !== exactHandlers.length) conflicting = true;
+  }
+  return { exact, related, conflicting };
+}
+
+function createHandler(command, matcher) {
+  return Object.freeze({
+    type: "command",
+    command,
+    timeout: 2,
+    ...(matcher ? { matcher } : {}),
+  });
+}
+
+function isExactHandler(handler, expected) {
+  if (!isRecord(handler)) return false;
+  const keys = Object.keys(handler).sort();
+  const expectedKeys = Object.keys(expected).sort();
+  return keys.length === expectedKeys.length
+    && keys.every((key, index) => key === expectedKeys[index])
+    && expectedKeys.every((key) => handler[key] === expected[key]);
+}
+
+function isRelatedHandler(handler) {
+  return isRecord(handler)
+    && typeof handler.command === "string"
+    && handler.command.includes("puppyone-agent-hook.mjs");
+}
+
+function state(enrollment, reason) {
+  return Object.freeze({ enrollment, ...(reason ? { reason } : {}) });
+}

--- a/electron/main/terminal-agent/activity/registration/hook-registration-service.mjs
+++ b/electron/main/terminal-agent/activity/registration/hook-registration-service.mjs
@@ -1,11 +1,12 @@
 import os from "node:os";
 import path from "node:path";
 import { createOwnedJsonHookConfig } from "./owned-config-mutation.mjs";
+import { createOwnedCursorCliHookConfig } from "./cursor-cli-hook-config.mjs";
 
 const PROVIDERS = Object.freeze([
   Object.freeze({ providerId: "codex", displayName: "Codex", configurable: true }),
   Object.freeze({ providerId: "claude", displayName: "Claude Code", configurable: true }),
-  Object.freeze({ providerId: "cursor", displayName: "Cursor Agent", configurable: false }),
+  Object.freeze({ providerId: "cursor", displayName: "Cursor Agent CLI", configurable: true }),
   Object.freeze({ providerId: "opencode", displayName: "OpenCode", configurable: false }),
   Object.freeze({ providerId: "pi", displayName: "Pi Agent", configurable: false }),
   Object.freeze({ providerId: "hermes", displayName: "Hermes Agent", configurable: false }),
@@ -23,6 +24,10 @@ export function createHookRegistrationService({ bridgeInstaller, homedir = os.ho
       providerId: "claude",
       command: providerBridgeCommand(bridgeInstaller.command, "claude"),
     })],
+    ["cursor", createOwnedCursorCliHookConfig({
+      configPath: path.join(homedir, ".cursor", "hooks.json"),
+      command: providerBridgeCommand(bridgeInstaller.command, "cursor"),
+    })],
   ]);
 
   async function getSnapshot() {
@@ -31,7 +36,7 @@ export function createHookRegistrationService({ bridgeInstaller, homedir = os.ho
       let enrollment = registration
         ? (await registration.inspect()).enrollment
         : "basic-only";
-      if (enrollment === "enabled" && !(await bridgeInstaller.exists())) {
+      if (enrollment === "enabled" && !(await bridgeInstaller.isCurrent())) {
         enrollment = "needs-repair";
       }
       return Object.freeze({ ...provider, enrollment });
@@ -51,11 +56,9 @@ export function createHookRegistrationService({ bridgeInstaller, homedir = os.ho
 
   async function isEnabled(providerId) {
     const registration = registrations.get(providerId);
-    return Boolean(
-      registration
-      && (await registration.inspect()).enrollment === "enabled"
-      && await bridgeInstaller.exists(),
-    );
+    if (!registration || (await registration.inspect()).enrollment !== "enabled") return false;
+    await bridgeInstaller.ensureCurrent();
+    return true;
   }
 
   async function hasAnyEnabled() {

--- a/electron/main/terminal-agent/activity/registration/owned-config-mutation.mjs
+++ b/electron/main/terminal-agent/activity/registration/owned-config-mutation.mjs
@@ -1,5 +1,9 @@
 import fs from "node:fs/promises";
-import path from "node:path";
+import {
+  isRecord,
+  readOwnedJsonFile,
+  writeOwnedJsonFileIfUnchanged,
+} from "./owned-json-file.mjs";
 
 const OWNED_EVENTS = Object.freeze({
   codex: Object.freeze(["PreToolUse", "PostToolUse", "SessionEnd"]),
@@ -11,7 +15,7 @@ export function createOwnedJsonHookConfig({ configPath, providerId, command, fsS
   if (!events) throw new Error(`Provider ${providerId} does not use JSON Hook registration.`);
 
   async function inspect() {
-    const source = await readSource(configPath, fsService);
+    const source = await readOwnedJsonFile(configPath, fsService);
     if (source.error) return Object.freeze({ enrollment: "needs-repair", reason: "invalid-json" });
     const counts = countOwnedHandlers(source.value, command, events);
     if (counts.exact === events.length && counts.related === events.length) {
@@ -24,7 +28,7 @@ export function createOwnedJsonHookConfig({ configPath, providerId, command, fsS
   }
 
   async function enable() {
-    const before = await readSource(configPath, fsService);
+    const before = await readOwnedJsonFile(configPath, fsService);
     if (before.error) throw new Error("AGENT_ACTIVITY_CONFIG_INVALID_JSON");
     const counts = countOwnedHandlers(before.value, command, events);
     if (counts.related > counts.exact) throw new Error("AGENT_ACTIVITY_CONFIG_CONFLICT");
@@ -37,12 +41,17 @@ export function createOwnedJsonHookConfig({ configPath, providerId, command, fsS
       }
       next.hooks[eventName] = groups;
     }
-    await writeIfUnchanged(configPath, before.source, next, fsService);
+    await writeOwnedJsonFileIfUnchanged({
+      configPath,
+      originalSource: before.source,
+      value: next,
+      fsService,
+    });
     return inspect();
   }
 
   async function disable() {
-    const before = await readSource(configPath, fsService);
+    const before = await readOwnedJsonFile(configPath, fsService);
     if (before.error) throw new Error("AGENT_ACTIVITY_CONFIG_INVALID_JSON");
     const counts = countOwnedHandlers(before.value, command, events);
     if (counts.related > counts.exact) throw new Error("AGENT_ACTIVITY_CONFIG_CONFLICT");
@@ -55,7 +64,12 @@ export function createOwnedJsonHookConfig({ configPath, providerId, command, fsS
       if (next.hooks[eventName].length === 0) delete next.hooks[eventName];
     }
     if (isRecord(next.hooks) && Object.keys(next.hooks).length === 0) delete next.hooks;
-    await writeIfUnchanged(configPath, before.source, next, fsService);
+    await writeOwnedJsonFileIfUnchanged({
+      configPath,
+      originalSource: before.source,
+      value: next,
+      fsService,
+    });
     return inspect();
   }
 
@@ -103,40 +117,4 @@ function removeExactHandler(group, command) {
   if (!isRecord(group) || !Array.isArray(group.hooks)) return group;
   const hooks = group.hooks.filter((handler) => !isExactHandler(handler, command));
   return hooks.length > 0 ? { ...group, hooks } : null;
-}
-
-async function readSource(configPath, fsService) {
-  let source;
-  try {
-    source = await fsService.readFile(configPath, "utf8");
-  } catch (error) {
-    if (error?.code !== "ENOENT") throw error;
-    return { source: null, value: {} };
-  }
-  try {
-    const value = JSON.parse(source);
-    return isRecord(value) ? { source, value } : { source, value: {}, error: true };
-  } catch {
-    return { source, value: {}, error: true };
-  }
-}
-
-async function writeIfUnchanged(configPath, originalSource, value, fsService) {
-  const latest = await readSource(configPath, fsService);
-  if (latest.source !== originalSource) throw new Error("AGENT_ACTIVITY_CONFIG_CHANGED");
-  await fsService.mkdir(path.dirname(configPath), { recursive: true, mode: 0o700 });
-  const tempPath = `${configPath}.puppyone-${process.pid}-${Date.now()}.tmp`;
-  const source = `${JSON.stringify(value, null, 2)}\n`;
-  try {
-    await fsService.writeFile(tempPath, source, { encoding: "utf8", mode: 0o600, flag: "wx" });
-    await fsService.rename(tempPath, configPath);
-    await fsService.chmod(configPath, 0o600).catch(() => undefined);
-  } catch (error) {
-    await fsService.unlink(tempPath).catch(() => undefined);
-    throw error;
-  }
-}
-
-function isRecord(value) {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/electron/main/terminal-agent/activity/registration/owned-json-file.mjs
+++ b/electron/main/terminal-agent/activity/registration/owned-json-file.mjs
@@ -1,0 +1,49 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export async function readOwnedJsonFile(configPath, fsService = fs) {
+  let source;
+  try {
+    source = await fsService.readFile(configPath, "utf8");
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+    return Object.freeze({ source: null, value: {} });
+  }
+  try {
+    const value = JSON.parse(source);
+    return isRecord(value)
+      ? Object.freeze({ source, value })
+      : Object.freeze({ source, value: {}, error: true });
+  } catch {
+    return Object.freeze({ source, value: {}, error: true });
+  }
+}
+
+export async function writeOwnedJsonFileIfUnchanged({
+  configPath,
+  originalSource,
+  value,
+  fsService = fs,
+}) {
+  const latest = await readOwnedJsonFile(configPath, fsService);
+  if (latest.source !== originalSource) throw new Error("AGENT_ACTIVITY_CONFIG_CHANGED");
+  await fsService.mkdir(path.dirname(configPath), { recursive: true, mode: 0o700 });
+  const temporaryPath = `${configPath}.puppyone-${process.pid}-${Date.now()}.tmp`;
+  const source = `${JSON.stringify(value, null, 2)}\n`;
+  try {
+    await fsService.writeFile(temporaryPath, source, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await fsService.rename(temporaryPath, configPath);
+    await fsService.chmod(configPath, 0o600).catch(() => undefined);
+  } catch (error) {
+    await fsService.unlink(temporaryPath).catch(() => undefined);
+    throw error;
+  }
+}
+
+export function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/electron/main/terminal-service.mjs
+++ b/electron/main/terminal-service.mjs
@@ -12,6 +12,14 @@ import {
 import { resolveCanonicalWorkspaceDirectory } from "./workspace-authorization.mjs";
 
 const DEFAULT_AGENT_REVEAL_TIMEOUT_MS = 2_400;
+const TERMINAL_DEFAULT_COLOR_QUERIES = Object.freeze([
+  { sequence: "\u001b]10;?\u001b\\", slot: 10 },
+  { sequence: "\u001b]10;?\u0007", slot: 10 },
+  { sequence: "\u001b]11;?\u001b\\", slot: 11 },
+  { sequence: "\u001b]11;?\u0007", slot: 11 },
+  { sequence: "\u009d10;?\u009c", slot: 10 },
+  { sequence: "\u009d11;?\u009c", slot: 11 },
+]);
 
 export function createTerminalService({
   appVersion,
@@ -102,6 +110,7 @@ export function createTerminalService({
       sender,
       cols,
       rows,
+      defaultColorResponder: createTerminalDefaultColorResponder(request?.defaultColors),
     };
 
     sessions.set(id, session);
@@ -110,10 +119,24 @@ export function createTerminalService({
       ? createAgentRevealGate(agentRevealTimeoutMs)
       : null;
     terminal.onData((data) => {
-      sendTerminalData(session, data);
+      const handled = session.defaultColorResponder?.process(data) ?? {
+        data: String(data),
+        replies: [],
+      };
+      try {
+        handled.replies.forEach((reply) => terminal.write(reply));
+      } catch (error) {
+        logger.warn("Unable to answer terminal default-color query:", error);
+        sendTerminalData(session, data);
+        agentRevealGate?.observe(data);
+        return;
+      }
+      if (handled.data.length > 0) sendTerminalData(session, handled.data);
       agentRevealGate?.observe(data);
     });
     terminal.onExit(({ exitCode, signal }) => {
+      const trailingData = session.defaultColorResponder?.flush() ?? "";
+      if (trailingData.length > 0) sendTerminalData(session, trailingData);
       agentRevealGate?.settle();
       sendTerminalExit(session, exitCode, signal ? String(signal) : null);
       if (sessions.get(id) === session) sessions.delete(id);
@@ -213,6 +236,92 @@ export function createTerminalService({
     closeAll,
     getSessionCount,
   };
+}
+
+export function createTerminalDefaultColorResponder(value) {
+  const colors = normalizeTerminalDefaultColors(value);
+  if (!colors) return null;
+  let carry = "";
+
+  return {
+    process(data) {
+      const source = `${carry}${String(data)}`;
+      const replies = [];
+      let output = "";
+      let cursor = 0;
+      carry = "";
+
+      while (cursor < source.length) {
+        const match = findNextTerminalDefaultColorQuery(source, cursor);
+        if (!match) {
+          const remainder = source.slice(cursor);
+          const carryLength = longestTerminalDefaultColorQueryPrefixSuffix(remainder);
+          output += remainder.slice(0, remainder.length - carryLength);
+          carry = remainder.slice(remainder.length - carryLength);
+          break;
+        }
+        output += source.slice(cursor, match.index);
+        replies.push(formatTerminalDefaultColorReply(match.slot, colors));
+        cursor = match.index + match.sequence.length;
+      }
+
+      return { data: output, replies };
+    },
+    flush() {
+      const data = carry;
+      carry = "";
+      return data;
+    },
+  };
+}
+
+function normalizeTerminalDefaultColors(value) {
+  const foreground = normalizeTerminalRgb(value?.foreground);
+  const background = normalizeTerminalRgb(value?.background);
+  return foreground && background ? { foreground, background } : null;
+}
+
+function normalizeTerminalRgb(value) {
+  if (!Array.isArray(value) || value.length !== 3) return null;
+  const channels = value.map(Number);
+  if (channels.some((channel) => (
+    !Number.isInteger(channel) || channel < 0 || channel > 255
+  ))) return null;
+  return channels;
+}
+
+function findNextTerminalDefaultColorQuery(source, cursor) {
+  let result = null;
+  for (const query of TERMINAL_DEFAULT_COLOR_QUERIES) {
+    const index = source.indexOf(query.sequence, cursor);
+    if (index !== -1 && (!result || index < result.index)) {
+      result = { ...query, index };
+    }
+  }
+  return result;
+}
+
+function longestTerminalDefaultColorQueryPrefixSuffix(value) {
+  const maxLength = Math.min(
+    value.length,
+    Math.max(...TERMINAL_DEFAULT_COLOR_QUERIES.map(({ sequence }) => sequence.length)) - 1,
+  );
+  for (let length = maxLength; length > 0; length -= 1) {
+    const suffix = value.slice(-length);
+    if (TERMINAL_DEFAULT_COLOR_QUERIES.some(({ sequence }) => sequence.startsWith(suffix))) {
+      return length;
+    }
+  }
+  return 0;
+}
+
+function formatTerminalDefaultColorReply(slot, colors) {
+  const color = slot === 10 ? colors.foreground : colors.background;
+  const components = color.map((channel) => {
+    const hex = channel.toString(16).padStart(2, "0");
+    return `${hex}${hex}`;
+  });
+  return `\u001b]${slot};rgb:${components.join("/")}\u001b\\`;
 }
 
 function createAgentRevealGate(timeoutValue) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dev:update-preview": "VITE_DESKTOP_UPDATE_PREVIEW=available VITE_DESKTOP_UPDATE_PREVIEW_VERSION=0.3.0-preview.1 VITE_DESKTOP_CLOUD_API_URL=https://api.puppyone.ai/api/v1 VITE_DESKTOP_CLOUD_WEB_URL=https://app.puppyone.ai npm run dev",
     "dev:renderer": "vite",
     "dev:browser": "vite --host 127.0.0.1",
-    "postinstall": "node scripts/fix-node-pty-permissions.mjs",
+    "postinstall": "node scripts/fix-node-pty-permissions.mjs && node scripts/patch-xterm-webgl-atlas.mjs",
     "build": "node scripts/check-desktop-build-environment.mjs && npm run check:boundaries && tsc && vite build && node scripts/check-renderer-public-assets.mjs && node scripts/check-bundle-budget.mjs && node scripts/check-packaged-artifact-budgets.mjs",
     "package:viewer-pack": "node scripts/package-viewer-pack.mjs",
     "check:artifact-budgets": "node scripts/check-packaged-artifact-budgets.mjs",

--- a/packages/shared-ui/src/editor/editorPaneMenuContribution.tsx
+++ b/packages/shared-ui/src/editor/editorPaneMenuContribution.tsx
@@ -22,7 +22,25 @@ export type EditorPaneMenuToggle = Readonly<{
   setChecked: (checked: boolean) => void;
 }>;
 
-export type EditorPaneMenuItem = EditorPaneMenuCommand | EditorPaneMenuToggle;
+export type EditorPaneMenuSegmentedOption = Readonly<{
+  id: string;
+  label: string;
+  icon: ReactNode;
+}>;
+
+export type EditorPaneMenuSegmentedControl = Readonly<{
+  kind: "segmented";
+  id: string;
+  label: string;
+  value: string;
+  options: readonly EditorPaneMenuSegmentedOption[];
+  setValue: (value: string) => void;
+}>;
+
+export type EditorPaneMenuItem =
+  | EditorPaneMenuCommand
+  | EditorPaneMenuToggle
+  | EditorPaneMenuSegmentedControl;
 
 export type EditorPaneMenuContribution = Readonly<{
   documentId: string;

--- a/packages/shared-ui/src/editor/editorPaneMenuContribution.tsx
+++ b/packages/shared-ui/src/editor/editorPaneMenuContribution.tsx
@@ -3,7 +3,10 @@
 import {
   createContext,
   type ReactNode,
+  useCallback,
   useContext,
+  useMemo,
+  useRef,
 } from "react";
 
 export type EditorPaneMenuCommand = Readonly<{
@@ -51,8 +54,15 @@ type EditorPaneMenuContributionPublisher = (
   contribution: EditorPaneMenuContribution | null,
 ) => void;
 
+type EditorPaneMenuContributionRegistry = Readonly<{
+  publish: (
+    owner: symbol,
+    contribution: EditorPaneMenuContribution | null,
+  ) => void;
+}>;
+
 const EditorPaneMenuContributionContext = createContext<
-  EditorPaneMenuContributionPublisher | null
+  EditorPaneMenuContributionRegistry | null
 >(null);
 
 export function EditorPaneMenuContributionProvider({
@@ -62,13 +72,38 @@ export function EditorPaneMenuContributionProvider({
   children: ReactNode;
   onContributionChange: EditorPaneMenuContributionPublisher;
 }>) {
+  const activeOwnerRef = useRef<symbol | null>(null);
+  const publish = useCallback((
+    owner: symbol,
+    contribution: EditorPaneMenuContribution | null,
+  ) => {
+    if (contribution) {
+      activeOwnerRef.current = owner;
+      onContributionChange(contribution);
+      return;
+    }
+    if (activeOwnerRef.current !== owner) return;
+    activeOwnerRef.current = null;
+    onContributionChange(null);
+  }, [onContributionChange]);
+  const registry = useMemo<EditorPaneMenuContributionRegistry>(
+    () => ({ publish }),
+    [publish],
+  );
+
   return (
-    <EditorPaneMenuContributionContext.Provider value={onContributionChange}>
+    <EditorPaneMenuContributionContext.Provider value={registry}>
       {children}
     </EditorPaneMenuContributionContext.Provider>
   );
 }
 
 export function useEditorPaneMenuContributionPublisher() {
-  return useContext(EditorPaneMenuContributionContext);
+  const registry = useContext(EditorPaneMenuContributionContext);
+  const ownerRef = useRef(Symbol("editor-pane-menu-contribution"));
+  const publish = useCallback<EditorPaneMenuContributionPublisher>(
+    (contribution) => registry?.publish(ownerRef.current, contribution),
+    [registry],
+  );
+  return registry ? publish : null;
 }

--- a/packages/shared-ui/src/editor/markdown/core/commands/markdownTaskCommands.ts
+++ b/packages/shared-ui/src/editor/markdown/core/commands/markdownTaskCommands.ts
@@ -1,5 +1,6 @@
 import { Transaction } from "@codemirror/state";
 import type { EditorView } from "@codemirror/view";
+import { getMarkdownTaskLine } from "../rendering/taskModel";
 
 export type MarkdownTaskCheckboxTarget = Readonly<{
   from: number;
@@ -9,9 +10,28 @@ export type MarkdownTaskCheckboxTarget = Readonly<{
 const TASK_CHECKBOX_TOKEN = /^\[[ xX]\]$/;
 
 /**
- * Toggles a task marker against the current EditorState rather than trusting
- * the widget's render-time checked value. That keeps repeated input and
- * mapped widgets deterministic while limiting projection work to one token.
+ * Resolves the task token from the current document at activation time.
+ *
+ * Incremental projections may map a widget through edits without rebuilding
+ * its WidgetType. A render-time absolute range can therefore become stale
+ * even though the widget is still mounted at the correct visual line.
+ */
+export function toggleMarkdownTaskCheckboxAt(
+  view: EditorView,
+  position: number,
+): boolean {
+  const safePosition = Math.max(0, Math.min(position, view.state.doc.length));
+  const task = getMarkdownTaskLine(view.state.doc.lineAt(safePosition));
+  if (!task) return false;
+  return toggleMarkdownTaskCheckbox(view, {
+    from: task.checkboxFrom,
+    to: task.checkboxTo,
+  });
+}
+
+/**
+ * Toggles a validated task marker against the current EditorState rather than
+ * trusting the widget's render-time checked value.
  */
 export function toggleMarkdownTaskCheckbox(
   view: EditorView,

--- a/packages/shared-ui/src/editor/markdown/core/widgets/inlineWidgets.ts
+++ b/packages/shared-ui/src/editor/markdown/core/widgets/inlineWidgets.ts
@@ -1,7 +1,7 @@
 import { EditorView, type Rect, WidgetType } from "@codemirror/view";
 import type { MarkdownTaskLine } from "../rendering/taskModel";
 import { getInlineWidgetEdgeX, getInlineWidgetTextCoords } from "../../shared/widgets/markdownWidgetMeasure";
-import { toggleMarkdownTaskCheckbox } from "../commands/markdownTaskCommands";
+import { toggleMarkdownTaskCheckboxAt } from "../commands/markdownTaskCommands";
 import { getMarkdownMessage } from "../editor/markdownLocalization";
 
 export type MarkdownSourceSyntaxKind =
@@ -111,8 +111,8 @@ export class TaskCheckboxWidget extends WidgetType {
       event.preventDefault();
       event.stopPropagation();
 
-      const target = readTaskCheckboxTarget(control);
-      if (!target || !toggleMarkdownTaskCheckbox(view, target)) return;
+      const position = readTaskCheckboxPosition(view, control);
+      if (position === null || !toggleMarkdownTaskCheckboxAt(view, position)) return;
     });
 
     return control;
@@ -148,8 +148,6 @@ function syncTaskCheckboxControl(
   view: EditorView,
 ) {
   control.style.setProperty("--md-list-depth", String(task.depth));
-  control.dataset.checkboxFrom = String(task.checkboxFrom);
-  control.dataset.checkboxTo = String(task.checkboxTo);
   control.setAttribute(
     "aria-label",
     getMarkdownMessage(
@@ -164,11 +162,16 @@ function syncTaskCheckboxIndicator(indicator: HTMLElement, checked: boolean) {
   indicator.className = checked ? "cm-md-task-checkbox is-checked" : "cm-md-task-checkbox";
 }
 
-function readTaskCheckboxTarget(control: HTMLButtonElement) {
-  const from = Number(control.dataset.checkboxFrom);
-  const to = Number(control.dataset.checkboxTo);
-  if (!Number.isInteger(from) || !Number.isInteger(to)) return null;
-  return { from, to };
+function readTaskCheckboxPosition(
+  view: EditorView,
+  control: HTMLButtonElement,
+): number | null {
+  if (!control.isConnected || !view.dom.contains(control)) return null;
+  try {
+    return view.posAtDOM(control);
+  } catch {
+    return null;
+  }
 }
 
 export class HorizontalRuleWidget extends WidgetType {

--- a/packages/shared-ui/src/editor/markdown/core/widgets/inlineWidgets.ts
+++ b/packages/shared-ui/src/editor/markdown/core/widgets/inlineWidgets.ts
@@ -1,6 +1,7 @@
 import { EditorView, type Rect, WidgetType } from "@codemirror/view";
 import type { MarkdownTaskLine } from "../rendering/taskModel";
 import { getInlineWidgetEdgeX, getInlineWidgetTextCoords } from "../../shared/widgets/markdownWidgetMeasure";
+import { getMappedWidgetPosition } from "../../shared/widgets/widgetDom";
 import { toggleMarkdownTaskCheckboxAt } from "../commands/markdownTaskCommands";
 import { getMarkdownMessage } from "../editor/markdownLocalization";
 
@@ -111,7 +112,7 @@ export class TaskCheckboxWidget extends WidgetType {
       event.preventDefault();
       event.stopPropagation();
 
-      const position = readTaskCheckboxPosition(view, control);
+      const position = getMappedWidgetPosition(view, control);
       if (position === null || !toggleMarkdownTaskCheckboxAt(view, position)) return;
     });
 
@@ -160,18 +161,6 @@ function syncTaskCheckboxControl(
 
 function syncTaskCheckboxIndicator(indicator: HTMLElement, checked: boolean) {
   indicator.className = checked ? "cm-md-task-checkbox is-checked" : "cm-md-task-checkbox";
-}
-
-function readTaskCheckboxPosition(
-  view: EditorView,
-  control: HTMLButtonElement,
-): number | null {
-  if (!control.isConnected || !view.dom.contains(control)) return null;
-  try {
-    return view.posAtDOM(control);
-  } catch {
-    return null;
-  }
 }
 
 export class HorizontalRuleWidget extends WidgetType {

--- a/packages/shared-ui/src/editor/markdown/features/code-block/codeBlockWidget.ts
+++ b/packages/shared-ui/src/editor/markdown/features/code-block/codeBlockWidget.ts
@@ -11,7 +11,11 @@ import {
 } from "./codeBlockModel";
 import { getDocRevision, type CommitResult } from "../../platform/brokers/transactionBroker";
 import { estimateCodeBlockLayoutHeight } from "./codeBlockLayout";
-import { normalizeLineEndings, stopCodeMirrorEvent } from "../../shared/widgets/widgetDom";
+import {
+  getMappedWidgetSourceRange,
+  normalizeLineEndings,
+  stopCodeMirrorEvent,
+} from "../../shared/widgets/widgetDom";
 import { getMarkdownLocalization } from "../../core/editor/markdownLocalization";
 import {
   MARKDOWN_RICH_BLOCK_EXECUTION,
@@ -62,6 +66,7 @@ export class CodeBlockWidget extends WidgetType {
     const panel = document.createElement("div");
     panel.className = "cm-md-code-panel";
     const readOnly = view.state.readOnly;
+    const sourceLength = Math.max(0, this.to - this.from);
     const baseSource = view.state.sliceDoc(this.from, this.to);
     const baseRevision = getDocRevision(view.state.doc);
     const initialSession = readOnly
@@ -124,10 +129,12 @@ export class CodeBlockWidget extends WidgetType {
     const ensureSession = () => {
       const existing = elementId ? host.editSessions.get(elementId) : undefined;
       if (existing) return existing;
+      const mappedRange = getMappedWidgetSourceRange(view, wrapper, sourceLength);
+      if (!mappedRange) return null;
       const session = host.editSessions.acquire({
         featureId: "codeBlock",
-        mappedRange: { from: this.from, to: this.to },
-        baseSource,
+        mappedRange,
+        baseSource: view.state.sliceDoc(mappedRange.from, mappedRange.to),
         baseRevision: getDocRevision(view.state.doc),
         draft: {
           code: normalizeLineEndings(codeEditor.value),
@@ -141,6 +148,7 @@ export class CodeBlockWidget extends WidgetType {
 
     const syncDraft = () => {
       const session = ensureSession();
+      if (!session) return;
       host.editSessions.update(session.elementId, {
         draft: {
           code: normalizeLineEndings(codeEditor.value),
@@ -154,6 +162,7 @@ export class CodeBlockWidget extends WidgetType {
     const commit = (options: { finish?: boolean; selection?: "start" | "end" } = {}): CommitResult | null => {
       if (committed || readOnly) return null;
       const session = ensureSession();
+      if (!session) return null;
       committed = true;
       const language = sanitizeCodeLanguage(languageInput.value);
       const code = normalizeLineEndings(codeEditor.value);
@@ -244,6 +253,10 @@ export class CodeBlockWidget extends WidgetType {
         event.preventDefault();
         committed = true;
         const session = ensureSession();
+        if (!session) {
+          committed = false;
+          return;
+        }
         const deleteFrom = session.mappedRange.from;
         const result = host.transactions.commit(view, {
           mappedRange: session.mappedRange,

--- a/packages/shared-ui/src/editor/markdown/features/mermaid/mermaidBlockWidget.ts
+++ b/packages/shared-ui/src/editor/markdown/features/mermaid/mermaidBlockWidget.ts
@@ -19,7 +19,11 @@ import { MarkdownWidgetMeasureController } from "../../platform/codemirror/layou
 import { estimateMermaidLayoutHeight } from "../code-block/codeBlockLayout";
 import { getDocRevision, type CommitResult } from "../../platform/brokers/transactionBroker";
 import { createPrincipalFromView, openMarkdownHref } from "../../core/editor/markdownLivePreviewContext";
-import { normalizeLineEndings, stopCodeMirrorEvent } from "../../shared/widgets/widgetDom";
+import {
+  getMappedWidgetSourceRange,
+  normalizeLineEndings,
+  stopCodeMirrorEvent,
+} from "../../shared/widgets/widgetDom";
 import {
   getMarkdownLocalization,
   type MarkdownLocalization,
@@ -72,6 +76,7 @@ export class MermaidBlockWidget extends WidgetType {
     shell.dir = direction;
     const readOnly = view.state.readOnly;
     const measure = new MarkdownWidgetMeasureController(host.layout);
+    const sourceLength = Math.max(0, this.to - this.from);
     const elementKey = `${this.from}:${this.to}`;
     const baseSource = view.state.sliceDoc(this.from, this.to);
     const recoveryKey = {
@@ -122,10 +127,12 @@ export class MermaidBlockWidget extends WidgetType {
     const ensureEditSession = (mode: "preview" | "editing" = editing ? "editing" : "preview") => {
       const existing = editSessionId ? host.editSessions.get(editSessionId) : undefined;
       if (existing) return existing;
+      const mappedRange = getMappedWidgetSourceRange(view, shell, sourceLength);
+      if (!mappedRange) return null;
       const session = host.editSessions.acquire({
         featureId: "mermaid",
-        mappedRange: { from: this.from, to: this.to },
-        baseSource,
+        mappedRange,
+        baseSource: view.state.sliceDoc(mappedRange.from, mappedRange.to),
         baseRevision: getDocRevision(view.state.doc),
         draft: { code: draftCode, language: this.language },
         mode,
@@ -136,6 +143,7 @@ export class MermaidBlockWidget extends WidgetType {
 
     const syncDraft = () => {
       const session = ensureEditSession("editing");
+      if (!session) return;
       host.editSessions.update(session.elementId, {
         draft: { code: draftCode, language: this.language },
         mode: "editing",
@@ -146,6 +154,7 @@ export class MermaidBlockWidget extends WidgetType {
     const commit = (options: { focus?: boolean; selection?: "start" | "end" } = {}): CommitResult | null => {
       if (committed || readOnly) return null;
       const session = ensureEditSession("editing");
+      if (!session) return null;
       committed = true;
       const nextCode = normalizeLineEndings(textarea?.value ?? draftCode);
       if (nextCode === this.code) {
@@ -305,11 +314,12 @@ export class MermaidBlockWidget extends WidgetType {
 
     const openEditor = () => {
       if (readOnly || editing) return;
+      const session = ensureEditSession("editing");
+      if (!session) return;
       activated = true;
       editing = true;
       committed = false;
       draftCode = textarea?.value ?? draftCode;
-      const session = ensureEditSession("editing");
       host.editSessions.update(session.elementId, {
         draft: { code: draftCode, language: this.language },
         mode: "editing",

--- a/packages/shared-ui/src/editor/markdown/features/table/tableCellEditor.ts
+++ b/packages/shared-ui/src/editor/markdown/features/table/tableCellEditor.ts
@@ -38,6 +38,7 @@ export type MarkdownTableCellEditorContext = {
   rowIndex: number;
   rows: readonly MarkdownTableRow[];
   renderInlinePreview: MarkdownInlinePreviewRenderer;
+  getTableRange: () => { from: number; to: number } | null;
   tableFrom: number;
   tableTo: number;
   view: EditorView;
@@ -63,6 +64,7 @@ export function createTableCellEditor(context: MarkdownTableCellEditorContext): 
     rowIndex,
     rows,
     renderInlinePreview,
+    getTableRange,
     tableFrom,
     tableTo,
     view,
@@ -131,13 +133,29 @@ export function createTableCellEditor(context: MarkdownTableCellEditorContext): 
   // the single recoverable owner (range-mapped, revision-aware).
   const beginEditSession = () => {
     const existing = editSessionId ? host.editSessions.get(editSessionId) : undefined;
-    const session = existing ?? host.editSessions.acquire({
-      ...recoveryKey,
-      baseRevision: getDocRevision(view.state.doc),
-      draft: { text: content.textContent ?? cell.text },
-      mode: "editing",
-      focusTarget: { rowIndex, columnIndex },
-    });
+    const currentTableRange = existing ? null : getTableRange();
+    if (!existing && !currentTableRange) return null;
+    const delta = currentTableRange ? currentTableRange.from - tableFrom : 0;
+    const mappedRange = existing?.mappedRange ?? {
+      from: cell.from + delta,
+      to: cell.to + delta,
+    };
+    const currentBaseSource = view.state.sliceDoc(mappedRange.from, mappedRange.to);
+    const session = existing
+      ?? host.editSessions.findRecoverable({
+        featureId: "table-cell",
+        mappedRange,
+        baseSource: currentBaseSource,
+      })
+      ?? host.editSessions.acquire({
+        featureId: "table-cell",
+        mappedRange,
+        baseSource: currentBaseSource,
+        baseRevision: getDocRevision(view.state.doc),
+        draft: { text: content.textContent ?? cell.text },
+        mode: "editing",
+        focusTarget: { rowIndex, columnIndex },
+      });
     editSessionId = session.elementId;
     return host.editSessions.update(session.elementId, {
       lifecycle: "mounted",
@@ -147,6 +165,7 @@ export function createTableCellEditor(context: MarkdownTableCellEditorContext): 
   };
   const updateEditSessionDraft = () => {
     const session = beginEditSession();
+    if (!session) return null;
     return host.editSessions.update(session.elementId, {
       draft: { text: content.textContent ?? "" },
       mode: "editing",
@@ -162,11 +181,9 @@ export function createTableCellEditor(context: MarkdownTableCellEditorContext): 
 
   const getMappedTableRange = () => {
     const session = editSessionId ? host.editSessions.get(editSessionId) : undefined;
-    const delta = session ? session.mappedRange.from - cell.from : 0;
-    return {
-      from: tableFrom + delta,
-      to: tableTo + delta,
-    };
+    if (!session) return getTableRange();
+    const delta = session.mappedRange.from - cell.from;
+    return { from: tableFrom + delta, to: tableTo + delta };
   };
 
   const getDraft = (): MarkdownTableCellDraft => ({
@@ -178,12 +195,14 @@ export function createTableCellEditor(context: MarkdownTableCellEditorContext): 
   const commitCellEdit = (target: { exitPosition?: number; focus?: MarkdownTableFocusTarget }): boolean => {
     const nextText = normalizeMarkdownTableCellInput(content.textContent ?? "");
     const session = updateEditSessionDraft() ?? beginEditSession();
+    if (!session) return false;
     // The CAS source is the exact Markdown slice (which may contain escaped
     // pipes); the editable draft is its decoded table-cell representation.
     const changed = nextText !== cell.text;
 
     if (!changed) {
       const mappedTable = getMappedTableRange();
+      if (!mappedTable) return false;
       finishEditSession("cancel");
       if (target.focus) {
         view.dispatch({
@@ -200,6 +219,7 @@ export function createTableCellEditor(context: MarkdownTableCellEditorContext): 
     }
 
     const mappedTable = getMappedTableRange();
+    if (!mappedTable) return false;
     const nextCellSource = sanitizeMarkdownTableCell(nextText);
     const nextTableTo = mappedTable.to + nextCellSource.length - session.baseSource.length;
     const selectionPosition = target.exitPosition === tableTo ? nextTableTo : mappedTable.from;
@@ -243,6 +263,7 @@ export function createTableCellEditor(context: MarkdownTableCellEditorContext): 
     suppressBlurCommit = true;
     if (editing) updateEditSessionDraft();
     const mappedTable = getMappedTableRange();
+    if (!mappedTable) return;
     const currentDraft = editing ? getDraft() : null;
     finishEditSession("complete");
     dispatchMarkdownTableStructureOperation({
@@ -298,8 +319,14 @@ export function createTableCellEditor(context: MarkdownTableCellEditorContext): 
       // Cell edit owns the chrome; drop the block selection so the table ring
       // and the cell ring never compete.
       const selection = view.state.selection.main;
-      if (!selection.empty && selection.from <= tableFrom && selection.to >= tableTo) {
-        view.dispatch({ selection: EditorSelection.cursor(getMappedTableRange().from) });
+      const mappedTable = getMappedTableRange();
+      if (
+        mappedTable
+        && !selection.empty
+        && selection.from <= mappedTable.from
+        && selection.to >= mappedTable.to
+      ) {
+        view.dispatch({ selection: EditorSelection.cursor(mappedTable.from) });
       }
     });
     content.addEventListener("keydown", (event) => {
@@ -370,11 +397,12 @@ export function createTableCellEditor(context: MarkdownTableCellEditorContext): 
     content.addEventListener("contextmenu", (event) => {
       event.preventDefault();
       event.stopPropagation();
+      const mappedTable = getMappedTableRange();
+      if (!mappedTable) return;
       closeActiveMarkdownTableMenu();
       tableMenuOpen = true;
       const tableWrapper = content.closest<HTMLElement>(".cm-md-table-widget-wrap");
       if (tableWrapper && rowIndex > 0) tableWrapper.dataset.mdTablePinnedRow = String(rowIndex);
-      const mappedTable = getMappedTableRange();
       const keyboardInvocation = event.clientX === 0 && event.clientY === 0;
       const anchorRect = keyboardInvocation ? content.getBoundingClientRect() : null;
       let nextMenu: HTMLElement | null = null;

--- a/packages/shared-ui/src/editor/markdown/features/table/tableDragLayer.ts
+++ b/packages/shared-ui/src/editor/markdown/features/table/tableDragLayer.ts
@@ -25,8 +25,7 @@ export type MarkdownTableDragHandleContext = {
   inlineViewport: MarkdownTableInlineViewportController;
   rows: readonly MarkdownTableRow[];
   table: HTMLTableElement;
-  tableFrom: number;
-  tableTo: number;
+  getTableRange: () => { from: number; to: number } | null;
   view: EditorView;
   wrapper: HTMLElement;
 };
@@ -167,16 +166,23 @@ export function createMarkdownTableDragLayer(context: MarkdownTableDragHandleCon
   context.table.addEventListener("pointerover", updateHoverFromEvent);
   context.wrapper.addEventListener("pointerleave", clearHover);
 
-  const buildDispatchContext = (): MarkdownTableDispatchContext => ({
-    alignments: context.alignments,
-    currentDraft: getActiveMarkdownTableCellDraft(context.wrapper),
-    rows: context.rows,
-    tableFrom: context.tableFrom,
-    tableTo: context.tableTo,
-    view: context.view,
-  });
+  const buildDispatchContext = (): MarkdownTableDispatchContext | null => {
+    const tableRange = context.getTableRange();
+    return tableRange
+      ? {
+          alignments: context.alignments,
+          currentDraft: getActiveMarkdownTableCellDraft(context.wrapper),
+          rows: context.rows,
+          tableFrom: tableRange.from,
+          tableTo: tableRange.to,
+          view: context.view,
+        }
+      : null;
+  };
 
   const openHandleMenu = (kind: MarkdownTableDragKind, sourceIndex: number, handle: HTMLElement) => {
+    const dispatchContext = buildDispatchContext();
+    if (!dispatchContext) return;
     closeActiveMarkdownTableMenu();
     setInteractionPinnedRow(kind === "row" ? sourceIndex : hover.rowIndex);
     setDragSourceHighlight(kind, sourceIndex, true);
@@ -186,7 +192,7 @@ export function createMarkdownTableDragLayer(context: MarkdownTableDragHandleCon
     const anchor = handle.querySelector<HTMLElement>(".cm-md-table-drag-handle-visual") ?? handle;
     const rect = anchor.getBoundingClientRect();
     let nextMenu: HTMLElement | null = null;
-    nextMenu = showMarkdownTableContextMenu(buildDispatchContext(), {
+    nextMenu = showMarkdownTableContextMenu(dispatchContext, {
       clientX: kind === "row"
         ? localization.direction === "rtl" ? rect.left - 4 : rect.right + 4
         : rect.left,
@@ -356,10 +362,12 @@ export function createMarkdownTableDragLayer(context: MarkdownTableDragHandleCon
 
     const applyMove = () => {
       if (dropBoundary == null) return;
+      const dispatchContext = buildDispatchContext();
+      if (!dispatchContext) return;
       if (kind === "column") {
         const targetColumnIndex = dropBoundary > sourceIndex ? dropBoundary - 1 : dropBoundary;
         if (targetColumnIndex === sourceIndex) return;
-        dispatchMarkdownTableStructureOperation(buildDispatchContext(), {
+        dispatchMarkdownTableStructureOperation(dispatchContext, {
           type: "move-column-to",
           rowIndex: hover.rowIndex ?? 0,
           columnIndex: sourceIndex,
@@ -370,7 +378,7 @@ export function createMarkdownTableDragLayer(context: MarkdownTableDragHandleCon
       const sourceBodyIndex = sourceIndex - 1;
       const targetBodyIndex = dropBoundary > sourceBodyIndex ? dropBoundary - 1 : dropBoundary;
       if (targetBodyIndex === sourceBodyIndex) return;
-      dispatchMarkdownTableStructureOperation(buildDispatchContext(), {
+      dispatchMarkdownTableStructureOperation(dispatchContext, {
         type: "move-row-to",
         rowIndex: sourceIndex,
         columnIndex: hover.columnIndex ?? 0,

--- a/packages/shared-ui/src/editor/markdown/features/table/tableWidget.ts
+++ b/packages/shared-ui/src/editor/markdown/features/table/tableWidget.ts
@@ -20,6 +20,7 @@ import {
 import { createMarkdownTableWindowController } from "./tableWindowController";
 import type { MarkdownInlinePreviewRenderer } from "../../shared/preview/markdownInlinePreviewPort";
 import { createMarkdownTableInlineViewportController } from "./tableInlineViewportController";
+import { getMappedWidgetSourceRange } from "../../shared/widgets/widgetDom";
 
 export class MarkdownTableWidget extends WidgetType {
   constructor(
@@ -72,6 +73,8 @@ export class MarkdownTableWidget extends WidgetType {
     wrapper.dataset.mdTableFrom = String(this.from);
     wrapper.dataset.mdTableExecution = this.execution.mode;
     wrapper.dataset.mdTableInlineViewport = "true";
+    const sourceLength = Math.max(0, this.to - this.from);
+    const getTableRange = () => getMappedWidgetSourceRange(view, wrapper, sourceLength);
     const rowCount = this.rows.length;
     // The semantic table model normalizes every row to the alignment width.
     // Do not rescan an oversized immutable row collection during DOM mount.
@@ -133,6 +136,7 @@ export class MarkdownTableWidget extends WidgetType {
           rowIndex,
           rows: this.rows,
           renderInlinePreview: this.renderInlinePreview,
+          getTableRange,
           tableFrom: this.from,
           tableTo: this.to,
           view,
@@ -198,12 +202,14 @@ export class MarkdownTableWidget extends WidgetType {
         className: "cm-md-table-add-row",
         label: localization.t("editor.table.addRow"),
         onActivate: () => {
+          const tableRange = getTableRange();
+          if (!tableRange) return;
           dispatchMarkdownTableStructureOperation({
             alignments: this.alignments,
             currentDraft: getActiveMarkdownTableCellDraft(wrapper),
             rows: this.rows,
-            tableFrom: this.from,
-            tableTo: this.to,
+            tableFrom: tableRange.from,
+            tableTo: tableRange.to,
             view,
           }, {
             type: "insert-row-below",
@@ -216,12 +222,14 @@ export class MarkdownTableWidget extends WidgetType {
         className: "cm-md-table-add-column",
         label: localization.t("editor.table.addColumn"),
         onActivate: () => {
+          const tableRange = getTableRange();
+          if (!tableRange) return;
           dispatchMarkdownTableStructureOperation({
             alignments: this.alignments,
             currentDraft: getActiveMarkdownTableCellDraft(wrapper),
             rows: this.rows,
-            tableFrom: this.from,
-            tableTo: this.to,
+            tableFrom: tableRange.from,
+            tableTo: tableRange.to,
             view,
           }, {
             type: "insert-column-right",
@@ -268,8 +276,7 @@ export class MarkdownTableWidget extends WidgetType {
       inlineViewport,
       rows: this.rows,
       table,
-      tableFrom: this.from,
-      tableTo: this.to,
+      getTableRange,
       view,
       wrapper,
     });

--- a/packages/shared-ui/src/editor/markdown/shared/widgets/widgetDom.ts
+++ b/packages/shared-ui/src/editor/markdown/shared/widgets/widgetDom.ts
@@ -9,6 +9,26 @@ export function hasPointerMoved(event: MouseEvent, pointerDown: { x: number; y: 
 }
 
 /**
+ * Resolve a mounted widget to its current document anchor.
+ *
+ * A DecorationSet maps the widget's range through transactions without
+ * mutating the immutable WidgetType that created its DOM. Interactive widgets
+ * must use this live anchor instead of constructor-time absolute offsets.
+ */
+export function getMappedWidgetPosition(
+  view: EditorView,
+  element: HTMLElement,
+): number | null {
+  if (!element.isConnected || !view.dom.contains(element)) return null;
+  try {
+    return view.posAtDOM(element, 0);
+  } catch {
+    // CodeMirror may detach a widget between pointer delivery and dispatch.
+    return null;
+  }
+}
+
+/**
  * Resolve a mounted replacement widget back to its current document range.
  *
  * CodeMirror maps decoration positions through every transaction, while a
@@ -21,16 +41,13 @@ export function getMappedWidgetSourceRange(
   element: HTMLElement,
   sourceLength: number,
 ): { from: number; to: number } | null {
-  try {
-    const from = view.posAtDOM(element, 0);
-    return {
-      from,
-      to: Math.min(view.state.doc.length, from + Math.max(0, sourceLength)),
-    };
-  } catch {
-    // CodeMirror may detach a widget between pointer delivery and dispatch.
-    return null;
-  }
+  const from = getMappedWidgetPosition(view, element);
+  return from === null
+    ? null
+    : {
+        from,
+        to: Math.min(view.state.doc.length, from + Math.max(0, sourceLength)),
+      };
 }
 
 export function normalizeLineEndings(value: string): string {

--- a/packages/shared-ui/src/editor/viewers/shared/TextEditorFrame.tsx
+++ b/packages/shared-ui/src/editor/viewers/shared/TextEditorFrame.tsx
@@ -277,8 +277,8 @@ export function TextEditorFrame({
     setMode(nextMode);
   }, [mode, sourceSnapshotMode]);
 
-  const setSourceModeEnabled = useCallback((enabled: boolean) => {
-    switchMode(enabled ? "source" : "live");
+  const setPaneMenuMode = useCallback((nextMode: string) => {
+    if (nextMode === "live" || nextMode === "source") switchMode(nextMode);
   }, [switchMode]);
 
   useLayoutEffect(() => {
@@ -292,11 +292,23 @@ export function TextEditorFrame({
       documentId,
       viewItems: [
         {
-          kind: "toggle",
-          id: "editor-source-mode",
-          label: sourceModeLabel ?? t("editor.mode.source"),
-          checked: mode === "source",
-          setChecked: setSourceModeEnabled,
+          kind: "segmented",
+          id: "editor-view-mode",
+          label: t("editor.mode.label"),
+          value: mode,
+          options: [
+            {
+              id: "live",
+              label: liveModeLabel ?? t("editor.mode.live"),
+              icon: liveModeIcon === "preview" ? <PreviewIcon /> : <PencilIcon />,
+            },
+            {
+              id: "source",
+              label: sourceModeLabel ?? t("editor.mode.source"),
+              icon: <CodeIcon />,
+            },
+          ],
+          setValue: setPaneMenuMode,
         },
       ],
     });
@@ -305,10 +317,12 @@ export function TextEditorFrame({
   }, [
     documentId,
     hideSourceView,
+    liveModeIcon,
+    liveModeLabel,
     mode,
     modeControlPlacement,
     publishPaneMenuContribution,
-    setSourceModeEnabled,
+    setPaneMenuMode,
     sourceModeLabel,
     t,
   ]);

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -335,6 +335,8 @@ export type {
   EditorPaneMenuCommand,
   EditorPaneMenuContribution,
   EditorPaneMenuItem,
+  EditorPaneMenuSegmentedControl,
+  EditorPaneMenuSegmentedOption,
   EditorPaneMenuToggle,
 } from "./editor/editorPaneMenuContribution";
 export { EditorSaveButton as SaveStatusButton } from "./editor/EditorSaveButton";

--- a/packages/shared-ui/src/styles/editor/csv-table-editor.css
+++ b/packages/shared-ui/src/styles/editor/csv-table-editor.css
@@ -576,7 +576,7 @@
   border: 1px solid var(--po-border);
   border-radius: 7px;
   background: color-mix(in srgb, var(--po-panel-raised) 96%, transparent);
-  box-shadow: 0 5px 18px color-mix(in srgb, var(--po-shadow) 18%, transparent);
+  box-shadow: var(--po-elevation-low);
   color: var(--po-text-muted);
   font-size: var(--po-editable-table-font-size);
   line-height: 1.2;

--- a/packages/shared-ui/src/styles/editor/editor-chrome.css
+++ b/packages/shared-ui/src/styles/editor/editor-chrome.css
@@ -34,7 +34,7 @@
   border: 1px solid var(--po-border);
   border-radius: 6px;
   background: var(--po-control);
-  box-shadow: 0 4px 12px var(--po-shadow);
+  box-shadow: var(--po-elevation-low);
 }
 
 .editor-mode-toggle button {

--- a/packages/shared-ui/src/styles/editor/editor-find.css
+++ b/packages/shared-ui/src/styles/editor/editor-find.css
@@ -23,9 +23,7 @@
   border-radius: 8px;
   background: color-mix(in srgb, var(--po-overlay) 88%, var(--po-panel-raised) 12%);
   color: var(--po-text-subtle);
-  box-shadow:
-    0 1px 2px color-mix(in srgb, var(--po-shadow) 18%, transparent),
-    0 8px 24px color-mix(in srgb, var(--po-shadow) 16%, transparent);
+  box-shadow: var(--po-elevation-low);
 }
 
 .editor-find-widget > svg {

--- a/packages/shared-ui/src/styles/editor/markdown-editor.css
+++ b/packages/shared-ui/src/styles/editor/markdown-editor.css
@@ -171,7 +171,7 @@
   border: 1px solid color-mix(in srgb, var(--po-border) 82%, transparent);
   border-radius: 7px;
   background: color-mix(in srgb, var(--po-panel) 98%, transparent);
-  box-shadow: 0 12px 32px rgba(47, 42, 35, 0.13);
+  box-shadow: var(--po-menu-shadow);
   color: var(--po-text);
   backdrop-filter: blur(12px);
 }

--- a/scripts/check-agent-activity-architecture.mjs
+++ b/scripts/check-agent-activity-architecture.mjs
@@ -46,7 +46,47 @@ for (const filePath of sourceFiles(path.join(root, "src", "features", "editor-wo
 requirePath("src/features/local-agents/ui/LocalAgentsSettingsView.tsx");
 requirePath("src/features/desktop-agent-presence/ui/AgentFileActivityAppearanceSetting.tsx");
 requirePath("src/features/desktop-agent-presence/ui/AgentFileActivityPermissionDialog.tsx");
+requirePath("electron/main/terminal-agent/activity/registration/cursor-cli-hook-config.mjs");
+requirePath("electron/main/terminal-agent/activity/bridge/shell-file-intent.mjs");
+requirePath("tests/fixtures/agent-activity/codex-0.147.0/pre-tool-use-bash-read.json");
+requirePath("tests/fixtures/agent-activity/codex-0.147.0/pre-tool-use-apply-patch-write.json");
+requirePath("tests/fixtures/agent-activity/README.md");
 requirePath("docs/architecture/desktop-agent/local-agents-and-file-activity.md");
+
+const activityFixtureRoot = path.join(root, "tests", "fixtures", "agent-activity");
+for (const filePath of files(activityFixtureRoot)) {
+  if (path.extname(filePath) !== ".json") continue;
+  const source = readFileSync(filePath, "utf8");
+  if (/(?:\/Users\/|\/home\/|[A-Za-z]:\\\\Users\\\\)/u.test(source)) {
+    errors.push(`${relative(filePath)} contains a developer home path; Agent fixtures must be synthetic`);
+  }
+  let fixture;
+  try {
+    fixture = JSON.parse(source);
+  } catch {
+    errors.push(`${relative(filePath)} is not valid JSON`);
+    continue;
+  }
+  for (const key of ["cwd", "workspace_root", "workspaceRoot", "project_root", "projectRoot"]) {
+    if (typeof fixture[key] === "string" && !fixture[key].startsWith("/workspace")) {
+      errors.push(`${relative(filePath)} must use a synthetic /workspace value for ${key}`);
+    }
+  }
+  if (fixture.transcript_path !== null && fixture.transcript_path !== undefined) {
+    errors.push(`${relative(filePath)} must not retain a transcript path`);
+  }
+  for (const key of [
+    "session_id",
+    "turn_id",
+    "tool_use_id",
+    "conversation_id",
+    "generation_id",
+  ]) {
+    if (typeof fixture[key] === "string" && !/(?:fixture|test)/u.test(fixture[key])) {
+      errors.push(`${relative(filePath)} must use a synthetic ${key}`);
+    }
+  }
+}
 const generalSettings = read("src/features/settings/main/GeneralSettingsView.tsx");
 if (/AgentActivity|agentFileActivity|localAgents/u.test(generalSettings)) {
   errors.push("General Settings must not own Agent activity enrollment");
@@ -96,6 +136,37 @@ if (/providerId|providers\.map|connection\.displayName|desktop-settings-switch/u
   errors.push("Agent file activity permission must remain one batch action, not per-Agent controls");
 }
 
+const hookRegistrationService = read("electron/main/terminal-agent/activity/registration/hook-registration-service.mjs");
+const cursorHookConfig = read("electron/main/terminal-agent/activity/registration/cursor-cli-hook-config.mjs");
+const bridgeInstaller = read("electron/main/terminal-agent/activity/registration/bridge-installer.mjs");
+const payloadProjector = read("electron/main/terminal-agent/activity/bridge/payload-projector.mjs");
+if (!hookRegistrationService.includes('{ providerId: "cursor", displayName: "Cursor Agent CLI", configurable: true }')
+    || !hookRegistrationService.includes('path.join(homedir, ".cursor", "hooks.json")')) {
+  errors.push("Cursor Agent CLI must remain an automatically configurable user-level Hook provider");
+}
+for (const eventName of ["preToolUse", "postToolUse", "postToolUseFailure", "sessionEnd"]) {
+  if (!cursorHookConfig.includes(`name: "${eventName}"`)) {
+    errors.push(`Cursor Agent CLI registration is missing ${eventName}`);
+  }
+}
+if (!cursorHookConfig.includes("writeOwnedJsonFileIfUnchanged")
+    || !cursorHookConfig.includes("AGENT_ACTIVITY_CONFIG_CONFLICT")) {
+  errors.push("Cursor Agent CLI registration must preserve compare-and-swap and owned-entry conflict safety");
+}
+if (!bridgeInstaller.includes('"shell-file-intent.mjs"')
+    || !bridgeInstaller.includes("async function isCurrent()")
+    || !bridgeInstaller.includes("async function ensureCurrent()")
+    || !hookRegistrationService.includes("await bridgeInstaller.ensureCurrent()")) {
+  errors.push("enrolled Terminal sessions must atomically refresh the complete Hook bridge before launch");
+}
+if (!payloadProjector.includes("projectShellReadPaths")
+    || !payloadProjector.includes("input.read_paths = shellReadPaths")) {
+  errors.push("the Hook bridge must project conservative literal shell reads at the provider edge");
+}
+if (/transcript_path|transcriptPath/u.test(payloadProjector)) {
+  errors.push("the Hook bridge must never treat Agent transcripts as an activity source");
+}
+
 if (errors.length > 0) {
   console.error("Agent activity architecture check failed:");
   errors.forEach((error) => console.error(`- ${error}`));
@@ -130,5 +201,13 @@ function* sourceFiles(directory) {
     const filePath = path.join(directory, entry);
     if (statSync(filePath).isDirectory()) yield* sourceFiles(filePath);
     else if (/\.(?:mjs|ts|tsx)$/u.test(entry)) yield filePath;
+  }
+}
+
+function* files(directory) {
+  for (const entry of readdirSync(directory)) {
+    const filePath = path.join(directory, entry);
+    if (statSync(filePath).isDirectory()) yield* files(filePath);
+    else yield filePath;
   }
 }

--- a/scripts/fixtures/markdown-pane-focus-continuity.tsx
+++ b/scripts/fixtures/markdown-pane-focus-continuity.tsx
@@ -4,6 +4,7 @@ import { EditorView } from "@codemirror/view";
 import { TestLocalizationProvider } from "@puppyone/localization/testing";
 import {
   EMPTY_EDITOR_GROUP,
+  EMPTY_MARKDOWN_WORKSPACE_ENVIRONMENT,
   activateEditorPane,
   assignEditorToActivePane,
   createEditorInput,
@@ -12,7 +13,6 @@ import {
   splitEditorPane,
   type DataNode,
   type DataPort,
-  type DataWorkspaceState,
 } from "@puppyone/shared-ui";
 import englishCatalog from "../../src/localization/catalog-loaders/en";
 import { DesktopEditorSplitView } from "../../src/features/editor-workbench/layout/DesktopEditorSplitView";
@@ -95,41 +95,6 @@ const dataPort: DataPort = {
     },
   },
 };
-const workspaceState: DataWorkspaceState = {
-  tree,
-  activePath: null,
-  activeNode: null,
-  selectedPaths: [],
-  selectedNodes: [],
-  currentFolderPath: null,
-  selectedFile: null,
-  loadingPath: null,
-  loadError: null,
-  rootLoading: false,
-  fileContent: null,
-  fileLoading: false,
-  fileError: null,
-  fileUrl: null,
-  fileUrlLoading: false,
-  fileUrlError: null,
-  markdownLinkGraph: {
-    documentCount: 0,
-    indexedDocumentCount: 0,
-    isIndexing: false,
-    resolveWikiLink: () => ({
-      exists: false,
-      ambiguous: false,
-      path: null,
-      name: "",
-      displayName: "",
-      target: "",
-    }),
-    resolveMarkdownLink: () => null,
-    getBacklinks: () => [],
-  },
-  markdownAssetUrlResolver: () => null,
-};
-
 function HorizontalMarkdownSplitFixture() {
   const [layout, setLayout] = useState(initialLayout);
   return (
@@ -139,9 +104,10 @@ function HorizontalMarkdownSplitFixture() {
         dataPort={dataPort}
         editorGroup={editorGroup}
         editorInteractionPreferences={{ showSaveStatus: false, markdownBlockDragEnabled: false }}
+        editorTree={tree}
         fileIconTheme="default"
         layout={layout}
-        state={workspaceState}
+        markdownEnvironment={EMPTY_MARKDOWN_WORKSPACE_ENVIRONMENT}
         workspace={{ id: "workspace", name: "Workspace", path: "/workspace", status: "recording" }}
         onClosePane={() => undefined}
         onFocusPane={(paneId) => setLayout((current) => activateEditorPane(current, paneId))}

--- a/scripts/patch-xterm-webgl-atlas.mjs
+++ b/scripts/patch-xterm-webgl-atlas.mjs
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const desktopRoot = path.resolve(path.dirname(scriptPath), "..");
+const bundlePaths = [
+  path.join(desktopRoot, "node_modules", "@xterm", "addon-webgl", "lib", "addon-webgl.js"),
+  path.join(desktopRoot, "node_modules", "@xterm", "addon-webgl", "lib", "addon-webgl.mjs"),
+  // Vite's optimizer hash does not include patched dependency contents. Patch
+  // an existing development cache as well so a local reinstall/restart cannot
+  // keep serving the pre-backport bundle.
+  path.join(desktopRoot, "node_modules", ".vite", "deps", "@xterm_addon-webgl.js"),
+];
+
+const generateMipmapPattern = /([A-Za-z_$][\w$]*)\.generateMipmap\(\1\.TEXTURE_2D\)/g;
+
+/**
+ * Backports xtermjs/xterm.js#5987 to the current stable WebGL addon.
+ *
+ * @xterm/addon-webgl 0.19 generates mipmaps for its glyph-atlas textures.
+ * Chromium/ANGLE can keep the context alive while returning corrupted atlas
+ * samples, so xterm's context-loss callback cannot recover. Upstream removed
+ * mipmaps and now uses ordinary linear filtering; keep this narrow transform
+ * until that change ships in a stable addon compatible with xterm 6.
+ */
+export function patchXtermWebglSource(source, sourceLabel = "xterm WebGL bundle") {
+  const matches = [...source.matchAll(generateMipmapPattern)];
+  if (matches.length === 0) {
+    const alreadyPatched = source.includes("TEXTURE_MIN_FILTER")
+      && source.includes("TEXTURE_MAG_FILTER")
+      && !source.includes("generateMipmap");
+    if (alreadyPatched) return { changed: false, source };
+    throw new Error(
+      `${sourceLabel} no longer matches the reviewed glyph-atlas patch. `
+      + "Review the installed @xterm/addon-webgl implementation before continuing.",
+    );
+  }
+  if (matches.length !== 1) {
+    throw new Error(`${sourceLabel} contains ${matches.length} generateMipmap calls; expected one.`);
+  }
+
+  const patchedSource = source.replace(generateMipmapPattern, (_call, gl) => (
+    `${gl}.texParameteri(${gl}.TEXTURE_2D,${gl}.TEXTURE_MIN_FILTER,${gl}.LINEAR),`
+    + `${gl}.texParameteri(${gl}.TEXTURE_2D,${gl}.TEXTURE_MAG_FILTER,${gl}.LINEAR)`
+  ));
+  return { changed: true, source: patchedSource };
+}
+
+export function patchInstalledXtermWebgl() {
+  for (const bundlePath of bundlePaths) {
+    if (!existsSync(bundlePath)) continue;
+    const source = readFileSync(bundlePath, "utf8");
+    const result = patchXtermWebglSource(source, path.relative(desktopRoot, bundlePath));
+    if (result.changed) writeFileSync(bundlePath, result.source);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  patchInstalledXtermWebgl();
+}

--- a/shared/agent-activity-contract/constants.d.mts
+++ b/shared/agent-activity-contract/constants.d.mts
@@ -1,0 +1,12 @@
+export const AGENT_ACTIVITY_SCHEMA_VERSION: 1;
+
+export const AGENT_ACTIVITY_LIMITS: Readonly<{
+  frameBytes: number;
+  pathLength: number;
+  providerIdLength: number;
+  stringLength: number;
+  targetsPerActivity: number;
+  activeClaimsPerWindow: number;
+  activeClaimLeaseMs: number;
+  completedLingerMs: number;
+}>;

--- a/shared/agent-activity-contract/constants.mjs
+++ b/shared/agent-activity-contract/constants.mjs
@@ -37,7 +37,7 @@ export const AGENT_ACTIVITY_LIMITS = Object.freeze({
   targetsPerActivity: 32,
   activeClaimsPerWindow: 256,
   activeClaimLeaseMs: 2 * 60 * 1000,
-  completedLingerMs: 1_600,
+  completedLingerMs: 4_000,
 });
 
 export function isAgentActivityPhase(value) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -444,35 +444,6 @@ function AppContent() {
   }, []);
 
   useEffect(() => {
-    if (!switcherOpen && !branchSwitcherOpen) return undefined;
-
-    const closeOnPointerDown = (event: PointerEvent) => {
-      const target = event.target;
-      if (target instanceof Node && switcherRef.current?.contains(target)) return;
-      if (target instanceof Node && branchSwitcherRef.current?.contains(target)) return;
-      if (
-        target instanceof Element
-        && target.closest('[data-titlebar-context-menu="true"]')
-      ) return;
-      setSwitcherOpen(false);
-      setBranchSwitcherOpen(false);
-    };
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setSwitcherOpen(false);
-        setBranchSwitcherOpen(false);
-      }
-    };
-
-    window.addEventListener("pointerdown", closeOnPointerDown, true);
-    window.addEventListener("keydown", closeOnEscape, true);
-    return () => {
-      window.removeEventListener("pointerdown", closeOnPointerDown, true);
-      window.removeEventListener("keydown", closeOnEscape, true);
-    };
-  }, [branchSwitcherOpen, branchSwitcherRef, setBranchSwitcherOpen, switcherOpen]);
-
-  useEffect(() => {
     setGitOperationError(null);
     setGitOperationLoading(null);
     setActiveSettingsSection("general");
@@ -825,6 +796,10 @@ function AppContent() {
     setBranchSwitcherOpen(false);
   }, [setBranchSwitcherOpen]);
 
+  const closeWorkspaceSwitcher = useCallback(() => {
+    setSwitcherOpen(false);
+  }, []);
+
   if (restoringWorkspace && !workspace) {
     return (
       <RestoringWorkspaceScreen
@@ -893,6 +868,7 @@ function AppContent() {
       workspaceSwitcherRef={switcherRef}
       onCheckoutBranch={handleCheckoutGitBranch}
       onGoHome={() => void goToHomepage()}
+      onCloseWorkspaceSwitcher={closeWorkspaceSwitcher}
       onOpenFolder={openFolder}
       onOpenWorkspaceSwitcherItem={openWorkspaceSwitcherItem}
       onCloseBranchSwitcher={closeBranchSwitcher}

--- a/src/ai-edits/ai-edits.css
+++ b/src/ai-edits/ai-edits.css
@@ -110,7 +110,7 @@
   border: 1px solid color-mix(in srgb, var(--po-border-subtle) 64%, transparent);
   border-radius: 8px;
   background: color-mix(in srgb, var(--po-panel) 78%, transparent);
-  box-shadow: 0 6px 18px rgba(47, 42, 35, 0.06);
+  box-shadow: var(--po-elevation-low);
   color: var(--po-text);
   pointer-events: auto;
   backdrop-filter: blur(12px);
@@ -197,7 +197,7 @@
   border: 1px solid color-mix(in srgb, var(--po-border) 70%, transparent);
   border-radius: 8px;
   background: color-mix(in srgb, var(--po-panel) 96%, transparent);
-  box-shadow: 0 18px 46px rgba(47, 42, 35, 0.16);
+  box-shadow: var(--po-menu-shadow);
   backdrop-filter: blur(14px);
 }
 

--- a/src/components/DesktopMenu.tsx
+++ b/src/components/DesktopMenu.tsx
@@ -14,6 +14,7 @@ function cx(...classes: Array<string | false | null | undefined>) {
 export type DesktopMenuSurfaceProps = HTMLAttributes<HTMLDivElement> & {
   ariaLabel?: string;
   className?: string;
+  elevation?: "default" | "compact";
   style?: CSSProperties;
 };
 
@@ -22,6 +23,7 @@ export const DesktopMenuSurface = forwardRef<HTMLDivElement, DesktopMenuSurfaceP
     ariaLabel,
     children,
     className,
+    elevation = "default",
     role = "menu",
     ...props
   },
@@ -35,6 +37,7 @@ export const DesktopMenuSurface = forwardRef<HTMLDivElement, DesktopMenuSurfaceP
       className={cx("desktop-menu-surface", className)}
       role={role}
       aria-label={ariaLabel}
+      data-menu-elevation={elevation === "compact" ? elevation : undefined}
       data-native-surface-occluder="true"
       data-po-scrollbar="menu"
       data-window-no-drag="true"

--- a/src/features/app-shell/DesktopHelpLauncher.tsx
+++ b/src/features/app-shell/DesktopHelpLauncher.tsx
@@ -295,71 +295,71 @@ export function DesktopHelpLauncher(overlayTheme: DesktopHelpLauncherProps) {
                           if (submissionState === "error") setSubmissionState("idle");
                         }}
                       />
+                    </div>
 
-                      <div className="desktop-feedback-composer-toolbar">
-                        <div className="desktop-feedback-attachment-slot">
-                          <input
-                            ref={fileInputRef}
-                            className="desktop-feedback-file-input"
-                            type="file"
-                            accept="image/png,image/jpeg,image/webp"
-                            tabIndex={-1}
-                            onChange={handleScreenshotInput}
-                          />
-                          {screenshot ? (
-                            <button
-                              className="desktop-feedback-screenshot"
-                              type="button"
-                              aria-label={t("shell.feedback.removeScreenshot")}
-                              title={t("shell.feedback.removeScreenshot")}
-                              disabled={submissionState === "sending" || submissionState === "sent"}
-                              onClick={() => {
-                                replaceScreenshot(null);
-                                setAttachmentError("");
-                                setAttachmentState("idle");
-                              }}
-                            >
-                              <img src={screenshot.previewUrl} alt="" />
-                              <span aria-hidden="true">
-                                <Trash2 size={12} strokeWidth={1.9} />
-                              </span>
-                            </button>
-                          ) : (
-                            <button
-                              className="desktop-feedback-attach"
-                              type="button"
-                              aria-label={t("shell.feedback.attachScreenshot")}
-                              title={t("shell.feedback.attachScreenshot")}
-                              disabled={
-                                attachmentState === "processing"
-                                || submissionState === "sending"
-                                || submissionState === "sent"
-                              }
-                              onClick={() => fileInputRef.current?.click()}
-                            >
-                              {attachmentState === "processing" ? (
-                                <LoaderCircle
-                                  className="desktop-feedback-spinner"
-                                  size={16}
-                                  strokeWidth={1.8}
-                                  aria-hidden="true"
-                                />
-                              ) : (
-                                <ImagePlus size={16} strokeWidth={1.7} aria-hidden="true" />
-                              )}
-                            </button>
-                          )}
-                          {attachmentState === "error" && attachmentError ? (
-                            <span
-                              className="desktop-feedback-attachment-error"
-                              role="img"
-                              aria-label={attachmentError}
-                              title={attachmentError}
-                            >
-                              <CircleAlert size={14} strokeWidth={1.8} aria-hidden="true" />
+                    <div className="desktop-feedback-attachment-row">
+                      <div className="desktop-feedback-attachment-slot">
+                        <input
+                          ref={fileInputRef}
+                          className="desktop-feedback-file-input"
+                          type="file"
+                          accept="image/png,image/jpeg,image/webp"
+                          tabIndex={-1}
+                          onChange={handleScreenshotInput}
+                        />
+                        {screenshot ? (
+                          <button
+                            className="desktop-feedback-screenshot"
+                            type="button"
+                            aria-label={t("shell.feedback.removeScreenshot")}
+                            title={t("shell.feedback.removeScreenshot")}
+                            disabled={submissionState === "sending" || submissionState === "sent"}
+                            onClick={() => {
+                              replaceScreenshot(null);
+                              setAttachmentError("");
+                              setAttachmentState("idle");
+                            }}
+                          >
+                            <img src={screenshot.previewUrl} alt="" />
+                            <span aria-hidden="true">
+                              <Trash2 size={12} strokeWidth={1.9} />
                             </span>
-                          ) : null}
-                        </div>
+                          </button>
+                        ) : (
+                          <button
+                            className="desktop-feedback-attach"
+                            type="button"
+                            aria-label={t("shell.feedback.attachScreenshot")}
+                            title={t("shell.feedback.attachScreenshot")}
+                            disabled={
+                              attachmentState === "processing"
+                              || submissionState === "sending"
+                              || submissionState === "sent"
+                            }
+                            onClick={() => fileInputRef.current?.click()}
+                          >
+                            {attachmentState === "processing" ? (
+                              <LoaderCircle
+                                className="desktop-feedback-spinner"
+                                size={16}
+                                strokeWidth={1.8}
+                                aria-hidden="true"
+                              />
+                            ) : (
+                              <ImagePlus size={16} strokeWidth={1.7} aria-hidden="true" />
+                            )}
+                          </button>
+                        )}
+                        {attachmentState === "error" && attachmentError ? (
+                          <span
+                            className="desktop-feedback-attachment-error"
+                            role="img"
+                            aria-label={attachmentError}
+                            title={attachmentError}
+                          >
+                            <CircleAlert size={14} strokeWidth={1.8} aria-hidden="true" />
+                          </span>
+                        ) : null}
                       </div>
                     </div>
                   </div>

--- a/src/features/app-shell/DesktopTitlebarContext.tsx
+++ b/src/features/app-shell/DesktopTitlebarContext.tsx
@@ -26,6 +26,7 @@ export function DesktopTitlebarContext({
   workspaceSwitcherRef,
   onCheckoutBranch,
   onCloseBranchSwitcher,
+  onCloseWorkspaceSwitcher,
   onGoHome,
   onOpenFolder,
   onOpenWorkspaceSwitcherItem,
@@ -51,6 +52,7 @@ export function DesktopTitlebarContext({
         titlebarLabel={workspaceTitlebarLabel}
         workspace={workspace}
         items={workspaceSwitcherItems}
+        onClose={onCloseWorkspaceSwitcher}
         onOpenFolder={onOpenFolder}
         onOpenItem={onOpenWorkspaceSwitcherItem}
         onGoHome={onGoHome}
@@ -90,6 +92,7 @@ type DesktopTitlebarContextProps = {
   workspaceSwitcherRef: RefObject<HTMLDivElement>;
   onCheckoutBranch: (branchName: string, remote: boolean) => Promise<boolean>;
   onCloseBranchSwitcher: () => void;
+  onCloseWorkspaceSwitcher: () => void;
   onGoHome: () => void;
   onOpenFolder: () => void;
   onOpenWorkspaceSwitcherItem: (item: DesktopWorkspaceSwitcherItem) => void;
@@ -151,6 +154,7 @@ function DesktopBranchSwitcher({
         anchorRef={refObject}
         className="desktop-branch-menu"
         gap={compact ? 8 : 4}
+        onDismiss={onDone}
         open={open && !disabled}
         preferredMaxHeight={440}
       >

--- a/src/features/app-shell/DesktopTitlebarMenuLayer.tsx
+++ b/src/features/app-shell/DesktopTitlebarMenuLayer.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactNode, RefObject } from "react";
+import { useEffect, type CSSProperties, type ReactNode, type RefObject } from "react";
 import { DesktopMenuSurface } from "../../components/DesktopMenu";
 import { DesktopOverlayLayer } from "./DesktopOverlayPortal";
 import { useAnchoredOverlayPosition } from "./useAnchoredOverlayPosition";
@@ -8,9 +8,12 @@ type DesktopTitlebarMenuLayerProps = {
   children: ReactNode;
   className: string;
   gap?: number;
+  onDismiss: () => void;
   open: boolean;
   preferredMaxHeight: number;
 };
+
+const TITLEBAR_CONTEXT_MENU_WIDTH = 300;
 
 /**
  * Keeps Header controls in the native chrome tree while rendering their
@@ -22,17 +25,46 @@ export function DesktopTitlebarMenuLayer({
   children,
   className,
   gap = 4,
+  onDismiss,
   open,
   preferredMaxHeight,
 }: DesktopTitlebarMenuLayerProps) {
-  const { setOverlayRef, overlayPosition } = useAnchoredOverlayPosition({
+  const { overlayRef, setOverlayRef, overlayPosition } = useAnchoredOverlayPosition({
     open,
     anchorRef,
-    preferredWidth: 360,
+    preferredWidth: TITLEBAR_CONTEXT_MENU_WIDTH,
     preferredMaxHeight,
     gap,
     margin: 8,
   });
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const isInsideMenu = (target: EventTarget | null) => target instanceof Node && Boolean(
+      anchorRef.current?.contains(target) || overlayRef.current?.contains(target),
+    );
+    const closeOnPointerDown = (event: PointerEvent) => {
+      if (!isInsideMenu(event.target)) onDismiss();
+    };
+    const closeOnFocusExit = (event: FocusEvent) => {
+      if (!isInsideMenu(event.target)) onDismiss();
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      onDismiss();
+      anchorRef.current?.querySelector<HTMLElement>('[aria-haspopup="menu"]')?.focus();
+    };
+
+    document.addEventListener("pointerdown", closeOnPointerDown, true);
+    document.addEventListener("focusin", closeOnFocusExit, true);
+    document.addEventListener("keydown", closeOnEscape, true);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnPointerDown, true);
+      document.removeEventListener("focusin", closeOnFocusExit, true);
+      document.removeEventListener("keydown", closeOnEscape, true);
+    };
+  }, [anchorRef, onDismiss, open, overlayRef]);
 
   if (!open) return null;
 
@@ -46,7 +78,7 @@ export function DesktopTitlebarMenuLayer({
     : {
         left: 0,
         top: 0,
-        width: 360,
+        width: TITLEBAR_CONTEXT_MENU_WIDTH,
         maxHeight: preferredMaxHeight,
         visibility: "hidden",
         pointerEvents: "none",

--- a/src/features/app-shell/DesktopWorkspaceSwitcher.tsx
+++ b/src/features/app-shell/DesktopWorkspaceSwitcher.tsx
@@ -25,6 +25,7 @@ type DesktopWorkspaceSwitcherProps = {
   titlebarLabel: string;
   workspace: Workspace;
   items: DesktopWorkspaceSwitcherItem[];
+  onClose: () => void;
   onOpenFolder: () => void;
   onOpenItem: (item: DesktopWorkspaceSwitcherItem) => void;
   onGoHome: () => void;
@@ -38,6 +39,7 @@ export function DesktopWorkspaceSwitcher({
   titlebarLabel,
   workspace,
   items,
+  onClose,
   onOpenFolder,
   onOpenItem,
   onGoHome,
@@ -79,6 +81,7 @@ export function DesktopWorkspaceSwitcher({
         anchorRef={refObject}
         className="desktop-project-menu"
         gap={compact ? 8 : 4}
+        onDismiss={onClose}
         open={open}
         preferredMaxHeight={520}
       >

--- a/src/features/app-shell/desktop-help-launcher.css
+++ b/src/features/app-shell/desktop-help-launcher.css
@@ -27,9 +27,7 @@
   border-radius: 999px;
   background: var(--po-panel-raised);
   color: var(--po-text-subtle);
-  box-shadow:
-    0 1px 4px color-mix(in srgb, var(--po-shadow) 16%, transparent),
-    0 0 0 0.5px color-mix(in srgb, var(--po-border) 44%, transparent);
+  box-shadow: none;
   opacity: 1;
   pointer-events: auto;
   cursor: var(--po-clickable-cursor, pointer);
@@ -38,8 +36,7 @@
     max-width 160ms cubic-bezier(0.2, 0.7, 0.2, 1),
     padding-inline-end 160ms cubic-bezier(0.2, 0.7, 0.2, 1),
     background-color 120ms ease,
-    color 120ms ease,
-    box-shadow 120ms ease;
+    color 120ms ease;
 }
 
 .desktop-help-launcher-icon-slot {
@@ -79,9 +76,7 @@
   padding-inline-end: var(--desktop-help-launcher-padding-end);
   background: var(--po-overlay);
   color: var(--po-text-muted);
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--po-divider) 58%, transparent),
-    0 2px 8px color-mix(in srgb, var(--po-shadow) 14%, transparent);
+  box-shadow: none;
   opacity: 1;
 }
 

--- a/src/features/app-shell/desktop-help-launcher.css
+++ b/src/features/app-shell/desktop-help-launcher.css
@@ -113,16 +113,8 @@
 }
 
 .desktop-feedback-header {
-  position: relative;
   align-items: center;
-  justify-content: center;
   padding-block-end: 10px;
-}
-
-.desktop-feedback-header .desktop-dialog-title-row {
-  width: 100%;
-  justify-content: center;
-  text-align: center;
 }
 
 .desktop-feedback-header .desktop-dialog-title-row h2 {
@@ -133,10 +125,7 @@
 }
 
 .desktop-feedback-close {
-  position: absolute;
-  inset-inline-end: 16px;
-  inset-block-start: 50%;
-  transform: translateY(-50%);
+  margin-inline-start: auto;
 }
 
 .desktop-feedback-form {
@@ -186,19 +175,17 @@
 
 .desktop-feedback-contact-input {
   width: 100%;
-  height: 34px;
+  height: 32px;
   box-sizing: border-box;
-  padding: 0 11px;
-  border: 1px solid var(--po-border);
-  border-radius: 8px;
+  padding: 0 9px;
+  border: 1px solid var(--po-divider);
+  border-radius: 6px;
   outline: 0;
-  background: var(--po-canvas);
+  background: var(--po-input, var(--po-panel-raised));
   color: var(--po-text);
   font: inherit;
   font-size: var(--po-text-size-body);
-  transition:
-    border-color 120ms ease,
-    box-shadow 120ms ease;
+  transition: border-color 120ms ease;
 }
 
 .desktop-feedback-contact-input::placeholder {
@@ -206,8 +193,7 @@
 }
 
 .desktop-feedback-contact-input:focus {
-  border-color: color-mix(in srgb, var(--po-accent) 38%, var(--po-border));
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--po-focus-ring) 48%, transparent);
+  border-color: var(--po-border-strong);
 }
 
 .desktop-feedback-contact-input[aria-invalid="true"] {
@@ -220,24 +206,19 @@
 }
 
 .desktop-feedback-composer {
-  display: flex;
-  min-height: 174px;
-  flex: 1 1 auto;
-  flex-direction: column;
+  min-height: 132px;
   overflow: hidden;
   margin: 0;
-  border: 1px solid var(--po-border);
-  border-radius: 10px;
-  background: var(--po-canvas);
+  border: 1px solid var(--po-divider);
+  border-radius: 6px;
+  background: var(--po-input, var(--po-panel-raised));
   transition:
     border-color 120ms ease,
-    background-color 120ms ease,
-    box-shadow 120ms ease;
+    background-color 120ms ease;
 }
 
 .desktop-feedback-composer:focus-within {
-  border-color: color-mix(in srgb, var(--po-accent) 38%, var(--po-border));
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--po-focus-ring) 48%, transparent);
+  border-color: var(--po-border-strong);
 }
 
 .desktop-feedback-composer[data-dragging="true"] {
@@ -246,12 +227,12 @@
 }
 
 .desktop-feedback-composer textarea {
+  display: block;
   width: 100%;
-  min-height: 108px;
+  min-height: 130px;
   box-sizing: border-box;
-  flex: 1 1 auto;
   resize: none;
-  padding: 12px 13px 4px;
+  padding: 10px 11px;
   border: 0;
   outline: 0;
   background: transparent;
@@ -270,13 +251,12 @@
   opacity: 0.74;
 }
 
-.desktop-feedback-composer-toolbar {
+.desktop-feedback-attachment-row {
   display: flex;
-  min-height: 38px;
-  align-items: flex-end;
+  min-height: 30px;
+  align-items: center;
   justify-content: flex-start;
-  gap: 10px;
-  padding: 3px 7px 7px 8px;
+  margin-block-start: 6px;
 }
 
 .desktop-feedback-attachment-slot {
@@ -393,14 +373,6 @@
 .desktop-feedback-submit {
   min-width: 78px;
   gap: 6px;
-  transition:
-    background-color 120ms ease,
-    color 120ms ease,
-    transform 100ms ease;
-}
-
-.desktop-feedback-submit:hover:not(:disabled) {
-  transform: translateY(-1px);
 }
 
 .desktop-feedback-submit[data-state="sent"] {

--- a/src/features/cloud/sections/access/styles/method-card.css
+++ b/src/features/cloud/sections/access/styles/method-card.css
@@ -289,7 +289,7 @@
   font-weight: 600;
   line-height: 1;
   white-space: nowrap;
-  box-shadow: 0 10px 24px color-mix(in srgb, var(--po-shadow) 30%, transparent);
+  box-shadow: none;
   cursor: var(--po-clickable-cursor, pointer);
   transform: translate(-50%, -50%);
   transition: background 0.14s ease, border-color 0.14s ease, color 0.14s ease, opacity 0.14s ease;

--- a/src/features/create-new/createEntryMenuRegistry.ts
+++ b/src/features/create-new/createEntryMenuRegistry.ts
@@ -1,0 +1,160 @@
+import type { DataNode } from "@puppyone/shared-ui";
+
+export const CREATE_NEW_ITEM_IDS = [
+  "markdown",
+  "contextMap",
+  "text",
+  "json",
+  "csv",
+  "html",
+  "slides",
+  "app",
+  "puppyflow",
+] as const;
+export type CreateNewItemId = typeof CREATE_NEW_ITEM_IDS[number];
+
+export type CreateEntryMenuItemKind = "folder" | CreateNewItemId;
+export type CreateEntryMenuGroup = "folder" | "primary" | "custom";
+
+export type CreateEntryMenuItemDefinition = Readonly<{
+  kind: CreateEntryMenuItemKind;
+  group: CreateEntryMenuGroup;
+  order: number;
+  defaultEnabled: boolean;
+  experimentalSetting?: "enableContextMaps" | "enablePuppyFlowFiles";
+  extension: string;
+  iconName: string;
+  iconType: DataNode["type"];
+}>;
+
+const CREATE_ENTRY_MENU_ITEM_REGISTRY = {
+  folder: {
+    kind: "folder",
+    group: "folder",
+    order: 0,
+    defaultEnabled: true,
+    extension: "",
+    iconName: "folder",
+    iconType: "folder",
+  },
+  markdown: {
+    kind: "markdown",
+    group: "primary",
+    order: 10,
+    defaultEnabled: true,
+    extension: ".md",
+    iconName: "Untitled.md",
+    iconType: "markdown",
+  },
+  csv: {
+    kind: "csv",
+    group: "primary",
+    order: 20,
+    defaultEnabled: true,
+    extension: ".csv",
+    iconName: "Untitled.csv",
+    iconType: "spreadsheet",
+  },
+  html: {
+    kind: "html",
+    group: "primary",
+    order: 30,
+    defaultEnabled: true,
+    extension: ".html",
+    iconName: "Untitled.html",
+    iconType: "html",
+  },
+  contextMap: {
+    kind: "contextMap",
+    group: "custom",
+    order: 10,
+    defaultEnabled: true,
+    experimentalSetting: "enableContextMaps",
+    extension: ".contextmap",
+    iconName: "Untitled.contextmap",
+    iconType: "context-map",
+  },
+  text: {
+    kind: "text",
+    group: "custom",
+    order: 20,
+    defaultEnabled: false,
+    extension: ".txt",
+    iconName: "Untitled.txt",
+    iconType: "text",
+  },
+  json: {
+    kind: "json",
+    group: "custom",
+    order: 30,
+    defaultEnabled: false,
+    extension: ".json",
+    iconName: "Untitled.json",
+    iconType: "json",
+  },
+  slides: {
+    kind: "slides",
+    group: "custom",
+    order: 40,
+    defaultEnabled: true,
+    extension: ".puppyoneapp",
+    iconName: "Untitled Slides.puppyoneapp",
+    iconType: "app",
+  },
+  app: {
+    kind: "app",
+    group: "custom",
+    order: 50,
+    defaultEnabled: false,
+    extension: ".puppyoneapp",
+    iconName: "Untitled.puppyoneapp",
+    iconType: "app",
+  },
+  puppyflow: {
+    kind: "puppyflow",
+    group: "custom",
+    order: 60,
+    defaultEnabled: false,
+    experimentalSetting: "enablePuppyFlowFiles",
+    extension: ".puppyflow",
+    iconName: "Untitled.puppyflow",
+    iconType: "workflow",
+  },
+} as const satisfies Record<CreateEntryMenuItemKind, CreateEntryMenuItemDefinition>;
+
+export const PRIMARY_CREATE_ENTRY_KINDS = CREATE_NEW_ITEM_IDS
+  .filter((kind) => CREATE_ENTRY_MENU_ITEM_REGISTRY[kind].group === "primary")
+  .sort((left, right) => (
+    CREATE_ENTRY_MENU_ITEM_REGISTRY[left].order - CREATE_ENTRY_MENU_ITEM_REGISTRY[right].order
+  ));
+
+export function getCreateEntryMenuItem(
+  kind: CreateEntryMenuItemKind,
+): CreateEntryMenuItemDefinition {
+  return CREATE_ENTRY_MENU_ITEM_REGISTRY[kind];
+}
+
+export function getDefaultCreateNewMenuItems(): Array<{
+  kind: CreateNewItemId;
+  enabled: true;
+}> {
+  return CREATE_NEW_ITEM_IDS.flatMap((kind) => (
+    CREATE_ENTRY_MENU_ITEM_REGISTRY[kind].defaultEnabled ? [{ kind, enabled: true }] : []
+  ));
+}
+
+export function getConfiguredCreateEntryMenuItems(
+  kinds: readonly CreateNewItemId[],
+  group: Exclude<CreateEntryMenuGroup, "folder">,
+): CreateEntryMenuItemDefinition[] {
+  const configuredKinds = new Set(kinds);
+  if (group === "primary") {
+    return PRIMARY_CREATE_ENTRY_KINDS
+      .filter((kind) => configuredKinds.has(kind))
+      .map((kind) => getCreateEntryMenuItem(kind));
+  }
+
+  return Array.from(configuredKinds)
+    .map((kind) => getCreateEntryMenuItem(kind))
+    .filter((item) => item.group === group);
+}

--- a/src/features/data-workspace/data-shell.css
+++ b/src/features/data-workspace/data-shell.css
@@ -401,7 +401,7 @@ body.data-sidebar-resizing * {
   font-size: 12px;
   font-weight: 620;
   line-height: 1.35;
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.22);
+  box-shadow: var(--po-elevation-low);
   pointer-events: none;
 }
 
@@ -419,7 +419,7 @@ body.data-sidebar-resizing * {
   font-size: 12px;
   font-weight: 620;
   line-height: 1.35;
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.22);
+  box-shadow: var(--po-elevation-low);
   pointer-events: none;
 }
 
@@ -576,9 +576,7 @@ body.data-sidebar-resizing * {
   padding: 0 4px;
   border-radius: 999px;
   background: var(--po-notification);
-  box-shadow:
-    0 0 0 1px var(--po-sidebar),
-    0 5px 12px color-mix(in srgb, var(--po-notification) 26%, transparent);
+  box-shadow: 0 0 0 1px var(--po-sidebar);
   color: var(--po-notification-text);
   font-size: 10px;
   font-style: normal;
@@ -610,10 +608,7 @@ body.data-sidebar-resizing * {
   border: 1px solid var(--desktop-git-bubble-border);
   border-radius: 999px;
   background: var(--desktop-git-bubble-bg);
-  box-shadow:
-    0 8px 18px color-mix(in srgb, var(--po-warning) 18%, transparent),
-    0 4px 12px color-mix(in srgb, var(--po-shadow) 24%, transparent),
-    inset 0 1px 0 color-mix(in srgb, var(--po-text-inverse) 22%, transparent);
+  box-shadow: var(--po-elevation-low);
   color: var(--desktop-git-bubble-text);
   font-size: 11.5px;
   font-weight: 680;

--- a/src/features/data-workspace/nodeActions.tsx
+++ b/src/features/data-workspace/nodeActions.tsx
@@ -1,6 +1,7 @@
-import { Fragment, type CSSProperties, type Dispatch, type ReactNode, type SetStateAction } from "react";
-import { useEffect, useMemo, useRef } from "react";
+import type { CSSProperties, Dispatch, ReactNode, SetStateAction } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  ChevronRight,
   ClipboardPaste,
   Copy,
   CopyPlus,
@@ -13,6 +14,7 @@ import {
   Plus,
   Scissors,
   Trash2,
+  Workflow,
 } from "lucide-react";
 import {
   createDefaultContextMapDocumentContent,
@@ -30,8 +32,14 @@ import { DesktopDialogCloseButton, DesktopDialogRoot } from "../../components/De
 import { DesktopMenuItem, DesktopMenuSeparator, DesktopMenuSurface } from "../../components/DesktopMenu";
 import type { CreateNewItemId, ExperimentalSettings } from "../../preferences";
 import { createUnconfiguredAppPreviewManifestContent } from "../../../shared/appPreviewManifest.js";
+import {
+  getConfiguredCreateEntryMenuItems,
+  getCreateEntryMenuItem,
+  type CreateEntryMenuItemDefinition,
+  type CreateEntryMenuItemKind,
+} from "../create-new/createEntryMenuRegistry";
 
-export type DesktopCreateEntryKind = "folder" | CreateNewItemId;
+export type DesktopCreateEntryKind = CreateEntryMenuItemKind;
 export type DesktopCreateEntryAnchor = {
   left: number;
   top: number;
@@ -73,67 +81,10 @@ export type DesktopNodeActionError = Readonly<
 const CREATE_ENTRY_MENU_MARGIN = 12;
 const CREATE_ENTRY_MENU_WIDTH = 184;
 const CREATE_ENTRY_MENU_ESTIMATED_HEIGHT = 112;
+const CREATE_ENTRY_SUBMENU_WIDTH = 184;
+const CREATE_ENTRY_SUBMENU_GAP = 4;
 const NODE_ACTION_MENU_WIDTH = 224;
 const NODE_ACTION_MENU_ESTIMATED_HEIGHT = 342;
-
-const CREATE_ENTRY_OPTIONS = [
-  {
-    kind: "folder",
-    iconName: "folder",
-    iconType: "folder",
-  },
-  {
-    kind: "markdown",
-    iconName: "Untitled.md",
-    iconType: "markdown",
-  },
-  {
-    kind: "contextMap",
-    iconName: "Untitled.contextmap",
-    iconType: "context-map",
-  },
-  {
-    kind: "text",
-    iconName: "Untitled.txt",
-    iconType: "text",
-  },
-  {
-    kind: "json",
-    iconName: "Untitled.json",
-    iconType: "json",
-  },
-  {
-    kind: "app",
-    iconName: "Untitled.puppyoneapp",
-    iconType: "app",
-  },
-  {
-    kind: "puppyflow",
-    iconName: "Untitled.puppyflow",
-    iconType: "workflow",
-  },
-  {
-    kind: "csv",
-    iconName: "Untitled.csv",
-    iconType: "spreadsheet",
-  },
-  {
-    kind: "html",
-    iconName: "Untitled.html",
-    iconType: "html",
-  },
-  {
-    kind: "slides",
-    iconName: "Untitled Slides.puppyoneapp",
-    iconType: "app",
-  },
-] as const satisfies Array<{
-  kind: DesktopCreateEntryKind;
-  iconName: string;
-  iconType: DataNode["type"];
-}>;
-
-type CreateEntryOption = (typeof CREATE_ENTRY_OPTIONS)[number];
 
 export function DesktopExplorerRowActions({
   node,
@@ -192,21 +143,73 @@ export function DesktopCreateEntryMenu({
 }) {
   const { t } = useLocalization();
   const menuRef = useRef<HTMLDivElement>(null);
-  const menuOptions = [
-    getCreateEntryOption("folder"),
-    ...Array.from(new Set(itemKinds)).map((kind) => getCreateEntryOption(kind)),
-  ];
+  const submenuCloseTimerRef = useRef<number | null>(null);
+  const suppressSubmenuFocusOpenRef = useRef(false);
+  const [customMenuOpen, setCustomMenuOpen] = useState(false);
+  const primaryOptions = getConfiguredCreateEntryMenuItems(itemKinds, "primary");
+  const customOptions = getConfiguredCreateEntryMenuItems(itemKinds, "custom");
   const sidebarLauncher = draft.anchor.placement === "auto-end";
   const menuWidth = sidebarLauncher
     ? Math.max(CREATE_ENTRY_MENU_WIDTH, draft.anchor.width)
     : CREATE_ENTRY_MENU_WIDTH;
-  const estimatedHeight = 8 + (menuOptions.length * 30) + (menuOptions.length > 1 ? 9 : 0);
+  const menuRowCount = 1 + primaryOptions.length + (customOptions.length > 0 ? 1 : 0);
+  const separatorCount = Number(primaryOptions.length > 0 || customOptions.length > 0)
+    + Number(primaryOptions.length > 0 && customOptions.length > 0);
+  const estimatedHeight = 8 + (menuRowCount * 30) + (separatorCount * 9);
   const position = getCreateEntryMenuPosition(draft.anchor, menuWidth, estimatedHeight);
+  const documentDirection = document.documentElement.dir === "rtl" ? "rtl" : "ltr";
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+  const logicalEndSpace = documentDirection === "rtl"
+    ? position.left - CREATE_ENTRY_MENU_MARGIN
+    : viewportWidth - (position.left + menuWidth) - CREATE_ENTRY_MENU_MARGIN;
+  const submenuSide = logicalEndSpace >= CREATE_ENTRY_SUBMENU_WIDTH + CREATE_ENTRY_SUBMENU_GAP
+    ? "end"
+    : "start";
   const menuStyle = {
     "--node-action-menu-left": `${position.left}px`,
     "--node-action-menu-top": `${position.top}px`,
     "--node-action-menu-width": `${menuWidth}px`,
   } as CSSProperties;
+
+  const clearSubmenuCloseTimer = () => {
+    if (submenuCloseTimerRef.current === null) return;
+    window.clearTimeout(submenuCloseTimerRef.current);
+    submenuCloseTimerRef.current = null;
+  };
+  const openCustomMenu = () => {
+    clearSubmenuCloseTimer();
+    setCustomMenuOpen(true);
+  };
+  const closeCustomMenu = () => {
+    clearSubmenuCloseTimer();
+    setCustomMenuOpen(false);
+  };
+  const scheduleCloseCustomMenu = () => {
+    clearSubmenuCloseTimer();
+    submenuCloseTimerRef.current = window.setTimeout(() => {
+      submenuCloseTimerRef.current = null;
+      setCustomMenuOpen(false);
+    }, 180);
+  };
+  const focusCustomMenu = () => {
+    openCustomMenu();
+    window.requestAnimationFrame(() => {
+      menuRef.current
+        ?.querySelector<HTMLButtonElement>(".desktop-create-entry-submenu button:not(:disabled)")
+        ?.focus();
+    });
+  };
+  const focusCustomMenuTrigger = () => {
+    const trigger = menuRef.current
+      ?.querySelector<HTMLButtonElement>(".desktop-create-entry-submenu-trigger");
+    if (!trigger) return;
+    if (document.activeElement === trigger) {
+      suppressSubmenuFocusOpenRef.current = false;
+      return;
+    }
+    suppressSubmenuFocusOpenRef.current = true;
+    trigger.focus();
+  };
 
   useEffect(() => {
     if (sidebarLauncher) return;
@@ -217,13 +220,35 @@ export function DesktopCreateEntryMenu({
   }, [sidebarLauncher]);
 
   useEffect(() => {
+    return () => clearSubmenuCloseTimer();
+  }, []);
+
+  useEffect(() => {
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target;
       if (target instanceof Node && menuRef.current?.contains(target)) return;
       onCancel();
     };
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onCancel();
+      if (event.key !== "Escape") return;
+      if (customMenuOpen) {
+        event.preventDefault();
+        if (submenuCloseTimerRef.current !== null) {
+          window.clearTimeout(submenuCloseTimerRef.current);
+          submenuCloseTimerRef.current = null;
+        }
+        setCustomMenuOpen(false);
+        const trigger = menuRef.current
+          ?.querySelector<HTMLButtonElement>(".desktop-create-entry-submenu-trigger");
+        if (trigger && document.activeElement !== trigger) {
+          suppressSubmenuFocusOpenRef.current = true;
+          trigger.focus();
+        } else {
+          suppressSubmenuFocusOpenRef.current = false;
+        }
+        return;
+      }
+      onCancel();
     };
     const handleViewportChange = () => onCancel();
 
@@ -237,7 +262,7 @@ export function DesktopCreateEntryMenu({
       window.removeEventListener("resize", handleViewportChange);
       window.removeEventListener("scroll", handleViewportChange, true);
     };
-  }, [onCancel]);
+  }, [customMenuOpen, onCancel]);
 
   return (
     <DesktopMenuSurface
@@ -250,16 +275,84 @@ export function DesktopCreateEntryMenu({
       onPointerDown={(event) => event.stopPropagation()}
       onClick={(event) => event.stopPropagation()}
     >
-      {menuOptions.map((option, index) => (
-        <Fragment key={option.kind}>
-          {index === 1 && <DesktopMenuSeparator />}
-          <DesktopNodeActionMenuItem
-            icon={<CreateEntryGlyph option={option} theme={fileIconTheme} />}
-            label={getCreateEntryOptionLabel(option.kind, t)}
-            onClick={() => onSelectKind(option.kind)}
-          />
-        </Fragment>
+      <DesktopNodeActionMenuItem
+        icon={<CreateEntryGlyph option={getCreateEntryMenuItem("folder")} theme={fileIconTheme} />}
+        label={getCreateEntryOptionLabel("folder", t)}
+        onClick={() => onSelectKind("folder")}
+      />
+      {(primaryOptions.length > 0 || customOptions.length > 0) && <DesktopMenuSeparator />}
+      {primaryOptions.map((option) => (
+        <DesktopNodeActionMenuItem
+          key={option.kind}
+          icon={<CreateEntryGlyph option={option} theme={fileIconTheme} />}
+          label={getCreateEntryOptionLabel(option.kind, t)}
+          onClick={() => onSelectKind(option.kind)}
+        />
       ))}
+      {primaryOptions.length > 0 && customOptions.length > 0 && <DesktopMenuSeparator />}
+      {customOptions.length > 0 && (
+        <div
+          className="desktop-create-entry-submenu-wrap"
+          data-open={customMenuOpen ? "true" : "false"}
+          data-submenu-side={submenuSide}
+          onPointerEnter={openCustomMenu}
+          onPointerLeave={scheduleCloseCustomMenu}
+          onFocus={() => {
+            if (suppressSubmenuFocusOpenRef.current) {
+              suppressSubmenuFocusOpenRef.current = false;
+              return;
+            }
+            openCustomMenu();
+          }}
+          onBlur={(event) => {
+            const relatedTarget = event.relatedTarget;
+            if (relatedTarget instanceof Node && event.currentTarget.contains(relatedTarget)) return;
+            scheduleCloseCustomMenu();
+          }}
+        >
+          <DesktopMenuItem
+            className="desktop-node-action-menu-item desktop-create-entry-submenu-trigger"
+            icon={<Workflow size={14} />}
+            label={t("workspace.node.customFiles")}
+            trailing={<ChevronRight className="po-directional-icon" size={14} />}
+            aria-controls="desktop-create-entry-custom-submenu"
+            aria-haspopup="menu"
+            aria-expanded={customMenuOpen}
+            onKeyDown={(event) => {
+              if (event.key !== "ArrowRight") return;
+              event.preventDefault();
+              event.stopPropagation();
+              focusCustomMenu();
+            }}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              openCustomMenu();
+            }}
+          />
+          <DesktopMenuSurface
+            id="desktop-create-entry-custom-submenu"
+            className="desktop-create-entry-submenu"
+            ariaLabel={t("workspace.node.createCustomFile")}
+            onKeyDown={(event) => {
+              if (event.key !== "ArrowLeft") return;
+              event.preventDefault();
+              event.stopPropagation();
+              closeCustomMenu();
+              focusCustomMenuTrigger();
+            }}
+          >
+            {customOptions.map((option) => (
+              <DesktopNodeActionMenuItem
+                key={option.kind}
+                icon={<CreateEntryGlyph option={option} theme={fileIconTheme} />}
+                label={getCreateEntryOptionLabel(option.kind, t)}
+                onClick={() => onSelectKind(option.kind)}
+              />
+            ))}
+          </DesktopMenuSurface>
+        </div>
+      )}
     </DesktopMenuSurface>
   );
 }
@@ -298,7 +391,7 @@ export function DesktopCreateEntryDialog({
 
   if (!selectedKind) return null;
 
-  const selectedOption = getCreateEntryOption(selectedKind);
+  const selectedOption = getCreateEntryMenuItem(selectedKind);
   const optionLabel = getCreateEntryOptionLabel(selectedKind, t);
   const errorMessage = formatDesktopNodeActionError(draft.error, t);
 
@@ -828,7 +921,7 @@ function CreateEntryGlyph({
   theme,
   size = 18,
 }: {
-  option: CreateEntryOption;
+  option: CreateEntryMenuItemDefinition;
   theme?: FileIconThemeId | null;
   size?: number;
 }) {
@@ -840,10 +933,6 @@ function CreateEntryGlyph({
       theme={theme}
     />
   );
-}
-
-function getCreateEntryOption(kind: DesktopCreateEntryKind): CreateEntryOption {
-  return CREATE_ENTRY_OPTIONS.find((option) => option.kind === kind) ?? CREATE_ENTRY_OPTIONS[0];
 }
 
 type DesktopFileTypeOption = {

--- a/src/features/desktop-agent-presence/application/agentActivityStore.ts
+++ b/src/features/desktop-agent-presence/application/agentActivityStore.ts
@@ -1,4 +1,5 @@
 import type { AgentActivityEvent } from "../../../../shared/agent-activity-contract/types";
+import { AGENT_ACTIVITY_LIMITS } from "../../../../shared/agent-activity-contract/constants.mjs";
 import type { AgentActivityClient } from "./agentActivityClient";
 import {
   normalizeWorkspaceRelativePath,
@@ -6,7 +7,7 @@ import {
   type AgentFilePresenceProjection,
 } from "../domain/agentActivity";
 
-const COMPLETION_LINGER_MS = 1_600;
+export const AGENT_FILE_ACTIVITY_COMPLETION_LINGER_MS = AGENT_ACTIVITY_LIMITS.completedLingerMs;
 
 export class AgentActivityStore {
   private readonly activities = new Map<string, AgentActivityEvent>();
@@ -54,7 +55,10 @@ export class AgentActivityStore {
     } else {
       this.activities.set(event.activityId, event);
       if (event.phase === "completed" || event.phase === "failed") {
-        const timer = setTimeout(() => this.remove(event.activityId), COMPLETION_LINGER_MS);
+        const timer = setTimeout(
+          () => this.remove(event.activityId),
+          AGENT_FILE_ACTIVITY_COMPLETION_LINGER_MS,
+        );
         this.removalTimers.set(event.activityId, timer);
       }
     }

--- a/src/features/desktop-agent-presence/domain/agentActivity.ts
+++ b/src/features/desktop-agent-presence/domain/agentActivity.ts
@@ -6,7 +6,7 @@ import type {
 const PROVIDER_LABELS: Readonly<Record<string, string>> = Object.freeze({
   codex: "Codex",
   claude: "Claude Code",
-  cursor: "Cursor Agent",
+  cursor: "Cursor Agent CLI",
   opencode: "OpenCode",
   pi: "Pi Agent",
   hermes: "Hermes Agent",
@@ -56,15 +56,23 @@ export function projectFilePresence(
 }
 
 export function toWorkspaceRelativePath(workspaceRoot: string, resourcePath: string) {
+  const resourceCandidate = String(resourcePath).replaceAll("\\", "/");
+  if (isUri(resourceCandidate)) return null;
+  if (!isAbsolutePath(resourceCandidate)) {
+    return normalizeWorkspaceRelativePath(resourceCandidate);
+  }
   const root = normalizeAbsolutePath(workspaceRoot).replace(/\/$/u, "");
-  const resource = normalizeAbsolutePath(resourcePath);
+  const resource = normalizeAbsolutePath(resourceCandidate);
   if (!root || resource === root || !resource.startsWith(`${root}/`)) return null;
   return normalizeWorkspaceRelativePath(resource.slice(root.length + 1));
 }
 
 export function normalizeWorkspaceRelativePath(value: string) {
   const normalized = String(value).replaceAll("\\", "/").replace(/^\.\//u, "");
-  return normalized && !normalized.startsWith("/") && !/(?:^|\/)\.\.(?:\/|$)/u.test(normalized)
+  return normalized
+    && !isAbsolutePath(normalized)
+    && !isUri(normalized)
+    && !/(?:^|\/)\.\.(?:\/|$)/u.test(normalized)
     ? normalized
     : null;
 }
@@ -81,4 +89,12 @@ function compareClaims(left: AgentFilePresenceClaim, right: AgentFilePresenceCla
 
 function normalizeAbsolutePath(value: string) {
   return String(value).replaceAll("\\", "/").replace(/\/{2,}/gu, "/");
+}
+
+function isAbsolutePath(value: string) {
+  return value.startsWith("/") || /^[A-Za-z]:\//u.test(value);
+}
+
+function isUri(value: string) {
+  return /^[A-Za-z][A-Za-z0-9+.-]*:\/\//u.test(value);
 }

--- a/src/features/desktop-agent-presence/ui/AgentFileActivityAppearanceSetting.tsx
+++ b/src/features/desktop-agent-presence/ui/AgentFileActivityAppearanceSetting.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useLocalization } from "@puppyone/localization";
+import { localAgentActivityProviderId } from "../../local-agents";
 import { AgentFileActivityPermissionDialog } from "./AgentFileActivityPermissionDialog";
 
 export function AgentFileActivityAppearanceSetting({
@@ -107,7 +108,7 @@ export async function reconcileNativeActivityHooks({
     const inventory = await desktop.discoverLocalAgentConnections({ rootPath: workspaceRoot, refresh: false });
     installedIds = new Set(inventory.connections
       .filter((connection) => connection.installation !== "not-found")
-      .map((connection) => connection.id));
+      .map((connection) => localAgentActivityProviderId(connection.id)));
   }
 
   const changed: Array<{ providerId: string; enabled: boolean }> = [];

--- a/src/features/desktop-agent-presence/ui/agent-file-presence.css
+++ b/src/features/desktop-agent-presence/ui/agent-file-presence.css
@@ -10,7 +10,7 @@
   border-radius: 999px;
   background: color-mix(in srgb, var(--po-panel) 88%, var(--agent-presence-accent));
   color: var(--po-text);
-  box-shadow: 0 4px 14px rgb(0 0 0 / 10%);
+  box-shadow: var(--po-elevation-low);
   font-size: 10px;
   font-weight: 600;
   line-height: 1;

--- a/src/features/desktop-terminal/runtime/terminalAppearance.ts
+++ b/src/features/desktop-terminal/runtime/terminalAppearance.ts
@@ -1,5 +1,12 @@
 import { Terminal, type ITheme } from "@xterm/xterm";
 
+export type TerminalRgbColor = [number, number, number];
+
+export type TerminalDefaultColors = {
+  foreground: TerminalRgbColor;
+  background: TerminalRgbColor;
+};
+
 export function readTerminalTheme(element: HTMLElement): ITheme {
   return {
     background: cssColor(
@@ -42,10 +49,19 @@ export function readTerminalTheme(element: HTMLElement): ITheme {
 }
 
 export function applyTerminalAppearance(terminal: Terminal, element: HTMLElement) {
-  terminal.options.theme = readTerminalTheme(element);
+  const theme = readTerminalTheme(element);
+  terminal.options.theme = theme;
   terminal.options.fontFamily = readTerminalFontFamily(element);
   terminal.options.fontSize = readTerminalFontSize(element);
   terminal.refresh(0, Math.max(0, terminal.rows - 1));
+  return terminalDefaultColorsFromTheme(theme);
+}
+
+export function terminalDefaultColorsFromTheme(theme: ITheme): TerminalDefaultColors {
+  return {
+    foreground: parseResolvedRgb(theme.foreground, [47, 42, 35]),
+    background: parseResolvedRgb(theme.background, [251, 250, 247]),
+  };
 }
 
 export function readTerminalFontFamily(element: HTMLElement) {
@@ -74,4 +90,15 @@ function resolveCssColor(element: HTMLElement, color: string) {
   const resolved = getComputedStyle(probe).color;
   probe.remove();
   return resolved || color;
+}
+
+function parseResolvedRgb(value: string | undefined, fallback: TerminalRgbColor): TerminalRgbColor {
+  if (typeof value !== "string") return fallback;
+  const match = value.match(
+    /^rgba?\(\s*([\d.]+)\s*[, ]\s*([\d.]+)\s*[, ]\s*([\d.]+)(?:\s*[,/]\s*[\d.]+)?\s*\)$/iu,
+  );
+  if (!match) return fallback;
+  const channels = match.slice(1, 4).map((channel) => Number(channel));
+  if (channels.some((channel) => !Number.isFinite(channel))) return fallback;
+  return channels.map((channel) => Math.min(Math.max(Math.round(channel), 0), 255)) as TerminalRgbColor;
 }

--- a/src/features/desktop-terminal/runtime/terminalRuntime.ts
+++ b/src/features/desktop-terminal/runtime/terminalRuntime.ts
@@ -11,6 +11,8 @@ import {
   readTerminalFontFamily,
   readTerminalFontSize,
   readTerminalTheme,
+  terminalDefaultColorsFromTheme,
+  type TerminalDefaultColors,
 } from "./terminalAppearance";
 import { TerminalActivityController } from "./terminalActivity";
 
@@ -77,6 +79,7 @@ export class TerminalRuntime implements TerminalRuntimeHandle {
   private scrollbarIdleTimer: number | null = null;
   private pendingPtySize: TerminalSize | null = null;
   private lastPtySize: TerminalSize | null = null;
+  private defaultColors: TerminalDefaultColors | null = null;
   private ptyReady = false;
   private pendingExit: TerminalExit | null = null;
   private active = false;
@@ -177,7 +180,7 @@ export class TerminalRuntime implements TerminalRuntimeHandle {
 
   applyAppearance() {
     if (this.disposed || !this.container || !this.terminal) return;
-    applyTerminalAppearance(this.terminal, this.container);
+    this.defaultColors = applyTerminalAppearance(this.terminal, this.container);
     this.scheduleFit();
   }
 
@@ -220,6 +223,7 @@ export class TerminalRuntime implements TerminalRuntimeHandle {
   }
 
   private initializeTerminal(container: HTMLDivElement) {
+    const theme = readTerminalTheme(container);
     const terminal = new Terminal({
       allowProposedApi: true,
       customGlyphs: true,
@@ -238,7 +242,7 @@ export class TerminalRuntime implements TerminalRuntimeHandle {
       },
       rescaleOverlappingGlyphs: true,
       scrollback: 6000,
-      theme: readTerminalTheme(container),
+      theme,
     });
     const fitAddon = new FitAddon();
     const unicode11Addon = new Unicode11Addon();
@@ -246,6 +250,7 @@ export class TerminalRuntime implements TerminalRuntimeHandle {
     this.terminal = terminal;
     this.fitAddon = fitAddon;
     this.unicode11Addon = unicode11Addon;
+    this.defaultColors = terminalDefaultColorsFromTheme(theme);
 
     terminal.loadAddon(fitAddon);
     terminal.loadAddon(unicode11Addon);
@@ -328,6 +333,7 @@ export class TerminalRuntime implements TerminalRuntimeHandle {
       cols: terminal.cols,
       rows: terminal.rows,
       launcherId: this.launcherId,
+      defaultColors: this.defaultColors ?? undefined,
     }).then((result) => {
       if (this.disposed) {
         void bridge.closeTerminal(result.id);

--- a/src/features/desktop-terminal/ui/TerminalCloseConfirmationDialog.tsx
+++ b/src/features/desktop-terminal/ui/TerminalCloseConfirmationDialog.tsx
@@ -5,6 +5,7 @@ import {
   DesktopDialogRoot,
   DesktopDialogSurface,
 } from "../../../components/DesktopDialog";
+import { DesktopOverlayLayer } from "../../app-shell/DesktopOverlayPortal";
 
 type TerminalCloseConfirmationDialogProps = {
   title: string;
@@ -21,54 +22,56 @@ export function TerminalCloseConfirmationDialog({
   const dialogTitle = t("terminal.closeDialog.title", { title });
 
   return (
-    <DesktopDialogRoot onClose={onCancel}>
-      <DesktopDialogSurface
-        width={420}
-        className="desktop-terminal-close-dialog"
-        ariaLabel={dialogTitle}
-      >
-        <header className="desktop-dialog-header">
-          <div className="desktop-dialog-title-row">
-            <span
-              className="desktop-dialog-leading desktop-terminal-close-dialog-leading"
-              aria-hidden="true"
-            >
-              <SquareTerminal size={17} strokeWidth={1.8} />
-            </span>
-            <div>
-              <h2>{dialogTitle}</h2>
+    <DesktopOverlayLayer>
+      <DesktopDialogRoot onClose={onCancel}>
+        <DesktopDialogSurface
+          width={420}
+          className="desktop-terminal-close-dialog"
+          ariaLabel={dialogTitle}
+        >
+          <header className="desktop-dialog-header">
+            <div className="desktop-dialog-title-row">
+              <span
+                className="desktop-dialog-leading desktop-terminal-close-dialog-leading"
+                aria-hidden="true"
+              >
+                <SquareTerminal size={17} strokeWidth={1.8} />
+              </span>
+              <div>
+                <h2>{dialogTitle}</h2>
+              </div>
             </div>
+            <DesktopDialogCloseButton
+              title={t("common.action.close")}
+              onClick={onCancel}
+            />
+          </header>
+
+          <div className="desktop-dialog-body" data-po-scrollbar="content">
+            <p className="desktop-terminal-close-dialog-detail">
+              {t("terminal.closeDialog.detail")}
+            </p>
           </div>
-          <DesktopDialogCloseButton
-            title={t("common.action.close")}
-            onClick={onCancel}
-          />
-        </header>
 
-        <div className="desktop-dialog-body" data-po-scrollbar="content">
-          <p className="desktop-terminal-close-dialog-detail">
-            {t("terminal.closeDialog.detail")}
-          </p>
-        </div>
-
-        <footer className="desktop-dialog-footer">
-          <button
-            className="desktop-dialog-button"
-            type="button"
-            data-desktop-dialog-initial-focus="true"
-            onClick={onCancel}
-          >
-            {t("common.action.cancel")}
-          </button>
-          <button
-            className="desktop-dialog-button desktop-terminal-close-dialog-confirm"
-            type="button"
-            onClick={onConfirm}
-          >
-            {t("terminal.closeDialog.confirm")}
-          </button>
-        </footer>
-      </DesktopDialogSurface>
-    </DesktopDialogRoot>
+          <footer className="desktop-dialog-footer">
+            <button
+              className="desktop-dialog-button"
+              type="button"
+              data-desktop-dialog-initial-focus="true"
+              onClick={onCancel}
+            >
+              {t("common.action.cancel")}
+            </button>
+            <button
+              className="desktop-dialog-button desktop-terminal-close-dialog-confirm"
+              type="button"
+              onClick={onConfirm}
+            >
+              {t("terminal.closeDialog.confirm")}
+            </button>
+          </footer>
+        </DesktopDialogSurface>
+      </DesktopDialogRoot>
+    </DesktopOverlayLayer>
   );
 }

--- a/src/features/editor-workbench/layout/DesktopEditorSplitView.tsx
+++ b/src/features/editor-workbench/layout/DesktopEditorSplitView.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useMemo,
   useState,
@@ -285,10 +286,21 @@ function EditorPane({
     ? editorNodeIndex.get(editor.resource) ?? null
     : null;
   const [findCommand, setFindCommand] = useState<EditorFindCommand | null>(null);
-  const [menuContribution, setMenuContribution] = useState<EditorPaneMenuContribution | null>(null);
+  const [menuContribution, setMenuContribution] = useState<Readonly<{
+    editorResource: string | null;
+    contribution: EditorPaneMenuContribution;
+  }> | null>(null);
+  const publishMenuContribution = useCallback((contribution: EditorPaneMenuContribution | null) => {
+    setMenuContribution(contribution
+      ? { editorResource: editor?.resource ?? null, contribution }
+      : null);
+  }, [editor?.resource]);
   const externalOpenPath = editor?.resource ?? null;
   const agentPresencePath = editor
     ? toWorkspaceRelativePath(workspace.path, editor.resource)
+    : null;
+  const paneMenuContribution = menuContribution?.editorResource === editor?.resource
+    ? menuContribution?.contribution ?? null
     : null;
 
   return (
@@ -303,7 +315,7 @@ function EditorPane({
       pane={pane}
       paneCount={paneCount}
       paneMove={paneMove}
-      menuContribution={menuContribution?.documentId === editor?.resource ? menuContribution : null}
+      menuContribution={paneMenuContribution}
       onActionsPaneChange={onOpenActionsPaneChange}
       onActivate={() => {
         if (!active) onFocusPane(pane.id);
@@ -328,7 +340,7 @@ function EditorPane({
         workspaceRoot={workspace.path}
         markdownDialect={workspace.markdownDialect}
         onFindCommandChange={setFindCommand}
-        onMenuContributionChange={setMenuContribution}
+        onMenuContributionChange={publishMenuContribution}
       />
     </EditorPaneShell>
   );

--- a/src/features/editor-workbench/layout/EditorPaneActionsMenu.tsx
+++ b/src/features/editor-workbench/layout/EditorPaneActionsMenu.tsx
@@ -32,6 +32,7 @@ import { DesktopOverlayLayer } from "../../app-shell/DesktopOverlayPortal";
 import { useAnchoredOverlayPosition } from "../../app-shell/useAnchoredOverlayPosition";
 
 const PANE_ACTIONS_MENU_WIDTH = 196;
+const PANE_ACTIONS_MENU_EXTENDED_WIDTH = 224;
 const PANE_ACTIONS_MENU_MAX_HEIGHT = 360;
 
 export type EditorPaneActionsMenuProps = Readonly<{
@@ -65,11 +66,14 @@ export function EditorPaneActionsMenu({
 }: EditorPaneActionsMenuProps) {
   const { t } = useLocalization();
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const preferredWidth = findCommand && onOpenExternal
+    ? PANE_ACTIONS_MENU_EXTENDED_WIDTH
+    : PANE_ACTIONS_MENU_WIDTH;
   const { setOverlayRef, overlayPosition } = useAnchoredOverlayPosition({
     open,
     anchorRef,
     boundarySelector: ".desktop-editor-split-view",
-    preferredWidth: PANE_ACTIONS_MENU_WIDTH,
+    preferredWidth,
     preferredMaxHeight: PANE_ACTIONS_MENU_MAX_HEIGHT,
     gap: 4,
     margin: 8,
@@ -141,7 +145,7 @@ export function EditorPaneActionsMenu({
     void action();
   };
   const viewItems = menuContribution?.viewItems ?? [];
-  const hasSecondaryActions = Boolean(findCommand || viewItems.length > 0);
+  const hasSecondaryActions = viewItems.length > 0;
   const openExternalLabel = externalOpenAppName
     ? t("editor.panes.openInApp", { app: externalOpenAppName })
     : t("editor.openDefaultApp");
@@ -155,7 +159,7 @@ export function EditorPaneActionsMenu({
     : {
         left: 0,
         top: 0,
-        width: PANE_ACTIONS_MENU_WIDTH,
+        width: preferredWidth,
         maxHeight: PANE_ACTIONS_MENU_MAX_HEIGHT,
         visibility: "hidden",
         pointerEvents: "none",
@@ -201,8 +205,17 @@ export function EditorPaneActionsMenu({
             onClick={() => runAndClose(() => onSplit("vertical", "second"))}
           />
           <div className="desktop-editor-pane-menu-end-actions">
-            {onOpenExternal && (
+            {(findCommand || onOpenExternal) && (
               <span className="desktop-editor-pane-menu-action-divider" aria-hidden="true" />
+            )}
+            {findCommand && (
+              <DesktopMenuIconButton
+                className="desktop-editor-pane-menu-primary-action desktop-editor-pane-menu-find-action"
+                icon={<Search size={15} strokeWidth={1.9} />}
+                label={t("editor.find.label")}
+                role="menuitem"
+                onClick={() => runAndClose(findCommand.open)}
+              />
             )}
             {onOpenExternal && (
               <DesktopMenuIconButton
@@ -224,31 +237,70 @@ export function EditorPaneActionsMenu({
         </div>
         {hasSecondaryActions && (
           <DesktopMenuSection className="desktop-editor-pane-menu-secondary-actions">
-            {findCommand && (
-              <DesktopMenuItem
-                icon={<Search size={14} strokeWidth={1.9} />}
-                label={t("editor.find.label")}
-                trailing="⌘F"
-                onClick={() => runAndClose(findCommand.open)}
-              />
-            )}
-            {viewItems.map((item) => item.kind === "toggle" ? (
-              <DesktopMenuItem
-                key={item.id}
-                icon={item.checked ? <Check size={14} strokeWidth={2} /> : <span />}
-                label={item.label}
-                role="menuitemcheckbox"
-                aria-checked={item.checked}
-                onClick={() => item.setChecked(!item.checked)}
-              />
-            ) : (
-              <DesktopMenuItem
-                key={item.id}
-                disabled={item.disabled}
-                label={item.label}
-                onClick={() => runAndClose(item.run)}
-              />
-            ))}
+            {viewItems.map((item) => {
+              if (item.kind === "toggle") {
+                return (
+                  <DesktopMenuItem
+                    key={item.id}
+                    icon={item.checked ? <Check size={14} strokeWidth={2} /> : <span />}
+                    label={item.label}
+                    role="menuitemcheckbox"
+                    aria-checked={item.checked}
+                    onClick={() => item.setChecked(!item.checked)}
+                  />
+                );
+              }
+              if (item.kind === "segmented") {
+                return (
+                  <div
+                    key={item.id}
+                    className="desktop-editor-pane-menu-segmented-control"
+                    role="group"
+                    aria-label={item.label}
+                  >
+                    {item.options.map((option, optionIndex) => {
+                      const selected = option.id === item.value;
+                      return (
+                        <button
+                          key={option.id}
+                          className="desktop-editor-pane-menu-segment"
+                          type="button"
+                          role="menuitemradio"
+                          aria-label={option.label}
+                          aria-checked={selected}
+                          title={option.label}
+                          onClick={() => item.setValue(option.id)}
+                          onKeyDown={(event) => {
+                            if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+                            event.preventDefault();
+                            const offset = event.key === "ArrowLeft" ? -1 : 1;
+                            const nextIndex = (
+                              optionIndex + offset + item.options.length
+                            ) % item.options.length;
+                            const nextOption = item.options[nextIndex];
+                            const buttons = event.currentTarget.parentElement?.querySelectorAll<
+                              HTMLButtonElement
+                            >(".desktop-editor-pane-menu-segment");
+                            buttons?.item(nextIndex).focus({ preventScroll: true });
+                            if (nextOption) item.setValue(nextOption.id);
+                          }}
+                        >
+                          {option.icon}
+                        </button>
+                      );
+                    })}
+                  </div>
+                );
+              }
+              return (
+                <DesktopMenuItem
+                  key={item.id}
+                  disabled={item.disabled}
+                  label={item.label}
+                  onClick={() => runAndClose(item.run)}
+                />
+              );
+            })}
           </DesktopMenuSection>
         )}
       </DesktopMenuSurface>

--- a/src/features/editor-workbench/layout/EditorPaneActionsMenu.tsx
+++ b/src/features/editor-workbench/layout/EditorPaneActionsMenu.tsx
@@ -34,7 +34,6 @@ const PANE_ACTION_SLOT_SIZE = 25;
 const PANE_ACTION_GAP = 3;
 const PANE_MENU_INLINE_CHROME = 10;
 const PANE_SEGMENT_GAP = 1;
-const PANE_SEGMENT_PADDING = 4;
 
 export type EditorPaneActionsMenuProps = Readonly<{
   anchorRef: RefObject<HTMLElement | null>;
@@ -315,7 +314,6 @@ function resolvePaneActionsMenuWidth({
   const segmentedWidth = (
     segmentCount * PANE_ACTION_SLOT_SIZE
     + Math.max(0, segmentCount - 1) * PANE_SEGMENT_GAP
-    + PANE_SEGMENT_PADDING
   );
   return (
     PANE_MENU_INLINE_CHROME

--- a/src/features/editor-workbench/layout/EditorPaneActionsMenu.tsx
+++ b/src/features/editor-workbench/layout/EditorPaneActionsMenu.tsx
@@ -30,6 +30,11 @@ import { useAnchoredOverlayPosition } from "../../app-shell/useAnchoredOverlayPo
 
 const PANE_ACTIONS_MENU_WIDTH = 196;
 const PANE_ACTIONS_MENU_MAX_HEIGHT = 360;
+const PANE_ACTION_SLOT_SIZE = 25;
+const PANE_ACTION_GAP = 3;
+const PANE_MENU_INLINE_CHROME = 10;
+const PANE_SEGMENT_GAP = 1;
+const PANE_SEGMENT_PADDING = 4;
 
 export type EditorPaneActionsMenuProps = Readonly<{
   anchorRef: RefObject<HTMLElement | null>;
@@ -61,11 +66,20 @@ export function EditorPaneActionsMenu({
 }: EditorPaneActionsMenuProps) {
   const { t } = useLocalization();
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const viewItems = menuContribution?.viewItems ?? [];
+  const segmentedControl = viewItems.find((item) => item.kind === "segmented") ?? null;
+  const hasSecondaryActions = viewItems.some((item) => item.kind !== "segmented");
+  const preferredWidth = resolvePaneActionsMenuWidth({
+    segmentedControl,
+    hasSecondaryActions,
+    hasFind: Boolean(findCommand),
+    hasExternalOpen: Boolean(onOpenExternal),
+  });
   const { setOverlayRef, overlayPosition } = useAnchoredOverlayPosition({
     open,
     anchorRef,
     boundarySelector: ".desktop-editor-split-view",
-    preferredWidth: PANE_ACTIONS_MENU_WIDTH,
+    preferredWidth,
     preferredMaxHeight: PANE_ACTIONS_MENU_MAX_HEIGHT,
     gap: 4,
     margin: 8,
@@ -136,9 +150,6 @@ export function EditorPaneActionsMenu({
     onCloseMenu();
     void action();
   };
-  const viewItems = menuContribution?.viewItems ?? [];
-  const segmentedControl = viewItems.find((item) => item.kind === "segmented") ?? null;
-  const hasSecondaryActions = viewItems.some((item) => item.kind !== "segmented");
   const openExternalLabel = externalOpenAppName
     ? t("editor.panes.openInApp", { app: externalOpenAppName })
     : t("editor.openDefaultApp");
@@ -152,7 +163,7 @@ export function EditorPaneActionsMenu({
     : {
         left: 0,
         top: 0,
-        width: PANE_ACTIONS_MENU_WIDTH,
+        width: preferredWidth,
         maxHeight: PANE_ACTIONS_MENU_MAX_HEIGHT,
         visibility: "hidden",
         pointerEvents: "none",
@@ -276,5 +287,40 @@ function PaneMenuSegmentedControl({
         );
       })}
     </div>
+  );
+}
+
+function resolvePaneActionsMenuWidth({
+  segmentedControl,
+  hasSecondaryActions,
+  hasFind,
+  hasExternalOpen,
+}: Readonly<{
+  segmentedControl: EditorPaneMenuSegmentedControl | null;
+  hasSecondaryActions: boolean;
+  hasFind: boolean;
+  hasExternalOpen: boolean;
+}>): number {
+  if (hasSecondaryActions) return PANE_ACTIONS_MENU_WIDTH;
+
+  const actionCount = 1 + Number(hasFind) + Number(hasExternalOpen);
+  const endItemCount = actionCount + Number(Boolean(segmentedControl));
+  const endActionsWidth = (
+    endItemCount * PANE_ACTION_SLOT_SIZE
+    + Math.max(0, endItemCount - 1) * PANE_ACTION_GAP
+  );
+  if (!segmentedControl) return PANE_MENU_INLINE_CHROME + endActionsWidth;
+
+  const segmentCount = segmentedControl.options.length;
+  const segmentedWidth = (
+    segmentCount * PANE_ACTION_SLOT_SIZE
+    + Math.max(0, segmentCount - 1) * PANE_SEGMENT_GAP
+    + PANE_SEGMENT_PADDING
+  );
+  return (
+    PANE_MENU_INLINE_CHROME
+    + segmentedWidth
+    + PANE_ACTION_GAP
+    + endActionsWidth
   );
 }

--- a/src/features/editor-workbench/layout/EditorPaneActionsMenu.tsx
+++ b/src/features/editor-workbench/layout/EditorPaneActionsMenu.tsx
@@ -175,6 +175,7 @@ export function EditorPaneActionsMenu({
       <DesktopMenuSurface
         ref={setMenuRef}
         className="desktop-editor-pane-menu"
+        elevation="compact"
         ariaLabel={editorLabel
           ? t("editor.panes.actionsFor", { name: editorLabel })
           : t("editor.panes.actions")}

--- a/src/features/editor-workbench/layout/EditorPaneActionsMenu.tsx
+++ b/src/features/editor-workbench/layout/EditorPaneActionsMenu.tsx
@@ -9,16 +9,13 @@ import { useLocalization } from "@puppyone/localization";
 import {
   Check,
   ExternalLink,
-  PanelBottom,
-  PanelLeft,
-  PanelRight,
-  PanelTop,
   Search,
   X,
 } from "lucide-react";
 import type {
   EditorFindCommand,
   EditorPaneMenuContribution,
+  EditorPaneMenuSegmentedControl,
   EditorPaneSplitOptions,
   EditorSplitDirection,
 } from "@puppyone/shared-ui";
@@ -32,7 +29,6 @@ import { DesktopOverlayLayer } from "../../app-shell/DesktopOverlayPortal";
 import { useAnchoredOverlayPosition } from "../../app-shell/useAnchoredOverlayPosition";
 
 const PANE_ACTIONS_MENU_WIDTH = 196;
-const PANE_ACTIONS_MENU_EXTENDED_WIDTH = 224;
 const PANE_ACTIONS_MENU_MAX_HEIGHT = 360;
 
 export type EditorPaneActionsMenuProps = Readonly<{
@@ -62,18 +58,14 @@ export function EditorPaneActionsMenu({
   onCloseMenu,
   onClosePane,
   onOpenExternal,
-  onSplit,
 }: EditorPaneActionsMenuProps) {
   const { t } = useLocalization();
   const menuRef = useRef<HTMLDivElement | null>(null);
-  const preferredWidth = findCommand && onOpenExternal
-    ? PANE_ACTIONS_MENU_EXTENDED_WIDTH
-    : PANE_ACTIONS_MENU_WIDTH;
   const { setOverlayRef, overlayPosition } = useAnchoredOverlayPosition({
     open,
     anchorRef,
     boundarySelector: ".desktop-editor-split-view",
-    preferredWidth,
+    preferredWidth: PANE_ACTIONS_MENU_WIDTH,
     preferredMaxHeight: PANE_ACTIONS_MENU_MAX_HEIGHT,
     gap: 4,
     margin: 8,
@@ -145,7 +137,8 @@ export function EditorPaneActionsMenu({
     void action();
   };
   const viewItems = menuContribution?.viewItems ?? [];
-  const hasSecondaryActions = viewItems.length > 0;
+  const segmentedControl = viewItems.find((item) => item.kind === "segmented") ?? null;
+  const hasSecondaryActions = viewItems.some((item) => item.kind !== "segmented");
   const openExternalLabel = externalOpenAppName
     ? t("editor.panes.openInApp", { app: externalOpenAppName })
     : t("editor.openDefaultApp");
@@ -159,7 +152,7 @@ export function EditorPaneActionsMenu({
     : {
         left: 0,
         top: 0,
-        width: preferredWidth,
+        width: PANE_ACTIONS_MENU_WIDTH,
         maxHeight: PANE_ACTIONS_MENU_MAX_HEIGHT,
         visibility: "hidden",
         pointerEvents: "none",
@@ -176,36 +169,9 @@ export function EditorPaneActionsMenu({
         style={menuStyle}
       >
         <div className="desktop-editor-pane-menu-primary-actions">
-          <DesktopMenuIconButton
-            className="desktop-editor-pane-menu-primary-action"
-            icon={<PanelLeft size={15} strokeWidth={1.8} />}
-            label={t("editor.panes.splitLeft")}
-            role="menuitem"
-            onClick={() => runAndClose(() => onSplit("horizontal", "first"))}
-          />
-          <DesktopMenuIconButton
-            className="desktop-editor-pane-menu-primary-action"
-            icon={<PanelRight size={15} strokeWidth={1.8} />}
-            label={t("editor.panes.splitRight")}
-            role="menuitem"
-            onClick={() => runAndClose(() => onSplit("horizontal", "second"))}
-          />
-          <DesktopMenuIconButton
-            className="desktop-editor-pane-menu-primary-action"
-            icon={<PanelTop size={15} strokeWidth={1.8} />}
-            label={t("editor.panes.splitUp")}
-            role="menuitem"
-            onClick={() => runAndClose(() => onSplit("vertical", "first"))}
-          />
-          <DesktopMenuIconButton
-            className="desktop-editor-pane-menu-primary-action"
-            icon={<PanelBottom size={15} strokeWidth={1.8} />}
-            label={t("editor.panes.splitDown")}
-            role="menuitem"
-            onClick={() => runAndClose(() => onSplit("vertical", "second"))}
-          />
+          {segmentedControl && <PaneMenuSegmentedControl item={segmentedControl} />}
           <div className="desktop-editor-pane-menu-end-actions">
-            {(findCommand || onOpenExternal) && (
+            {segmentedControl && (
               <span className="desktop-editor-pane-menu-action-divider" aria-hidden="true" />
             )}
             {findCommand && (
@@ -238,6 +204,7 @@ export function EditorPaneActionsMenu({
         {hasSecondaryActions && (
           <DesktopMenuSection className="desktop-editor-pane-menu-secondary-actions">
             {viewItems.map((item) => {
+              if (item.kind === "segmented") return null;
               if (item.kind === "toggle") {
                 return (
                   <DesktopMenuItem
@@ -248,48 +215,6 @@ export function EditorPaneActionsMenu({
                     aria-checked={item.checked}
                     onClick={() => item.setChecked(!item.checked)}
                   />
-                );
-              }
-              if (item.kind === "segmented") {
-                return (
-                  <div
-                    key={item.id}
-                    className="desktop-editor-pane-menu-segmented-control"
-                    role="group"
-                    aria-label={item.label}
-                  >
-                    {item.options.map((option, optionIndex) => {
-                      const selected = option.id === item.value;
-                      return (
-                        <button
-                          key={option.id}
-                          className="desktop-editor-pane-menu-segment"
-                          type="button"
-                          role="menuitemradio"
-                          aria-label={option.label}
-                          aria-checked={selected}
-                          title={option.label}
-                          onClick={() => item.setValue(option.id)}
-                          onKeyDown={(event) => {
-                            if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
-                            event.preventDefault();
-                            const offset = event.key === "ArrowLeft" ? -1 : 1;
-                            const nextIndex = (
-                              optionIndex + offset + item.options.length
-                            ) % item.options.length;
-                            const nextOption = item.options[nextIndex];
-                            const buttons = event.currentTarget.parentElement?.querySelectorAll<
-                              HTMLButtonElement
-                            >(".desktop-editor-pane-menu-segment");
-                            buttons?.item(nextIndex).focus({ preventScroll: true });
-                            if (nextOption) item.setValue(nextOption.id);
-                          }}
-                        >
-                          {option.icon}
-                        </button>
-                      );
-                    })}
-                  </div>
                 );
               }
               return (
@@ -305,5 +230,51 @@ export function EditorPaneActionsMenu({
         )}
       </DesktopMenuSurface>
     </DesktopOverlayLayer>
+  );
+}
+
+function PaneMenuSegmentedControl({
+  item,
+}: Readonly<{
+  item: EditorPaneMenuSegmentedControl;
+}>) {
+  return (
+    <div
+      className="desktop-editor-pane-menu-segmented-control"
+      role="group"
+      aria-label={item.label}
+    >
+      {item.options.map((option, optionIndex) => {
+        const selected = option.id === item.value;
+        return (
+          <button
+            key={option.id}
+            className="desktop-editor-pane-menu-segment"
+            type="button"
+            role="menuitemradio"
+            aria-label={option.label}
+            aria-checked={selected}
+            title={option.label}
+            onClick={() => item.setValue(option.id)}
+            onKeyDown={(event) => {
+              if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+              event.preventDefault();
+              const offset = event.key === "ArrowLeft" ? -1 : 1;
+              const nextIndex = (
+                optionIndex + offset + item.options.length
+              ) % item.options.length;
+              const nextOption = item.options[nextIndex];
+              const buttons = event.currentTarget.parentElement?.querySelectorAll<
+                HTMLButtonElement
+              >(".desktop-editor-pane-menu-segment");
+              buttons?.item(nextIndex).focus({ preventScroll: true });
+              if (nextOption) item.setValue(nextOption.id);
+            }}
+          >
+            {option.icon}
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/src/features/editor-workbench/layout/EditorPaneActionsMenu.tsx
+++ b/src/features/editor-workbench/layout/EditorPaneActionsMenu.tsx
@@ -34,6 +34,8 @@ const PANE_ACTION_SLOT_SIZE = 25;
 const PANE_ACTION_GAP = 3;
 const PANE_MENU_INLINE_CHROME = 10;
 const PANE_SEGMENT_GAP = 1;
+const PANE_DIVIDER_WIDTH = 1;
+const PANE_DIVIDER_INLINE_MARGIN = 3;
 
 export type EditorPaneActionsMenuProps = Readonly<{
   anchorRef: RefObject<HTMLElement | null>;
@@ -303,18 +305,22 @@ function resolvePaneActionsMenuWidth({
   if (hasSecondaryActions) return PANE_ACTIONS_MENU_WIDTH;
 
   const actionCount = 1 + Number(hasFind) + Number(hasExternalOpen);
-  const endItemCount = actionCount + Number(Boolean(segmentedControl));
-  const endActionsWidth = (
-    endItemCount * PANE_ACTION_SLOT_SIZE
-    + Math.max(0, endItemCount - 1) * PANE_ACTION_GAP
+  const actionsWidth = (
+    actionCount * PANE_ACTION_SLOT_SIZE
+    + Math.max(0, actionCount - 1) * PANE_ACTION_GAP
   );
-  if (!segmentedControl) return PANE_MENU_INLINE_CHROME + endActionsWidth;
+  if (!segmentedControl) return PANE_MENU_INLINE_CHROME + actionsWidth;
 
   const segmentCount = segmentedControl.options.length;
   const segmentedWidth = (
     segmentCount * PANE_ACTION_SLOT_SIZE
     + Math.max(0, segmentCount - 1) * PANE_SEGMENT_GAP
   );
+  const dividerWidth = (
+    PANE_DIVIDER_WIDTH
+    + PANE_DIVIDER_INLINE_MARGIN * 2
+  );
+  const endActionsWidth = dividerWidth + PANE_ACTION_GAP + actionsWidth;
   return (
     PANE_MENU_INLINE_CHROME
     + segmentedWidth

--- a/src/features/editor-workbench/layout/desktop-editor-split-view.css
+++ b/src/features/editor-workbench/layout/desktop-editor-split-view.css
@@ -260,6 +260,9 @@
   display: flex;
   align-items: center;
   gap: 3px;
+}
+
+.desktop-editor-pane-menu-segmented-control + .desktop-editor-pane-menu-end-actions {
   margin-inline-start: auto;
 }
 
@@ -297,14 +300,15 @@
 
 .desktop-editor-pane-menu-segmented-control {
   display: grid;
-  grid-auto-columns: 1fr;
+  grid-auto-columns: var(--desktop-editor-pane-menu-action-size);
   grid-auto-flow: column;
-  gap: 2px;
-  min-width: 0;
+  flex: 0 0 auto;
+  gap: 1px;
   padding: 2px;
-  border: 1px solid var(--po-divider);
-  border-radius: var(--desktop-toolbar-action-radius);
-  background: color-mix(in srgb, var(--po-control) 72%, transparent);
+  border: 0;
+  border-radius: calc(var(--desktop-toolbar-action-radius) + 1px);
+  background: color-mix(in srgb, var(--po-control) 78%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--po-divider) 82%, transparent);
 }
 
 .desktop-editor-pane-menu-segment {
@@ -330,8 +334,9 @@
 }
 
 .desktop-editor-pane-menu-segment[aria-checked="true"] {
-  background: var(--po-selected);
-  color: var(--po-text);
+  background: var(--desktop-titlebar-active, var(--po-selected));
+  color: var(--desktop-titlebar-text, var(--po-text));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--po-text-muted) 10%, transparent);
 }
 
 .desktop-editor-pane-content {

--- a/src/features/editor-workbench/layout/desktop-editor-split-view.css
+++ b/src/features/editor-workbench/layout/desktop-editor-split-view.css
@@ -235,6 +235,7 @@
   overflow-x: hidden;
   overflow-y: auto;
   padding: 4px;
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--po-shadow) 42%, transparent);
 }
 
 .desktop-editor-pane-menu-primary-actions {
@@ -267,19 +268,12 @@
 }
 
 .desktop-editor-pane-menu-action-divider {
-  display: grid;
-  width: var(--desktop-editor-pane-menu-action-size);
-  height: var(--desktop-editor-pane-menu-action-size);
-  flex: 0 0 var(--desktop-editor-pane-menu-action-size);
-  place-items: center;
-  pointer-events: none;
-}
-
-.desktop-editor-pane-menu-action-divider::before {
   width: 1px;
-  height: 12px;
+  height: 18px;
+  flex: 0 0 1px;
+  margin-inline: 3px;
   background: var(--po-divider);
-  content: "";
+  pointer-events: none;
 }
 
 .desktop-editor-pane-menu-close-action.desktop-menu-icon-button {

--- a/src/features/editor-workbench/layout/desktop-editor-split-view.css
+++ b/src/features/editor-workbench/layout/desktop-editor-split-view.css
@@ -302,13 +302,13 @@
   display: grid;
   grid-auto-columns: var(--desktop-editor-pane-menu-action-size);
   grid-auto-flow: column;
+  height: var(--desktop-editor-pane-menu-action-size);
   flex: 0 0 auto;
   gap: 1px;
-  padding: 2px;
+  padding: 0;
   border: 0;
-  border-radius: calc(var(--desktop-toolbar-action-radius) + 1px);
-  background: color-mix(in srgb, var(--po-control) 78%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--po-divider) 82%, transparent);
+  background: transparent;
+  box-shadow: none;
 }
 
 .desktop-editor-pane-menu-segment {
@@ -319,7 +319,7 @@
   place-items: center;
   padding: 0;
   border: 0;
-  border-radius: calc(var(--desktop-toolbar-action-radius) - 2px);
+  border-radius: var(--desktop-toolbar-action-radius);
   background: transparent;
   color: var(--desktop-titlebar-text-muted, var(--po-text-muted));
   cursor: var(--po-clickable-cursor, pointer);
@@ -336,7 +336,6 @@
 .desktop-editor-pane-menu-segment[aria-checked="true"] {
   background: var(--desktop-titlebar-active, var(--po-selected));
   color: var(--desktop-titlebar-text, var(--po-text));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--po-text-muted) 10%, transparent);
 }
 
 .desktop-editor-pane-content {

--- a/src/features/editor-workbench/layout/desktop-editor-split-view.css
+++ b/src/features/editor-workbench/layout/desktop-editor-split-view.css
@@ -195,7 +195,7 @@
   border: 0;
   border-radius: 2px;
   background: color-mix(in srgb, var(--po-canvas) 88%, transparent);
-  box-shadow: 0 10px 24px color-mix(in srgb, black 16%, transparent);
+  box-shadow: var(--po-elevation-popover);
   opacity: 0.88;
   pointer-events: none;
   will-change: transform;

--- a/src/features/editor-workbench/layout/desktop-editor-split-view.css
+++ b/src/features/editor-workbench/layout/desktop-editor-split-view.css
@@ -295,6 +295,45 @@
   border-top: 1px solid var(--po-divider);
 }
 
+.desktop-editor-pane-menu-segmented-control {
+  display: grid;
+  grid-auto-columns: 1fr;
+  grid-auto-flow: column;
+  gap: 2px;
+  min-width: 0;
+  padding: 2px;
+  border: 1px solid var(--po-divider);
+  border-radius: var(--desktop-toolbar-action-radius);
+  background: color-mix(in srgb, var(--po-control) 72%, transparent);
+}
+
+.desktop-editor-pane-menu-segment {
+  appearance: none;
+  display: grid;
+  height: var(--desktop-editor-pane-menu-action-size);
+  min-width: 0;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: calc(var(--desktop-toolbar-action-radius) - 2px);
+  background: transparent;
+  color: var(--desktop-titlebar-text-muted, var(--po-text-muted));
+  cursor: var(--po-clickable-cursor, pointer);
+  transition: background 0.1s ease, color 0.1s ease;
+}
+
+.desktop-editor-pane-menu-segment:hover,
+.desktop-editor-pane-menu-segment:focus-visible {
+  background: var(--desktop-titlebar-hover, var(--po-hover));
+  color: var(--desktop-titlebar-text, var(--po-text));
+  outline: none;
+}
+
+.desktop-editor-pane-menu-segment[aria-checked="true"] {
+  background: var(--po-selected);
+  color: var(--po-text);
+}
+
 .desktop-editor-pane-content {
   position: relative;
   z-index: 0;

--- a/src/features/editor-workbench/layout/desktop-editor-split-view.css
+++ b/src/features/editor-workbench/layout/desktop-editor-split-view.css
@@ -235,7 +235,6 @@
   overflow-x: hidden;
   overflow-y: auto;
   padding: 4px;
-  box-shadow: 0 2px 8px color-mix(in srgb, var(--po-shadow) 42%, transparent);
 }
 
 .desktop-editor-pane-menu-primary-actions {

--- a/src/features/editor-workbench/runtime/EditorPaneDocumentRuntime.tsx
+++ b/src/features/editor-workbench/runtime/EditorPaneDocumentRuntime.tsx
@@ -183,8 +183,12 @@ function samePaneEnvironment(
 
 function isMarkdownDocumentDescriptor(node: DataNode | null, resource: string | null): boolean {
   return node?.type === "markdown"
-    || node?.mimeType === "text/markdown"
+    || hasMimeType(node, "text/markdown")
     || /\.(?:md|markdown|mdx)$/i.test(node?.path ?? resource ?? "");
+}
+
+function hasMimeType(node: DataNode | null, expected: string): boolean {
+  return node?.mimeType?.split(";", 1)[0]?.trim().toLowerCase() === expected;
 }
 
 function sameDocumentRefresh(

--- a/src/features/editor-workbench/runtime/EditorPaneDocumentRuntime.tsx
+++ b/src/features/editor-workbench/runtime/EditorPaneDocumentRuntime.tsx
@@ -96,7 +96,10 @@ function RegularEditorPaneDocumentRuntime({
     listChildren: dataPort.listChildren,
     readFile: dataPort.readFile,
   }), [dataPort.listChildren, dataPort.readFile, refreshKey?.sequence]);
-  const hideSourceView = node?.type === "markdown" ? false : true;
+  const hideSourceView = !isMarkdownDocumentDescriptor(
+    node,
+    editor?.resource ?? null,
+  );
 
   return (
     <FilePreview

--- a/src/features/local-agents/index.ts
+++ b/src/features/local-agents/index.ts
@@ -4,5 +4,6 @@ export {
   installedLocalAgents,
   isLocalAgentEnabled,
   isLocalAgentRuntimeEnabled,
+  localAgentActivityProviderId,
   setLocalAgentEnabled,
 } from "./model/localAgentSelection";

--- a/src/features/local-agents/model/localAgentSelection.ts
+++ b/src/features/local-agents/model/localAgentSelection.ts
@@ -2,7 +2,12 @@ import type { AgentLocalConnection } from "../../../../shared/agent-contract/typ
 import type { LocalAgentsSettings } from "../../../preferences";
 
 const RUNTIME_ID_BY_LOCAL_AGENT_ID: Readonly<Record<string, string>> = {
+  "cursor-agent": "cursor",
   opencode: "opencode-native",
+};
+
+const ACTIVITY_PROVIDER_ID_BY_LOCAL_AGENT_ID: Readonly<Record<string, string>> = {
+  "cursor-agent": "cursor",
 };
 
 export function installedLocalAgents(connections: readonly AgentLocalConnection[]) {
@@ -30,4 +35,8 @@ export function enabledLocalAgentRuntimeIds(settings: LocalAgentsSettings) {
 
 export function isLocalAgentRuntimeEnabled(settings: LocalAgentsSettings, runtimeId: string) {
   return enabledLocalAgentRuntimeIds(settings).includes(runtimeId);
+}
+
+export function localAgentActivityProviderId(localAgentId: string) {
+  return ACTIVITY_PROVIDER_ID_BY_LOCAL_AGENT_ID[localAgentId] ?? localAgentId;
 }

--- a/src/features/plugins/plugins.css
+++ b/src/features/plugins/plugins.css
@@ -325,7 +325,7 @@
   border: 1px solid var(--po-border);
   border-radius: 7px;
   background: var(--po-overlay);
-  box-shadow: 0 10px 28px color-mix(in srgb, #000 20%, transparent);
+  box-shadow: var(--po-menu-shadow-compact);
 }
 
 .desktop-plugin-menu button {

--- a/src/features/settings/main/CreateNewSettingsView.tsx
+++ b/src/features/settings/main/CreateNewSettingsView.tsx
@@ -30,65 +30,12 @@ import {
   type CreateNewMenuSettings,
   type ExperimentalSettings,
 } from "../../../preferences";
+import { getCreateEntryMenuItem } from "../../create-new/createEntryMenuRegistry";
 import { SettingsSectionHeader } from "../components";
-
-type CreateNewTypeVisual = {
-  extension: string;
-  iconName: string;
-  iconType: DataNode["type"];
-};
 
 type DragTarget = {
   edge: "before" | "after";
   kind: CreateNewItemId;
-};
-
-const CREATE_NEW_TYPE_VISUALS: Record<CreateNewItemId, CreateNewTypeVisual> = {
-  markdown: {
-    extension: ".md",
-    iconName: "Untitled.md",
-    iconType: "markdown",
-  },
-  contextMap: {
-    extension: ".contextmap",
-    iconName: "Untitled.contextmap",
-    iconType: "context-map",
-  },
-  text: {
-    extension: ".txt",
-    iconName: "Untitled.txt",
-    iconType: "text",
-  },
-  json: {
-    extension: ".json",
-    iconName: "Untitled.json",
-    iconType: "json",
-  },
-  csv: {
-    extension: ".csv",
-    iconName: "Untitled.csv",
-    iconType: "spreadsheet",
-  },
-  html: {
-    extension: ".html",
-    iconName: "Untitled.html",
-    iconType: "html",
-  },
-  slides: {
-    extension: ".puppyoneapp",
-    iconName: "Untitled Slides.puppyoneapp",
-    iconType: "app",
-  },
-  app: {
-    extension: ".puppyoneapp",
-    iconName: "Untitled.puppyoneapp",
-    iconType: "app",
-  },
-  puppyflow: {
-    extension: ".puppyflow",
-    iconName: "Untitled.puppyflow",
-    iconType: "workflow",
-  },
 };
 
 export function CreateNewSettingsView({
@@ -254,7 +201,7 @@ export function CreateNewSettingsView({
 
                 <div className="desktop-create-new-file-list" role="list">
                   {settings.items.map((item, index) => {
-                    const visual = CREATE_NEW_TYPE_VISUALS[item.kind];
+                    const visual = getCreateEntryMenuItem(item.kind);
                     const label = t(`workspace.node.create.kind.${item.kind}.label`);
                     const available = isCreateNewItemAvailable(item.kind, experimentalSettings);
                     const dragBefore = dragTarget?.kind === item.kind && dragTarget.edge === "before";
@@ -369,7 +316,7 @@ export function CreateNewSettingsView({
                       ariaLabel={t("settings.createNew.addMenu")}
                     >
                       {addableKinds.map((kind) => {
-                        const visual = CREATE_NEW_TYPE_VISUALS[kind];
+                        const visual = getCreateEntryMenuItem(kind);
                         return (
                           <DesktopMenuItem
                             key={kind}

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -19,6 +19,12 @@ import {
   resolveRendererPublicAssetUrl,
   type PulseGridPresetId,
 } from "@puppyone/shared-ui";
+import {
+  CREATE_NEW_ITEM_IDS,
+  getCreateEntryMenuItem,
+  getDefaultCreateNewMenuItems,
+  type CreateNewItemId,
+} from "./features/create-new/createEntryMenuRegistry";
 
 export type { TypographyPreferences } from "./features/typography/fontCatalog";
 export {
@@ -32,6 +38,8 @@ export {
   resolveActiveThemeMode,
 };
 export type { InterfaceStyle, ThemeMode };
+export { CREATE_NEW_ITEM_IDS };
+export type { CreateNewItemId };
 
 export type LightThemePreset = "neutral" | "warm" | "graphite";
 export type DarkThemePreset = "default" | "warm" | "graphite";
@@ -98,18 +106,6 @@ export type ExperimentalSettings = {
 };
 
 export const CREATE_NEW_MENU_VERSION = 3 as const;
-export const CREATE_NEW_ITEM_IDS = [
-  "markdown",
-  "contextMap",
-  "text",
-  "json",
-  "csv",
-  "html",
-  "slides",
-  "app",
-  "puppyflow",
-] as const;
-export type CreateNewItemId = typeof CREATE_NEW_ITEM_IDS[number];
 export type CreateNewMenuItem = {
   kind: CreateNewItemId;
   enabled: boolean;
@@ -202,13 +198,7 @@ export const DEFAULT_EXPERIMENTAL_SETTINGS: ExperimentalSettings = {
 };
 export const DEFAULT_CREATE_NEW_MENU_SETTINGS: CreateNewMenuSettings = {
   version: CREATE_NEW_MENU_VERSION,
-  items: [
-    { kind: "markdown", enabled: true },
-    { kind: "contextMap", enabled: true },
-    { kind: "csv", enabled: true },
-    { kind: "html", enabled: true },
-    { kind: "slides", enabled: true },
-  ],
+  items: getDefaultCreateNewMenuItems(),
 };
 
 export const SIDEBAR_NAVIGATION_LAYOUT_OPTIONS = [
@@ -679,9 +669,8 @@ export function isCreateNewItemAvailable(
   kind: CreateNewItemId,
   experimentalSettings: ExperimentalSettings,
 ): boolean {
-  if (kind === "puppyflow") return experimentalSettings.enablePuppyFlowFiles;
-  if (kind === "contextMap") return experimentalSettings.enableContextMaps;
-  return true;
+  const experimentalSetting = getCreateEntryMenuItem(kind).experimentalSetting;
+  return !experimentalSetting || experimentalSettings[experimentalSetting];
 }
 
 function matchesEnabledCreateMenu(

--- a/src/styles/asset-library-home.css
+++ b/src/styles/asset-library-home.css
@@ -110,7 +110,7 @@
   border: 1px solid var(--po-border-subtle);
   border-radius: 8px;
   background: var(--po-overlay);
-  box-shadow: 0 10px 24px color-mix(in srgb, var(--po-shadow) 52%, transparent);
+  box-shadow: var(--po-menu-shadow);
 }
 
 .asset-library-home-create-menu button {
@@ -262,7 +262,7 @@
 .asset-library-card:focus-within .asset-library-card-main {
   border-color: var(--po-border-strong);
   background: var(--po-panel-raised);
-  box-shadow: 6px 7px 0 var(--po-shadow);
+  box-shadow: var(--po-elevation-low);
 }
 
 .asset-library-card-main:disabled {
@@ -466,7 +466,7 @@
   outline: none;
   border-color: var(--po-border-strong);
   background: color-mix(in srgb, var(--po-panel-raised) 32%, transparent);
-  box-shadow: 6px 7px 0 var(--po-shadow);
+  box-shadow: var(--po-elevation-low);
   color: var(--po-text);
   transform: translateY(-2px);
 }

--- a/src/styles/file-actions.css
+++ b/src/styles/file-actions.css
@@ -270,7 +270,7 @@
   border-radius: var(--desktop-sidebar-row-radius);
   background: color-mix(in srgb, var(--po-sidebar) 94%, var(--po-text) 6%);
   backdrop-filter: none;
-  box-shadow: 0 8px 22px color-mix(in srgb, var(--po-shadow) 38%, transparent);
+  box-shadow: var(--po-menu-shadow-compact);
 }
 
 .desktop-create-entry-menu[data-sidebar-launcher="true"] .desktop-menu-separator {

--- a/src/styles/file-actions.css
+++ b/src/styles/file-actions.css
@@ -259,6 +259,62 @@
   overflow: visible;
 }
 
+.desktop-create-entry-submenu-wrap {
+  position: relative;
+  min-width: 0;
+}
+
+/* Keep hover continuous across the visual gap between the two menu surfaces. */
+.desktop-create-entry-submenu-wrap::after {
+  position: absolute;
+  z-index: 1;
+  inset-block: -6px;
+  inset-inline-end: -10px;
+  display: none;
+  width: 14px;
+  content: "";
+}
+
+.desktop-create-entry-submenu-wrap[data-submenu-side="start"]::after {
+  inset-inline-start: -10px;
+  inset-inline-end: auto;
+}
+
+.desktop-create-entry-submenu-wrap[data-open="true"]::after {
+  display: block;
+}
+
+.desktop-create-entry-submenu-trigger .desktop-menu-item-trailing {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.86;
+}
+
+.desktop-create-entry-submenu {
+  position: absolute;
+  z-index: 2;
+  inset-block-start: -4px;
+  inset-inline-start: calc(100% + 4px);
+  display: none;
+  width: 184px;
+  max-width: calc(100vw - 24px);
+  max-height: calc(100vh - 24px);
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: var(--po-menu-padding);
+  font-size: 13px;
+}
+
+.desktop-create-entry-submenu-wrap[data-submenu-side="start"] > .desktop-create-entry-submenu {
+  inset-inline-start: auto;
+  inset-inline-end: calc(100% + 4px);
+}
+
+.desktop-create-entry-submenu-wrap[data-open="true"] > .desktop-create-entry-submenu {
+  display: block;
+}
+
 .desktop-create-entry-menu.desktop-node-action-menu[data-sidebar-launcher="true"] {
   --po-menu-item-height: var(--desktop-sidebar-row-height);
   --po-menu-item-padding-inline: var(--desktop-sidebar-row-content-left);

--- a/src/styles/menus.css
+++ b/src/styles/menus.css
@@ -11,6 +11,14 @@
   backdrop-filter: blur(20px);
 }
 
+.desktop-menu-surface[data-menu-elevation="compact"] {
+  --po-menu-shadow-compact: 0 2px 4px -2px
+    color-mix(in srgb, var(--po-shadow) 32%, transparent);
+  --interface-menu-box-shadow: var(--po-menu-shadow-compact);
+
+  box-shadow: var(--po-menu-shadow-compact);
+}
+
 .desktop-create-entry-menu.desktop-node-action-menu {
   border-color: var(--po-menu-border);
   border-radius: var(--po-menu-radius);

--- a/src/styles/menus.css
+++ b/src/styles/menus.css
@@ -12,8 +12,6 @@
 }
 
 .desktop-menu-surface[data-menu-elevation="compact"] {
-  --po-menu-shadow-compact: 0 2px 4px -2px
-    color-mix(in srgb, var(--po-shadow) 32%, transparent);
   --interface-menu-box-shadow: var(--po-menu-shadow-compact);
 
   box-shadow: var(--po-menu-shadow-compact);

--- a/src/styles/minimal-mode.css
+++ b/src/styles/minimal-mode.css
@@ -34,9 +34,7 @@
   border: 1px solid color-mix(in srgb, var(--po-menu-border) 82%, transparent);
   border-radius: 10px;
   background: color-mix(in srgb, var(--po-menu-bg) 94%, transparent);
-  box-shadow:
-    0 8px 26px color-mix(in srgb, var(--po-shadow) 22%, transparent),
-    0 1px 3px color-mix(in srgb, var(--po-shadow) 14%, transparent);
+  box-shadow: var(--po-elevation-low);
   color: var(--po-text);
   backdrop-filter: blur(18px) saturate(1.08);
   transform: translateX(-50%);
@@ -48,9 +46,7 @@
 .desktop-minimal-mode-dock[data-expanded="true"] {
   border-color: var(--po-menu-border);
   background: var(--po-menu-bg);
-  box-shadow:
-    0 12px 34px color-mix(in srgb, var(--po-shadow) 28%, transparent),
-    0 2px 7px color-mix(in srgb, var(--po-shadow) 18%, transparent);
+  box-shadow: var(--po-elevation-low);
 }
 
 .desktop-minimal-mode-logo,

--- a/src/styles/minimal-mode.css
+++ b/src/styles/minimal-mode.css
@@ -20,6 +20,7 @@
   --desktop-titlebar-active: var(--po-selected);
   --desktop-titlebar-focus: var(--po-focus-ring);
   --desktop-titlebar-control-height: var(--desktop-chrome-control-size);
+  --desktop-titlebar-button-gap: 2px;
 
   position: absolute;
   z-index: 90;
@@ -29,7 +30,7 @@
   min-width: 0;
   height: 34px;
   align-items: center;
-  gap: 2px;
+  gap: var(--desktop-titlebar-button-gap);
   padding: 2px;
   border: 1px solid color-mix(in srgb, var(--po-menu-border) 82%, transparent);
   border-radius: 10px;
@@ -110,7 +111,7 @@
   display: none;
   min-width: 0;
   align-items: center;
-  gap: 2px;
+  gap: var(--desktop-titlebar-button-gap);
 }
 
 .desktop-minimal-mode-dock:hover .desktop-minimal-mode-controls,
@@ -129,7 +130,7 @@
 
 .desktop-minimal-mode-context .desktop-titlebar-context {
   height: var(--desktop-chrome-control-size);
-  gap: 2px;
+  gap: var(--desktop-titlebar-button-gap);
 }
 
 .desktop-minimal-mode-context .desktop-titlebar-workspace-wrap,
@@ -160,7 +161,7 @@
 }
 
 .desktop-minimal-mode-titlebar-actions {
-  gap: 2px;
+  gap: var(--desktop-titlebar-button-gap);
 }
 
 .desktop-minimal-mode-titlebar-actions .desktop-titlebar-action {

--- a/src/styles/titlebar.css
+++ b/src/styles/titlebar.css
@@ -77,7 +77,7 @@
   height: 100%;
   min-width: 0;
   align-items: center;
-  gap: 0;
+  gap: var(--desktop-titlebar-button-gap);
 }
 
 .desktop-titlebar-context-item {
@@ -127,7 +127,7 @@
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
-  gap: 3px;
+  gap: var(--desktop-titlebar-button-gap);
   height: var(--desktop-titlebar-control-height);
   overflow: visible;
 }
@@ -397,7 +397,7 @@
   z-index: 80;
   top: calc(100% + 4px);
   inset-inline-start: 0;
-  width: min(360px, calc(100vw - 32px));
+  width: min(300px, calc(100vw - 16px));
   padding: 8px;
   border: 1px solid var(--po-menu-border);
   border-radius: var(--po-menu-radius);
@@ -528,6 +528,7 @@
  */
 @media (max-width: 720px) {
   .desktop-titlebar {
+    --desktop-titlebar-button-gap: 1px;
     gap: 2px;
     padding-inline-end: 4px;
   }
@@ -538,10 +539,6 @@
 
   .desktop-titlebar-context {
     overflow: hidden;
-  }
-
-  .desktop-titlebar-actions {
-    gap: 1px;
   }
 
   .desktop-titlebar-action-divider {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -8,6 +8,7 @@
   --desktop-chrome-control-size: 30px;
   --desktop-titlebar-control-height: 24px;
   --desktop-titlebar-tool-action-width: 34px;
+  --desktop-titlebar-button-gap: 3px;
   --desktop-sidebar-control-size: var(--desktop-chrome-control-size);
   --desktop-sidebar-nav-height: calc(var(--desktop-sidebar-control-size) + 8px);
   --desktop-sidebar-nav-padding: 4px;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -297,7 +297,12 @@
   --po-tree-guide: color-mix(in srgb, var(--po-sidebar) 94%, var(--po-text));
   --po-menu-bg: color-mix(in srgb, var(--po-overlay) 92%, var(--po-panel) 8%);
   --po-menu-border: color-mix(in srgb, var(--po-border) 82%, transparent);
-  --po-menu-shadow: 0 18px 44px color-mix(in srgb, var(--po-shadow) 86%, transparent);
+  --po-elevation-low: 0 2px 4px -2px
+    color-mix(in srgb, var(--po-shadow) 32%, transparent);
+  --po-elevation-popover: 0 3px 8px -4px
+    color-mix(in srgb, var(--po-shadow) 64%, transparent);
+  --po-menu-shadow-compact: var(--po-elevation-low);
+  --po-menu-shadow: var(--po-elevation-popover);
 }
 
 .dark {
@@ -420,7 +425,10 @@
   --po-scrollbar-thumb-hover: rgba(255, 255, 255, 0.16);
   --po-menu-bg: color-mix(in srgb, var(--po-overlay) 92%, var(--po-panel-raised) 8%);
   --po-menu-border: color-mix(in srgb, var(--po-border) 88%, transparent);
-  --po-menu-shadow: 0 18px 44px color-mix(in srgb, var(--po-shadow) 92%, transparent);
+  --po-elevation-low: 0 2px 4px -2px
+    color-mix(in srgb, var(--po-shadow) 28%, transparent);
+  --po-elevation-popover: 0 3px 8px -4px
+    color-mix(in srgb, var(--po-shadow) 36%, transparent);
 }
 
 :where(.app-shell, .onboarding-shell, .desktop-overlay-root, .desktop-theme-preview-surface)[data-light-theme-preset="warm"]:not(.dark) {

--- a/src/styles/utility-screens.css
+++ b/src/styles/utility-screens.css
@@ -115,7 +115,7 @@
   border-radius: 8px;
   background: color-mix(in srgb, var(--po-danger) 9%, var(--po-panel-raised));
   color: var(--po-danger);
-  box-shadow: 0 12px 30px rgba(73, 55, 35, 0.16);
+  box-shadow: var(--po-elevation-low);
   font-size: 13px;
   font-weight: 750;
 }

--- a/src/styles/window-chrome.css
+++ b/src/styles/window-chrome.css
@@ -26,3 +26,14 @@
 :where([data-window-no-drag="true"]) {
   -webkit-app-region: no-drag;
 }
+
+/*
+ * Native drag regions do not emit renderer pointer events. While a titlebar
+ * menu is present, temporarily return every chrome drag region to normal hit
+ * testing so clicks on empty Header space can dismiss the menu. Removing the
+ * Portal menu restores native window dragging without a second state owner.
+ */
+:where(body:has([data-titlebar-context-menu="true"]))
+  :where([data-window-drag-region="true"]) {
+  -webkit-app-region: no-drag;
+}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -360,6 +360,10 @@ export type TerminalCreateRequest = {
   cols: number;
   rows: number;
   launcherId?: DesktopTerminalLauncherId;
+  defaultColors?: {
+    foreground: [number, number, number];
+    background: [number, number, number];
+  };
 };
 
 export type TerminalAgentId = Exclude<DesktopTerminalLauncherId, "shell">;

--- a/tests/agentActivityStore.test.ts
+++ b/tests/agentActivityStore.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AgentActivityClient } from "../src/features/desktop-agent-presence/application/agentActivityClient";
-import { AgentActivityStore } from "../src/features/desktop-agent-presence/application/agentActivityStore";
+import {
+  AGENT_FILE_ACTIVITY_COMPLETION_LINGER_MS,
+  AgentActivityStore,
+} from "../src/features/desktop-agent-presence/application/agentActivityStore";
 import type { AgentActivityEvent } from "../shared/agent-activity-contract/types";
+import {
+  normalizeWorkspaceRelativePath,
+  toWorkspaceRelativePath,
+} from "../src/features/desktop-agent-presence/domain/agentActivity";
 
 describe("AgentActivityStore", () => {
   it("uses one native subscription and updates only affected path listeners", async () => {
@@ -46,6 +53,48 @@ describe("AgentActivityStore", () => {
     store.apply(event({ activityId: "write", providerId: "claude", operation: "file.write", phase: "cancelled" }));
     expect(store.getPathSnapshot("src/App.tsx")?.primary.kind).toBe("reading");
     store.dispose();
+  });
+
+  it("keeps a completed claim visible long enough to be perceived", () => {
+    vi.useFakeTimers();
+    const client: AgentActivityClient = {
+      subscribe: async () => ({ schemaVersion: 1, activities: [] }),
+      onEvent: () => () => undefined,
+      unsubscribe: () => undefined,
+    };
+    const store = new AgentActivityStore(client);
+    try {
+      store.apply(event({ phase: "started" }));
+      store.apply(event({ phase: "completed" }));
+      expect(store.getPathSnapshot("src/App.tsx")?.primary.phase).toBe("completed");
+      vi.advanceTimersByTime(AGENT_FILE_ACTIVITY_COMPLETION_LINGER_MS - 1);
+      expect(store.getPathSnapshot("src/App.tsx")).not.toBeNull();
+      vi.advanceTimersByTime(1);
+      expect(store.getPathSnapshot("src/App.tsx")).toBeNull();
+    } finally {
+      store.dispose();
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("Agent activity workspace path projection", () => {
+  it("uses the same key for relative Editor resources and absolute Explorer paths", () => {
+    const root = "/workspace/sample-project";
+    expect(toWorkspaceRelativePath(root, "notes.md")).toBe("notes.md");
+    expect(toWorkspaceRelativePath(root, "./notes/today.md")).toBe("notes/today.md");
+    expect(toWorkspaceRelativePath(root, `${root}/notes.md`)).toBe("notes.md");
+    expect(toWorkspaceRelativePath("C:\\workspace", "C:\\workspace\\src\\app.ts"))
+      .toBe("src/app.ts");
+  });
+
+  it("rejects resources that do not identify a workspace-relative file", () => {
+    const root = "/workspace/sample-project";
+    expect(toWorkspaceRelativePath(root, root)).toBeNull();
+    expect(toWorkspaceRelativePath(root, "/workspace/other-project/secret.md")).toBeNull();
+    expect(toWorkspaceRelativePath(root, "../secret.md")).toBeNull();
+    expect(toWorkspaceRelativePath(root, "file:///workspace/other-project/secret.md")).toBeNull();
+    expect(normalizeWorkspaceRelativePath("C:\\outside\\secret.md")).toBeNull();
   });
 });
 

--- a/tests/agentFileActivityAppearanceSetting.test.ts
+++ b/tests/agentFileActivityAppearanceSetting.test.ts
@@ -29,12 +29,13 @@ describe("Agent file activity Appearance setting", () => {
       getAgentActivityEnrollment: vi.fn(async () => enrollment([
         provider("codex", true, "not-configured"),
         provider("claude", true, "not-configured"),
-        provider("cursor", false, "basic-only"),
+        provider("cursor", true, "not-configured"),
       ])),
       discoverLocalAgentConnections: vi.fn(async () => ({
         connections: [
           localConnection("codex", "detected"),
           localConnection("claude", "not-found"),
+          localConnection("cursor-agent", "detected"),
         ],
         scannedAt: new Date(0).toISOString(),
         warnings: [],
@@ -44,8 +45,10 @@ describe("Agent file activity Appearance setting", () => {
 
     await reconcileNativeActivityHooks({ enabled: true, workspaceRoot: "/workspace" });
 
-    expect(setEnrollment).toHaveBeenCalledTimes(1);
-    expect(setEnrollment).toHaveBeenCalledWith({ providerId: "codex", enabled: true });
+    expect(setEnrollment.mock.calls).toEqual([
+      [{ providerId: "codex", enabled: true }],
+      [{ providerId: "cursor", enabled: true }],
+    ]);
   });
 
   it("removes every configurable Hook when the Appearance switch is disabled", async () => {

--- a/tests/agentFilePresence.test.tsx
+++ b/tests/agentFilePresence.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentActivityEvent } from "../shared/agent-activity-contract/types";
+import type { AgentActivityClient } from "../src/features/desktop-agent-presence/application/agentActivityClient";
+import { AgentActivityStore } from "../src/features/desktop-agent-presence/application/agentActivityStore";
+import { AgentFilePresence } from "../src/features/desktop-agent-presence/ui/AgentFilePresence";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let store: AgentActivityStore | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  store?.dispose();
+  root = null;
+  store = null;
+  document.body.replaceChildren();
+});
+
+describe("Agent file presence", () => {
+  it("renders the Codex eye for reads and the Agent hand for writes", () => {
+    const client: AgentActivityClient = {
+      subscribe: async () => ({ schemaVersion: 1, activities: [] }),
+      onEvent: () => () => undefined,
+      unsubscribe: () => undefined,
+    };
+    const activityStore = new AgentActivityStore(client);
+    store = activityStore;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root?.render(
+      <AgentFilePresence path="notes.md" store={activityStore} />,
+    ));
+
+    act(() => store?.apply(activity({
+      activityId: "read",
+      providerId: "codex",
+      operation: "file.read",
+      access: "read",
+    })));
+    expect(presence().textContent).toContain("Codex");
+    expect(presence().getAttribute("aria-label")).toBe("Codex is reading this file");
+    expect(presence().getAttribute("data-kind")).toBe("reading");
+    expect(presence().querySelector(".lucide-eye")).not.toBeNull();
+
+    act(() => store?.apply(activity({
+      activityId: "write",
+      providerId: "claude",
+      operation: "file.write",
+      access: "write",
+    })));
+    expect(presence().textContent).toContain("Claude Code");
+    expect(presence().getAttribute("aria-label")).toBe("Claude Code is writing this file");
+    expect(presence().getAttribute("data-kind")).toBe("writing");
+    expect(presence().querySelector(".lucide-hand")).not.toBeNull();
+  });
+});
+
+function presence() {
+  const element = document.querySelector<HTMLElement>(".desktop-agent-file-presence");
+  if (!element) throw new Error("missing Agent file presence");
+  return element;
+}
+
+function activity({
+  activityId,
+  providerId,
+  operation,
+  access,
+}: {
+  activityId: string;
+  providerId: string;
+  operation: "file.read" | "file.write";
+  access: "read" | "write";
+}): AgentActivityEvent {
+  return {
+    schemaVersion: 1,
+    eventId: `event-${activityId}`,
+    activityId,
+    providerId,
+    terminalSessionId: "terminal-1",
+    phase: "started",
+    operation,
+    targets: [{ workspaceRelativePath: "notes.md", access, confidence: "exact" }],
+    occurredAt: Date.now(),
+  };
+}

--- a/tests/ciElectronSmokeSandbox.test.mjs
+++ b/tests/ciElectronSmokeSandbox.test.mjs
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  new URL("../.github/workflows/ci.yml", import.meta.url),
+  "utf8",
+);
+const markdownFocusFixture = readFileSync(
+  new URL("../scripts/fixtures/markdown-pane-focus-continuity.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("CI Electron smoke sandbox boundary", () => {
+  it("limits the GitHub runner sandbox fallback to the Chromium smoke step", () => {
+    const jobEnvironment = workflow.slice(
+      workflow.indexOf("    env:"),
+      workflow.indexOf("    steps:"),
+    );
+    const smokeStep = readStep(
+      "Test MDI focus continuity in Chromium",
+      "Build",
+    );
+
+    expect(jobEnvironment).not.toContain("ELECTRON_DISABLE_SANDBOX");
+    expect(smokeStep).toContain('ELECTRON_DISABLE_SANDBOX: "1"');
+    expect(smokeStep).toContain(
+      "xvfb-run --auto-servernum npm run smoke:markdown-pane-focus-continuity",
+    );
+  });
+
+  it("keeps the smoke fixture on the current split-view input contract", () => {
+    expect(markdownFocusFixture).toContain("editorTree={tree}");
+    expect(markdownFocusFixture).toContain(
+      "markdownEnvironment={EMPTY_MARKDOWN_WORKSPACE_ENVIRONMENT}",
+    );
+    expect(markdownFocusFixture).not.toContain("state={workspaceState}");
+  });
+});
+
+function readStep(name, nextName) {
+  const start = workflow.indexOf(`      - name: ${name}`);
+  const end = workflow.indexOf(`\n      - name: ${nextName}`, start);
+  if (start < 0 || end < 0) {
+    throw new Error(`Unable to locate CI step ${name}`);
+  }
+  return workflow.slice(start, end);
+}

--- a/tests/createEntryMenu.test.tsx
+++ b/tests/createEntryMenu.test.tsx
@@ -52,40 +52,52 @@ describe("create entry menu", () => {
       .toBeLessThan(draft.anchor.top);
   });
 
-  it("offers Folder followed by Markdown, CSV, HTML, and Slides in the intended grouping", () => {
+  it("keeps Folder and the three core files in front of a hoverable Custom files submenu", () => {
     const onSelectKind = vi.fn();
     const container = render(
       <DesktopCreateEntryMenu
         draft={createDraft()}
-        itemKinds={["markdown", "csv", "html", "slides"]}
+        itemKinds={["contextMap", "html", "app", "markdown", "csv", "slides"]}
         onCancel={vi.fn()}
         onSelectKind={onSelectKind}
       />,
     );
     const menu = container.querySelector<HTMLElement>(".desktop-create-entry-menu");
     expect(menu).not.toBeNull();
-    expect(Array.from(menu?.children ?? [], (child) => (
-      child.classList.contains("desktop-menu-separator") ? "divider" : child.textContent?.trim()
-    ))).toEqual([
+    expect(readDirectMenuRows(menu)).toEqual([
       "Folder",
       "divider",
       "Markdown file",
       "CSV file",
       "HTML file",
-      "Slides",
+      "divider",
+      "Custom files",
     ]);
 
     expect(container.textContent).not.toContain("Paste");
     expect(container.textContent).not.toContain("Text file");
     expect(container.textContent).not.toContain("JSON file");
-    expect(container.textContent).not.toContain("Custom files");
+    const customMenuWrap = container.querySelector<HTMLElement>(".desktop-create-entry-submenu-wrap");
+    const customMenuTrigger = container.querySelector<HTMLButtonElement>(".desktop-create-entry-submenu-trigger");
+    expect(customMenuWrap?.dataset.open).toBe("false");
+    expect(Array.from(
+      container.querySelectorAll(".desktop-create-entry-submenu .desktop-menu-item-label"),
+      (label) => label.textContent?.trim(),
+    )).toEqual(["Context Map", "PuppyOne app", "Slides"]);
+
+    act(() => customMenuTrigger?.dispatchEvent(new PointerEvent("pointerover", { bubbles: true })));
+    expect(customMenuWrap?.dataset.open).toBe("true");
 
     act(() => Array.from(container.querySelectorAll<HTMLButtonElement>("button"))
       .find((button) => button.textContent?.trim() === "CSV file")?.click());
     expect(onSelectKind).toHaveBeenCalledWith("csv");
+
+    act(() => Array.from(container.querySelectorAll<HTMLButtonElement>("button"))
+      .find((button) => button.textContent?.trim() === "Context Map")?.click());
+    expect(onSelectKind).toHaveBeenCalledWith("contextMap");
   });
 
-  it("renders the configured file type order without adding hidden defaults", () => {
+  it("keeps configured custom types in the submenu without adding hidden defaults", () => {
     const container = render(
       <DesktopCreateEntryMenu
         draft={createDraft()}
@@ -95,17 +107,65 @@ describe("create entry menu", () => {
       />,
     );
 
-    expect(Array.from(
-      container.querySelector(".desktop-create-entry-menu")?.children ?? [],
-      (child) => child.classList.contains("desktop-menu-separator")
-        ? "divider"
-        : child.querySelector(".desktop-menu-item-label")?.textContent?.trim(),
-    )).toEqual([
+    expect(readDirectMenuRows(container.querySelector(".desktop-create-entry-menu"))).toEqual([
       "Folder",
       "divider",
-      "JSON file",
       "Markdown file",
+      "divider",
+      "Custom files",
     ]);
+    expect(container.querySelector(
+      ".desktop-create-entry-submenu .desktop-menu-item-label",
+    )?.textContent?.trim())
+      .toBe("JSON file");
+    expect(container.textContent).not.toContain("CSV file");
+    expect(container.textContent).not.toContain("HTML file");
+  });
+
+  it("opens the Custom files submenu away from the nearest viewport edge", () => {
+    const draft = createDraft();
+    draft.anchor = {
+      ...draft.anchor,
+      left: 980,
+      right: 1004,
+    };
+    const container = render(
+      <DesktopCreateEntryMenu
+        draft={draft}
+        itemKinds={["markdown", "contextMap"]}
+        onCancel={vi.fn()}
+        onSelectKind={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector<HTMLElement>(".desktop-create-entry-submenu-wrap")
+      ?.dataset.submenuSide).toBe("start");
+  });
+
+  it("opens Custom files from focus and returns to its trigger with ArrowLeft", () => {
+    const container = render(
+      <DesktopCreateEntryMenu
+        draft={createDraft()}
+        itemKinds={["markdown", "contextMap"]}
+        onCancel={vi.fn()}
+        onSelectKind={vi.fn()}
+      />,
+    );
+    const wrap = container.querySelector<HTMLElement>(".desktop-create-entry-submenu-wrap");
+    const trigger = container.querySelector<HTMLButtonElement>(".desktop-create-entry-submenu-trigger");
+    const customItem = container.querySelector<HTMLButtonElement>(
+      ".desktop-create-entry-submenu .desktop-menu-item",
+    );
+
+    act(() => trigger?.focus());
+    expect(wrap?.dataset.open).toBe("true");
+
+    act(() => {
+      customItem?.focus();
+      customItem?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    });
+    expect(wrap?.dataset.open).toBe("false");
+    expect(document.activeElement).toBe(trigger);
   });
 
   it("does not render a divider when Folder is the only configured item", () => {
@@ -155,6 +215,15 @@ function render(element: React.ReactElement) {
   root = createRoot(container);
   act(() => root?.render(withTestLocalization(element)));
   return container;
+}
+
+function readDirectMenuRows(menu: Element | null): Array<string | undefined> {
+  return Array.from(menu?.children ?? [], (child) => {
+    if (child.classList.contains("desktop-menu-separator")) return "divider";
+    return child.querySelector(".desktop-menu-item-label")
+      ?.textContent
+      ?.trim();
+  });
 }
 
 function createDraft(): DesktopCreateEntryDraft {

--- a/tests/createEntryMenuRegistry.test.ts
+++ b/tests/createEntryMenuRegistry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { CREATE_NEW_ITEM_IDS } from "../src/preferences";
+import {
+  getDefaultCreateNewMenuItems,
+  getConfiguredCreateEntryMenuItems,
+  getCreateEntryMenuItem,
+  PRIMARY_CREATE_ENTRY_KINDS,
+} from "../src/features/create-new/createEntryMenuRegistry";
+
+describe("create entry menu registry", () => {
+  it("covers every configurable item and keeps the primary group ordered centrally", () => {
+    expect(PRIMARY_CREATE_ENTRY_KINDS).toEqual(["markdown", "csv", "html"]);
+    expect(CREATE_NEW_ITEM_IDS.map((kind) => getCreateEntryMenuItem(kind).kind))
+      .toEqual(CREATE_NEW_ITEM_IDS);
+    expect(getDefaultCreateNewMenuItems()).toEqual([
+      { kind: "markdown", enabled: true },
+      { kind: "contextMap", enabled: true },
+      { kind: "csv", enabled: true },
+      { kind: "html", enabled: true },
+      { kind: "slides", enabled: true },
+    ]);
+  });
+
+  it("derives menu groups without losing the configured custom order", () => {
+    const configured = ["app", "html", "contextMap", "markdown", "csv"] as const;
+
+    expect(getConfiguredCreateEntryMenuItems(configured, "primary").map((item) => item.kind))
+      .toEqual(["markdown", "csv", "html"]);
+    expect(getConfiguredCreateEntryMenuItems(configured, "custom").map((item) => item.kind))
+      .toEqual(["app", "contextMap"]);
+  });
+});

--- a/tests/csvTitlebarSettings.test.tsx
+++ b/tests/csvTitlebarSettings.test.tsx
@@ -91,12 +91,8 @@ describe("CSV pane-menu settings", () => {
     const primaryActions = menu?.querySelectorAll<HTMLButtonElement>(
       ".desktop-editor-pane-menu-primary-action",
     );
-    expect(primaryActions).toHaveLength(7);
+    expect(primaryActions).toHaveLength(3);
     expect(Array.from(primaryActions ?? []).map((item) => item.getAttribute("aria-label"))).toEqual([
-      "Split editor left",
-      "Split editor right",
-      "Split editor up",
-      "Split editor down",
       "Find in file",
       "Open in Numbers",
       "Close editor pane",
@@ -109,7 +105,8 @@ describe("CSV pane-menu settings", () => {
     expect(menu?.querySelector('[aria-label="Find in file"]')).not.toBeNull();
     expect(menu?.textContent).toContain("Header row");
     expect(menu?.textContent).toContain("Row numbers");
-    expect(document.activeElement?.getAttribute("aria-label")).toBe("Split editor left");
+    expect(menu?.querySelector(".desktop-editor-pane-menu-action-divider")).toBeNull();
+    expect(document.activeElement?.getAttribute("aria-label")).toBe("Find in file");
 
     await act(async () => document.activeElement?.dispatchEvent(new KeyboardEvent("keydown", {
       key: "End",
@@ -120,7 +117,7 @@ describe("CSV pane-menu settings", () => {
       key: "Home",
       bubbles: true,
     })));
-    expect(document.activeElement?.getAttribute("aria-label")).toBe("Split editor left");
+    expect(document.activeElement?.getAttribute("aria-label")).toBe("Find in file");
 
     const toggles = menu?.querySelectorAll<HTMLButtonElement>('[role="menuitemcheckbox"]');
     expect(toggles).toHaveLength(2);
@@ -223,7 +220,6 @@ describe("CSV pane-menu settings", () => {
     const group = openEditor(EMPTY_EDITOR_GROUP, createEditorInput(path));
     const openExternal = vi.fn();
     const closePane = vi.fn();
-    const splitPane = vi.fn();
     const container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -248,7 +244,7 @@ describe("CSV pane-menu settings", () => {
         onMovePane={vi.fn()}
         onOpenAtPaneEdge={vi.fn()}
         onResizeSplit={vi.fn()}
-        onSplitPane={splitPane}
+        onSplitPane={vi.fn()}
       />,
     )));
 
@@ -259,30 +255,12 @@ describe("CSV pane-menu settings", () => {
 
     expect(menu.dataset.hasSecondary).toBeUndefined();
     expect(menu.textContent).toBe("");
-    expect(actions).toHaveLength(6);
+    expect(actions).toHaveLength(2);
     expect(actions.map((item) => item.getAttribute("aria-label"))).toEqual([
-      "Split editor left",
-      "Split editor right",
-      "Split editor up",
-      "Split editor down",
       "Open in default app",
       "Close editor pane",
     ]);
     expect(menu.querySelector(".desktop-menu-section")).toBeNull();
-
-    const splitCases = [
-      ["Split editor left", "horizontal", "first"],
-      ["Split editor right", "horizontal", "second"],
-      ["Split editor up", "vertical", "first"],
-      ["Split editor down", "vertical", "second"],
-    ] as const;
-    for (const [label, direction, placement] of splitCases) {
-      const splitAction = document.querySelector<HTMLButtonElement>(`[aria-label="${label}"]`);
-      await act(async () => splitAction?.click());
-      expect(splitPane).toHaveBeenLastCalledWith("editor-pane-1", direction, placement);
-      expect(document.querySelector(".desktop-editor-pane-menu")).toBeNull();
-      await openPaneMenu(handle);
-    }
 
     const closeAction = document.querySelector<HTMLButtonElement>(
       '[aria-label="Close editor pane"]',

--- a/tests/csvTitlebarSettings.test.tsx
+++ b/tests/csvTitlebarSettings.test.tsx
@@ -91,12 +91,13 @@ describe("CSV pane-menu settings", () => {
     const primaryActions = menu?.querySelectorAll<HTMLButtonElement>(
       ".desktop-editor-pane-menu-primary-action",
     );
-    expect(primaryActions).toHaveLength(6);
+    expect(primaryActions).toHaveLength(7);
     expect(Array.from(primaryActions ?? []).map((item) => item.getAttribute("aria-label"))).toEqual([
       "Split editor left",
       "Split editor right",
       "Split editor up",
       "Split editor down",
+      "Find in file",
       "Open in Numbers",
       "Close editor pane",
     ]);
@@ -104,7 +105,8 @@ describe("CSV pane-menu settings", () => {
       "desktop-editor-pane-menu-close-action",
     )).toBe(true);
     expect(Array.from(primaryActions ?? []).every((item) => item.textContent === "")).toBe(true);
-    expect(menu?.textContent).toContain("Find in file");
+    expect(menu?.textContent).not.toContain("Find in file");
+    expect(menu?.querySelector('[aria-label="Find in file"]')).not.toBeNull();
     expect(menu?.textContent).toContain("Header row");
     expect(menu?.textContent).toContain("Row numbers");
     expect(document.activeElement?.getAttribute("aria-label")).toBe("Split editor left");
@@ -136,8 +138,7 @@ describe("CSV pane-menu settings", () => {
     expect(document.querySelector(".desktop-editor-pane-menu")).toBeNull();
 
     await openPaneMenu(handle!);
-    const findItem = Array.from(document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'))
-      .find((item) => item.textContent?.includes("Find in file"));
+    const findItem = document.querySelector<HTMLButtonElement>('[aria-label="Find in file"]');
     await act(async () => findItem?.click());
     expect(container.querySelector(".editor-find-widget input")).toBeInstanceOf(HTMLInputElement);
   });

--- a/tests/csvTitlebarSettings.test.tsx
+++ b/tests/csvTitlebarSettings.test.tsx
@@ -86,6 +86,7 @@ describe("CSV pane-menu settings", () => {
 
     await openPaneMenu(handle!);
     const menu = document.querySelector<HTMLElement>(".desktop-editor-pane-menu");
+    expect(menu?.style.width).toBe("196px");
     expect(menu?.textContent).not.toContain("data.csv");
     expect(document.querySelector(".desktop-editor-pane-menu-title")).toBeNull();
     const primaryActions = menu?.querySelectorAll<HTMLButtonElement>(
@@ -251,6 +252,7 @@ describe("CSV pane-menu settings", () => {
     const handle = container.querySelector<HTMLButtonElement>(".desktop-editor-pane-handle")!;
     await openPaneMenu(handle);
     const menu = document.querySelector<HTMLElement>(".desktop-editor-pane-menu")!;
+    expect(menu.style.width).toBe("63px");
     const actions = Array.from(menu.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'));
 
     expect(menu.dataset.hasSecondary).toBeUndefined();

--- a/tests/desktop-terminal.architecture.test.ts
+++ b/tests/desktop-terminal.architecture.test.ts
@@ -4,6 +4,9 @@ import { describe, expect, it } from "vitest";
 describe("Desktop Terminal architecture boundaries", () => {
   it("keeps terminal processes user-owned and the content free of overlapping chrome", () => {
     const panel = source("src/features/desktop-terminal/ui/RightTerminalPanel.tsx");
+    const closeDialog = source(
+      "src/features/desktop-terminal/ui/TerminalCloseConfirmationDialog.tsx",
+    );
     const launcher = source("src/features/desktop-terminal/ui/TerminalLauncher.tsx");
     const launchers = source("src/features/desktop-terminal/model/terminalLaunchers.ts");
     const sessionView = source("src/features/desktop-terminal/ui/TerminalSessionView.tsx");
@@ -62,6 +65,8 @@ describe("Desktop Terminal architecture boundaries", () => {
     expect(panel).toContain("close: requestCloseSession");
     expect(panel).toContain("onClose={requestCloseSession}");
     expect(panel).toContain("<TerminalCloseConfirmationDialog");
+    expect(closeDialog).toContain("<DesktopOverlayLayer>");
+    expect(closeDialog).toContain("<DesktopDialogRoot");
     expect(panel).toContain("<TerminalLauncher");
     expect(panel).toContain("create: createLauncher");
     expect(panel).toContain("onCreate={createLauncher}");

--- a/tests/desktop-terminal.menu.test.tsx
+++ b/tests/desktop-terminal.menu.test.tsx
@@ -495,18 +495,21 @@ describe("Desktop Terminal titlebar session manager", () => {
       />,
     )));
 
-    const dialog = container.querySelector<HTMLElement>('[role="dialog"]');
+    const overlayRoot = document.querySelector<HTMLElement>("#desktop-overlay-root");
+    const dialog = overlayRoot?.querySelector<HTMLElement>('[role="dialog"]');
+    expect(overlayRoot).not.toBeNull();
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
     expect(dialog?.getAttribute("aria-label")).toBe("Close Terminal 2?");
     expect(dialog?.textContent).toContain(
       "This will stop the shell and any command running in this terminal.",
     );
     expect(document.activeElement?.textContent).toBe("Cancel");
 
-    clickButton(container, "Cancel");
+    clickButton(overlayRoot!, "Cancel");
     expect(onCancel).toHaveBeenCalledOnce();
     expect(onConfirm).not.toHaveBeenCalled();
 
-    clickButton(container, "Close terminal");
+    clickButton(overlayRoot!, "Close terminal");
     expect(onConfirm).toHaveBeenCalledOnce();
   });
 });

--- a/tests/desktopEditorArchitecture.test.ts
+++ b/tests/desktopEditorArchitecture.test.ts
@@ -19,7 +19,8 @@ describe("Desktop editor architecture", () => {
     expect(editorPaneDocumentRuntime).toContain("hideSourceView={hideSourceView}");
     expect(markdownViewer).toContain('modeControlPlacement="pane-menu"');
     expect(textEditorFrame).toContain("publishPaneMenuContribution");
-    expect(textEditorFrame).toContain('id: "editor-source-mode"');
+    expect(textEditorFrame).toContain('kind: "segmented"');
+    expect(textEditorFrame).toContain('id: "editor-view-mode"');
     expect(textEditorFrame).toContain('switchMode("live")');
     expect(textEditorFrame).toContain('switchMode("source")');
     expect(textEditorFrame).toContain('t("editor.mode.source")');

--- a/tests/desktopEditorArchitecture.test.ts
+++ b/tests/desktopEditorArchitecture.test.ts
@@ -15,7 +15,7 @@ const markdownViewer = read(
 describe("Desktop editor architecture", () => {
   it("exposes Markdown Source Code through the pane menu in the Desktop workspace", () => {
     expect(desktopDataSurface).toContain("hidePreviewSourceView");
-    expect(editorPaneDocumentRuntime).toContain('node?.type === "markdown"');
+    expect(editorPaneDocumentRuntime).toContain("!isMarkdownDocumentDescriptor(");
     expect(editorPaneDocumentRuntime).toContain("hideSourceView={hideSourceView}");
     expect(markdownViewer).toContain('modeControlPlacement="pane-menu"');
     expect(textEditorFrame).toContain("publishPaneMenuContribution");

--- a/tests/desktopHelpLauncher.test.tsx
+++ b/tests/desktopHelpLauncher.test.tsx
@@ -103,6 +103,8 @@ describe("DesktopHelpLauncher", () => {
       dialog?.querySelector<HTMLButtonElement>(".desktop-feedback-attach")
         ?.getAttribute("aria-label"),
     ).toBe("Attach screenshot");
+    expect(dialog?.querySelector(".desktop-feedback-composer")?.nextElementSibling?.classList)
+      .toContain("desktop-feedback-attachment-row");
     const submitButton = dialog?.querySelector<HTMLButtonElement>(".desktop-feedback-submit");
     expect(submitButton?.getAttribute("aria-label")).toBe("Send");
     expect(submitButton?.textContent).toBe("Send");
@@ -288,7 +290,7 @@ describe("DesktopHelpLauncher", () => {
     expect(launcherCss).toMatch(/\.desktop-feedback-dialog-backdrop\s*\{[^}]*pointer-events:\s*auto/s);
     expect(launcherCss).toMatch(/\.desktop-feedback-dialog\s*\{[^}]*width:\s*min\(400px,/s);
     expect(launcherCss).toMatch(
-      /\.desktop-feedback-header\s*\{[^}]*position:\s*relative[^}]*justify-content:\s*center/s,
+      /\.desktop-feedback-header\s*\{[^}]*align-items:\s*center/s,
     );
     expect(launcherCss).toMatch(
       /\.desktop-feedback-fields\s*\{[^}]*display:\s*grid[^}]*grid-template-columns:\s*minmax\(0, 1fr\)/s,
@@ -298,8 +300,17 @@ describe("DesktopHelpLauncher", () => {
       /\.desktop-feedback-required-marker\s*\{[^}]*color:\s*var\(--po-danger\)/s,
     );
     expect(launcherCss).toMatch(
-      /\.desktop-feedback-contact-input\s*\{[^}]*border:\s*1px solid var\(--po-border\)[^}]*background:\s*var\(--po-canvas\)/s,
+      /\.desktop-feedback-contact-input\s*\{[^}]*border:\s*1px solid var\(--po-divider\)[^}]*border-radius:\s*6px[^}]*background:\s*var\(--po-input, var\(--po-panel-raised\)\)/s,
     );
+    expect(launcherCss).toMatch(
+      /\.desktop-feedback-composer:focus-within\s*\{[^}]*border-color:\s*var\(--po-border-strong\)[^}]*\}/s,
+    );
+    expect(launcherCss.match(/\.desktop-feedback-composer:focus-within\s*\{[^}]*\}/s)?.[0])
+      .not.toContain("box-shadow");
+    expect(launcherCss.match(/\.desktop-feedback-contact-input:focus\s*\{[^}]*\}/s)?.[0])
+      .not.toContain("box-shadow");
+    expect(launcherCss).not.toContain("desktop-feedback-composer-toolbar");
+    expect(launcherCss).not.toContain("translateY(-1px)");
     expect(launcherCss.match(/\.desktop-feedback-footer\s*\{[^}]*\}/s)?.[0]).not.toContain(
       "border-block-start",
     );

--- a/tests/editorModeToggle.test.tsx
+++ b/tests/editorModeToggle.test.tsx
@@ -2,12 +2,13 @@
  * @vitest-environment happy-dom
  */
 import React from "react";
-import { act } from "react";
+import { act, useLayoutEffect } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   EditorPaneMenuContributionProvider,
   type EditorPaneMenuContribution,
+  useEditorPaneMenuContributionPublisher,
 } from "../packages/shared-ui/src/editor/editorPaneMenuContribution";
 import { TextEditorFrame } from "../packages/shared-ui/src/editor/viewers/shared/TextEditorFrame";
 import { testT, withTestLocalization } from "./testLocalization";
@@ -117,4 +118,49 @@ describe("editor mode toggle", () => {
     expect(container.querySelector('[data-editor-mode="live"]')).toBeNull();
     expect(container.querySelector('[data-editor-mode="source"]')).not.toBeNull();
   });
+
+  it("ignores stale Viewer cleanup after a newer contribution takes ownership", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    let contribution: EditorPaneMenuContribution | null = null;
+    let publishFirst: ((value: EditorPaneMenuContribution | null) => void) | null = null;
+    let publishSecond: ((value: EditorPaneMenuContribution | null) => void) | null = null;
+
+    act(() => root?.render(
+      <EditorPaneMenuContributionProvider
+        onContributionChange={(value) => {
+          contribution = value;
+        }}
+      >
+        <PublisherCapture onReady={(publish) => { publishFirst = publish; }} />
+        <PublisherCapture onReady={(publish) => { publishSecond = publish; }} />
+      </EditorPaneMenuContributionProvider>,
+    ));
+
+    const first = createContribution("first");
+    const second = createContribution("second");
+    act(() => publishFirst?.(first));
+    act(() => publishSecond?.(second));
+    act(() => publishFirst?.(null));
+    expect(contribution).toBe(second);
+    act(() => publishSecond?.(null));
+    expect(contribution).toBeNull();
+  });
 });
+
+function PublisherCapture({
+  onReady,
+}: Readonly<{
+  onReady: (publish: (value: EditorPaneMenuContribution | null) => void) => void;
+}>) {
+  const publish = useEditorPaneMenuContributionPublisher();
+  useLayoutEffect(() => {
+    if (publish) onReady(publish);
+  }, [onReady, publish]);
+  return null;
+}
+
+function createContribution(documentId: string): EditorPaneMenuContribution {
+  return { documentId, viewItems: [] };
+}

--- a/tests/editorModeToggle.test.tsx
+++ b/tests/editorModeToggle.test.tsx
@@ -23,7 +23,7 @@ afterEach(() => {
 });
 
 describe("editor mode toggle", () => {
-  it("publishes Source Code into the pane menu instead of rendering editor chrome", () => {
+  it("publishes the editor modes as a segmented pane-menu control", () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -55,22 +55,26 @@ describe("editor mode toggle", () => {
     expect(contribution).toMatchObject({
       documentId: "mode.md",
       viewItems: [{
-        kind: "toggle",
-        id: "editor-source-mode",
-        label: testT("editor.mode.source"),
-        checked: false,
+        kind: "segmented",
+        id: "editor-view-mode",
+        label: testT("editor.mode.label"),
+        value: "live",
+        options: [
+          { id: "live", label: testT("editor.mode.live") },
+          { id: "source", label: testT("editor.mode.source") },
+        ],
       }],
     });
 
-    const sourceModeItem = contribution?.viewItems[0];
-    expect(sourceModeItem?.kind).toBe("toggle");
+    const modeControl = contribution?.viewItems[0];
+    expect(modeControl?.kind).toBe("segmented");
     act(() => {
-      if (sourceModeItem?.kind === "toggle") sourceModeItem.setChecked(true);
+      if (modeControl?.kind === "segmented") modeControl.setValue("source");
     });
 
     expect(container.querySelector('[data-editor-mode="live"]')).toBeNull();
     expect(container.querySelector('[data-editor-mode="source"]')).not.toBeNull();
-    expect(contribution?.viewItems[0]).toMatchObject({ checked: true });
+    expect(contribution?.viewItems[0]).toMatchObject({ value: "source" });
   });
 
   it.each([

--- a/tests/editorSplitPaneArchitecture.test.ts
+++ b/tests/editorSplitPaneArchitecture.test.ts
@@ -237,6 +237,15 @@ describe("editor split-pane architecture", () => {
     expect(paneActionsMenuSource).toContain(
       "segmentedControl && <PaneMenuSegmentedControl item={segmentedControl}",
     );
+    expect(paneActionsMenuSource).toContain("resolvePaneActionsMenuWidth({");
+    expect(paneActionsMenuSource).toContain("PANE_ACTION_SLOT_SIZE = 25");
+    expect(splitSource).toContain("editorResource: editor?.resource ?? null");
+    expect(splitSource).toContain(
+      "menuContribution?.editorResource === editor?.resource",
+    );
+    expect(splitSource).not.toContain(
+      "menuContribution?.documentId === editor?.resource",
+    );
     const segmentedControlRule = readCssBlock(
       splitStyles,
       ".desktop-editor-pane-menu-segmented-control",

--- a/tests/editorSplitPaneArchitecture.test.ts
+++ b/tests/editorSplitPaneArchitecture.test.ts
@@ -201,20 +201,18 @@ describe("editor split-pane architecture", () => {
       splitStyles,
       ".desktop-editor-pane-menu-action-divider",
     );
-    expect(externalDividerRule).toContain(
-      "width: var(--desktop-editor-pane-menu-action-size);",
-    );
-    expect(externalDividerRule).toContain(
-      "height: var(--desktop-editor-pane-menu-action-size);",
-    );
+    expect(externalDividerRule).toContain("width: 1px;");
+    expect(externalDividerRule).toContain("height: 18px;");
+    expect(externalDividerRule).toContain("flex: 0 0 1px;");
+    expect(externalDividerRule).toContain("margin-inline: 3px;");
+    expect(externalDividerRule).toContain("background: var(--po-divider);");
     expect(externalDividerRule).toContain("pointer-events: none;");
-    const externalDividerLineRule = readCssBlock(
-      splitStyles,
-      ".desktop-editor-pane-menu-action-divider::before",
+    expect(splitStyles).not.toContain(".desktop-editor-pane-menu-action-divider::before");
+    expect(paneMenuRule).toContain(
+      "box-shadow: 0 2px 8px color-mix(in srgb, var(--po-shadow) 42%, transparent);",
     );
-    expect(externalDividerLineRule).toContain("width: 1px;");
-    expect(externalDividerLineRule).toContain("height: 12px;");
-    expect(externalDividerLineRule).toContain("background: var(--po-divider);");
+    expect(paneActionsMenuSource).toContain("PANE_DIVIDER_WIDTH = 1");
+    expect(paneActionsMenuSource).toContain("PANE_DIVIDER_INLINE_MARGIN = 3");
     expect(paneActionsMenuSource).toContain(
       'className="desktop-editor-pane-menu-primary-action desktop-editor-pane-menu-close-action"',
     );

--- a/tests/editorSplitPaneArchitecture.test.ts
+++ b/tests/editorSplitPaneArchitecture.test.ts
@@ -82,6 +82,14 @@ const splitStyles = readFileSync(
   new URL("../src/features/editor-workbench/layout/desktop-editor-split-view.css", import.meta.url),
   "utf8",
 );
+const menuStyles = readFileSync(
+  new URL("../src/styles/menus.css", import.meta.url),
+  "utf8",
+);
+const desktopMenuSource = readFileSync(
+  new URL("../src/components/DesktopMenu.tsx", import.meta.url),
+  "utf8",
+);
 const dataShellStyles = readFileSync(
   new URL("../src/features/data-workspace/data-shell.css", import.meta.url),
   "utf8",
@@ -180,6 +188,7 @@ describe("editor split-pane architecture", () => {
     );
     expect(paneMenuRule).toContain("position: fixed;");
     expect(paneMenuRule).toContain("overflow-y: auto;");
+    expect(paneMenuRule).not.toContain("box-shadow:");
     expect(splitStyles).not.toContain('.desktop-editor-pane-menu[data-has-secondary="true"]');
     const closeActionRule = readCssBlock(
       splitStyles,
@@ -208,9 +217,25 @@ describe("editor split-pane architecture", () => {
     expect(externalDividerRule).toContain("background: var(--po-divider);");
     expect(externalDividerRule).toContain("pointer-events: none;");
     expect(splitStyles).not.toContain(".desktop-editor-pane-menu-action-divider::before");
-    expect(paneMenuRule).toContain(
-      "box-shadow: 0 2px 8px color-mix(in srgb, var(--po-shadow) 42%, transparent);",
+    expect(paneActionsMenuSource).toContain('elevation="compact"');
+    expect(desktopMenuSource).toContain('elevation?: "default" | "compact";');
+    expect(desktopMenuSource).toContain(
+      'data-menu-elevation={elevation === "compact" ? elevation : undefined}',
     );
+    const compactMenuElevationRule = readCssBlock(
+      menuStyles,
+      '.desktop-menu-surface[data-menu-elevation="compact"]',
+    );
+    expect(compactMenuElevationRule).toContain(
+      "--po-menu-shadow-compact: 0 2px 4px -2px",
+    );
+    expect(compactMenuElevationRule).toContain(
+      "color-mix(in srgb, var(--po-shadow) 32%, transparent);",
+    );
+    expect(compactMenuElevationRule).toContain(
+      "--interface-menu-box-shadow: var(--po-menu-shadow-compact);",
+    );
+    expect(compactMenuElevationRule).toContain("box-shadow: var(--po-menu-shadow-compact);");
     expect(paneActionsMenuSource).toContain("PANE_DIVIDER_WIDTH = 1");
     expect(paneActionsMenuSource).toContain("PANE_DIVIDER_INLINE_MARGIN = 3");
     expect(paneActionsMenuSource).toContain(

--- a/tests/editorSplitPaneArchitecture.test.ts
+++ b/tests/editorSplitPaneArchitecture.test.ts
@@ -213,6 +213,31 @@ describe("editor split-pane architecture", () => {
     expect(paneActionsMenuSource).toContain(
       'className="desktop-editor-pane-menu-primary-action desktop-editor-pane-menu-close-action"',
     );
+    const findActionIndex = paneActionsMenuSource.indexOf(
+      "desktop-editor-pane-menu-find-action",
+    );
+    const externalActionIndex = paneActionsMenuSource.indexOf(
+      "desktop-editor-pane-menu-external-action",
+    );
+    const closeActionIndex = paneActionsMenuSource.indexOf(
+      "desktop-editor-pane-menu-close-action",
+    );
+    expect(findActionIndex).toBeGreaterThan(0);
+    expect(externalActionIndex).toBeGreaterThan(findActionIndex);
+    expect(closeActionIndex).toBeGreaterThan(externalActionIndex);
+    expect(paneActionsMenuSource).toContain("PANE_ACTIONS_MENU_EXTENDED_WIDTH = 224");
+    const segmentedControlRule = readCssBlock(
+      splitStyles,
+      ".desktop-editor-pane-menu-segmented-control",
+    );
+    expect(segmentedControlRule).toContain("grid-auto-columns: 1fr;");
+    expect(segmentedControlRule).toContain("border: 1px solid var(--po-divider);");
+    const selectedSegmentRule = readCssBlock(
+      splitStyles,
+      '.desktop-editor-pane-menu-segment[aria-checked="true"]',
+    );
+    expect(selectedSegmentRule).toContain("background: var(--po-selected);");
+    expect(selectedSegmentRule).toContain("color: var(--po-text);");
     const paneRule = readCssBlock(splitStyles, ".desktop-editor-pane");
     const paneFrameRule = readCssBlock(
       splitStyles,

--- a/tests/editorSplitPaneArchitecture.test.ts
+++ b/tests/editorSplitPaneArchitecture.test.ts
@@ -227,15 +227,10 @@ describe("editor split-pane architecture", () => {
       '.desktop-menu-surface[data-menu-elevation="compact"]',
     );
     expect(compactMenuElevationRule).toContain(
-      "--po-menu-shadow-compact: 0 2px 4px -2px",
-    );
-    expect(compactMenuElevationRule).toContain(
-      "color-mix(in srgb, var(--po-shadow) 32%, transparent);",
-    );
-    expect(compactMenuElevationRule).toContain(
       "--interface-menu-box-shadow: var(--po-menu-shadow-compact);",
     );
     expect(compactMenuElevationRule).toContain("box-shadow: var(--po-menu-shadow-compact);");
+    expect(tokens).toContain("--po-menu-shadow-compact: var(--po-elevation-low);");
     expect(paneActionsMenuSource).toContain("PANE_DIVIDER_WIDTH = 1");
     expect(paneActionsMenuSource).toContain("PANE_DIVIDER_INLINE_MARGIN = 3");
     expect(paneActionsMenuSource).toContain(

--- a/tests/editorSplitPaneArchitecture.test.ts
+++ b/tests/editorSplitPaneArchitecture.test.ts
@@ -253,8 +253,14 @@ describe("editor split-pane architecture", () => {
     expect(segmentedControlRule).toContain(
       "grid-auto-columns: var(--desktop-editor-pane-menu-action-size);",
     );
+    expect(segmentedControlRule).toContain(
+      "height: var(--desktop-editor-pane-menu-action-size);",
+    );
     expect(segmentedControlRule).toContain("flex: 0 0 auto;");
+    expect(segmentedControlRule).toContain("padding: 0;");
     expect(segmentedControlRule).toContain("border: 0;");
+    expect(segmentedControlRule).toContain("background: transparent;");
+    expect(segmentedControlRule).toContain("box-shadow: none;");
     const selectedSegmentRule = readCssBlock(
       splitStyles,
       '.desktop-editor-pane-menu-segment[aria-checked="true"]',

--- a/tests/editorSplitPaneArchitecture.test.ts
+++ b/tests/editorSplitPaneArchitecture.test.ts
@@ -123,10 +123,10 @@ describe("editor split-pane architecture", () => {
     expect(splitSource).toContain("onOpenAtPaneEdge");
     expect(splitSource).toContain("onMovePane");
     expect(splitSource).toContain("onSplitPane");
-    expect(paneActionsMenuSource).toContain('t("editor.panes.splitLeft")');
-    expect(paneActionsMenuSource).toContain('t("editor.panes.splitRight")');
-    expect(paneActionsMenuSource).toContain('t("editor.panes.splitUp")');
-    expect(paneActionsMenuSource).toContain('t("editor.panes.splitDown")');
+    expect(paneActionsMenuSource).not.toContain('t("editor.panes.splitLeft")');
+    expect(paneActionsMenuSource).not.toContain('t("editor.panes.splitRight")');
+    expect(paneActionsMenuSource).not.toContain('t("editor.panes.splitUp")');
+    expect(paneActionsMenuSource).not.toContain('t("editor.panes.splitDown")');
     expect(workbenchControllerSource).toContain("const splitPane = useCallback");
     expect(workbenchControllerSource).toContain("editorId: null");
     expect(paneShellSource).toContain('className="desktop-editor-drop-preview"');
@@ -191,7 +191,12 @@ describe("editor split-pane architecture", () => {
       ".desktop-editor-pane-menu-end-actions",
     );
     expect(endActionsRule).toContain("display: flex;");
-    expect(endActionsRule).toContain("margin-inline-start: auto;");
+    expect(endActionsRule).not.toContain("margin-inline-start: auto;");
+    const segmentedEndActionsRule = readCssBlock(
+      splitStyles,
+      ".desktop-editor-pane-menu-segmented-control + .desktop-editor-pane-menu-end-actions",
+    );
+    expect(segmentedEndActionsRule).toContain("margin-inline-start: auto;");
     const externalDividerRule = readCssBlock(
       splitStyles,
       ".desktop-editor-pane-menu-action-divider",
@@ -225,19 +230,32 @@ describe("editor split-pane architecture", () => {
     expect(findActionIndex).toBeGreaterThan(0);
     expect(externalActionIndex).toBeGreaterThan(findActionIndex);
     expect(closeActionIndex).toBeGreaterThan(externalActionIndex);
-    expect(paneActionsMenuSource).toContain("PANE_ACTIONS_MENU_EXTENDED_WIDTH = 224");
+    expect(paneActionsMenuSource).not.toContain("PanelLeft");
+    expect(paneActionsMenuSource).not.toContain("PanelRight");
+    expect(paneActionsMenuSource).not.toContain("PanelTop");
+    expect(paneActionsMenuSource).not.toContain("PanelBottom");
+    expect(paneActionsMenuSource).toContain(
+      "segmentedControl && <PaneMenuSegmentedControl item={segmentedControl}",
+    );
     const segmentedControlRule = readCssBlock(
       splitStyles,
       ".desktop-editor-pane-menu-segmented-control",
     );
-    expect(segmentedControlRule).toContain("grid-auto-columns: 1fr;");
-    expect(segmentedControlRule).toContain("border: 1px solid var(--po-divider);");
+    expect(segmentedControlRule).toContain(
+      "grid-auto-columns: var(--desktop-editor-pane-menu-action-size);",
+    );
+    expect(segmentedControlRule).toContain("flex: 0 0 auto;");
+    expect(segmentedControlRule).toContain("border: 0;");
     const selectedSegmentRule = readCssBlock(
       splitStyles,
       '.desktop-editor-pane-menu-segment[aria-checked="true"]',
     );
-    expect(selectedSegmentRule).toContain("background: var(--po-selected);");
-    expect(selectedSegmentRule).toContain("color: var(--po-text);");
+    expect(selectedSegmentRule).toContain(
+      "background: var(--desktop-titlebar-active, var(--po-selected));",
+    );
+    expect(selectedSegmentRule).toContain(
+      "color: var(--desktop-titlebar-text, var(--po-text));",
+    );
     const paneRule = readCssBlock(splitStyles, ".desktop-editor-pane");
     const paneFrameRule = readCssBlock(
       splitStyles,

--- a/tests/electron.agent-activity-contract.test.mjs
+++ b/tests/electron.agent-activity-contract.test.mjs
@@ -40,6 +40,16 @@ describe("Agent activity path policy", () => {
     })).resolves.toMatchObject({ workspaceRelativePath: "src/new/deep.txt" });
   });
 
+  it("canonicalizes the workspace root before enforcing the containment boundary", async () => {
+    const root = await temporaryWorkspace();
+    await writeFile(path.join(root, "readme.md"), "ok");
+    await expect(resolvePublicActivityTarget({
+      candidate: { path: "readme.md", access: "read", confidence: "exact" },
+      cwd: root,
+      workspaceRoot: root,
+    })).resolves.toMatchObject({ workspaceRelativePath: "readme.md" });
+  });
+
   it("rejects traversal and symlink escape", async () => {
     const parent = await temporaryWorkspace();
     const root = path.join(parent, "workspace");

--- a/tests/electron.agent-activity-ingest.test.mjs
+++ b/tests/electron.agent-activity-ingest.test.mjs
@@ -1,12 +1,18 @@
-import { mkdtemp, rm, stat } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { afterEach, describe, expect, it } from "vitest";
+import { createAgentActivityService } from "../electron/main/agent-activity/application/agent-activity-service.mjs";
 import { createHookIngestServer } from "../electron/main/agent-activity/transport/hook-ingest-server.mjs";
 import { createHookSessionAuth } from "../electron/main/agent-activity/transport/hook-session-auth.mjs";
+import { codexActivityAdapter } from "../electron/main/terminal-agent/activity/adapters/codex/descriptor.mjs";
+import { forwardHookInput } from "../electron/main/terminal-agent/activity/bridge/puppyone-agent-hook.mjs";
 
 const cleanups = [];
+const socketTestTempRoot = process.platform === "darwin" ? "/private/tmp" : os.tmpdir();
 
 afterEach(async () => {
   await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
@@ -14,7 +20,7 @@ afterEach(async () => {
 
 describe("Agent activity local ingest", () => {
   it("accepts one authenticated local frame and rejects a stale token", async () => {
-    const directory = await mkdtemp(path.join(os.tmpdir(), "puppyone-activity-ingest-"));
+    const directory = await mkdtemp(path.join(socketTestTempRoot, "puppyone-activity-ingest-"));
     const auth = createHookSessionAuth();
     const received = [];
     const server = createHookIngestServer({
@@ -40,6 +46,128 @@ describe("Agent activity local ingest", () => {
     if (process.platform !== "win32") {
       expect((await stat(endpoint)).mode & 0o777).toBe(0o600);
     }
+  });
+
+  it("carries versioned Codex read and write Hooks through the real socket into editor-safe activity", async () => {
+    const directory = await mkdtemp(path.join(socketTestTempRoot, "puppyone-codex-hook-e2e-"));
+    const workspaceRoot = path.join(directory, "workspace");
+    await mkdir(workspaceRoot);
+    await writeFile(path.join(workspaceRoot, "notes.md"), "test\n");
+
+    const publicEvents = [];
+    const service = createAgentActivityService({
+      publish(_webContentsId, event) {
+        publicEvents.push(event);
+      },
+    });
+    service.registerTerminalSession({
+      terminalSessionId: "terminal-codex-e2e",
+      providerId: "codex",
+      workspaceRoot,
+      webContentsId: 7,
+    });
+    const auth = createHookSessionAuth();
+    const server = createHookIngestServer({
+      auth,
+      runtimeDirectory: path.join(directory, "runtime"),
+      onEnvelope: async (envelope) => {
+        const normalized = codexActivityAdapter.normalize(envelope.payload, {
+          terminalSessionId: envelope.terminalSessionId,
+          occurredAt: Date.now(),
+        });
+        return normalized ? service.ingest(normalized) : false;
+      },
+    });
+    cleanups.push(async () => {
+      service.dispose();
+      await server.dispose();
+      await rm(directory, { recursive: true, force: true });
+    });
+    const endpoint = await server.start();
+    const token = auth.issue({
+      terminalSessionId: "terminal-codex-e2e",
+      providerId: "codex",
+    });
+    const fixture = {
+      ...readFixture("codex-0.147.0/pre-tool-use-bash-read.json"),
+      cwd: workspaceRoot,
+    };
+    const environment = {
+      PUPPYONE_AGENT_ACTIVITY_ENDPOINT: endpoint,
+      PUPPYONE_AGENT_ACTIVITY_TOKEN: token,
+      PUPPYONE_AGENT_ACTIVITY_PROVIDER: "codex",
+      PUPPYONE_AGENT_ACTIVITY_TERMINAL_SESSION_ID: "terminal-codex-e2e",
+    };
+
+    expect(await forwardHookInput({
+      environment,
+      input: Readable.from([JSON.stringify(fixture)]),
+    })).toBe(true);
+    await waitFor(() => publicEvents.length === 1);
+    expect(publicEvents[0]).toMatchObject({
+      providerId: "codex",
+      terminalSessionId: "terminal-codex-e2e",
+      phase: "started",
+      operation: "file.read",
+      targets: [{
+        workspaceRelativePath: "notes.md",
+        access: "read",
+        confidence: "exact",
+      }],
+    });
+    expect(JSON.stringify(publicEvents[0])).not.toContain("tail -20");
+    expect(JSON.stringify(publicEvents[0])).not.toContain(workspaceRoot);
+
+    expect(await forwardHookInput({
+      environment,
+      input: Readable.from([JSON.stringify({
+        ...fixture,
+        hook_event_name: "PostToolUse",
+      })]),
+    })).toBe(true);
+    await waitFor(() => publicEvents.length === 2);
+    expect(publicEvents[1]).toMatchObject({
+      activityId: publicEvents[0].activityId,
+      phase: "completed",
+      operation: "file.read",
+      targets: [{ workspaceRelativePath: "notes.md" }],
+    });
+
+    const writeFixture = {
+      ...readFixture("codex-0.147.0/pre-tool-use-apply-patch-write.json"),
+      cwd: workspaceRoot,
+    };
+    expect(await forwardHookInput({
+      environment,
+      input: Readable.from([JSON.stringify(writeFixture)]),
+    })).toBe(true);
+    await waitFor(() => publicEvents.length === 3);
+    expect(publicEvents[2]).toMatchObject({
+      providerId: "codex",
+      phase: "started",
+      operation: "file.write",
+      targets: [{
+        workspaceRelativePath: "notes.md",
+        access: "write",
+        confidence: "exact",
+      }],
+    });
+    expect(JSON.stringify(publicEvents[2])).not.toContain("+new");
+
+    expect(await forwardHookInput({
+      environment,
+      input: Readable.from([JSON.stringify({
+        ...writeFixture,
+        hook_event_name: "PostToolUse",
+      })]),
+    })).toBe(true);
+    await waitFor(() => publicEvents.length === 4);
+    expect(publicEvents[3]).toMatchObject({
+      activityId: publicEvents[2].activityId,
+      phase: "completed",
+      operation: "file.write",
+      targets: [{ workspaceRelativePath: "notes.md" }],
+    });
   });
 });
 
@@ -76,4 +204,11 @@ async function waitFor(predicate) {
     if (Date.now() >= deadline) throw new Error("Timed out waiting for local ingest.");
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
+}
+
+function readFixture(relativePath) {
+  return JSON.parse(readFileSync(
+    new URL(`./fixtures/agent-activity/${relativePath}`, import.meta.url),
+    "utf8",
+  ));
 }

--- a/tests/electron.agent-activity-registration.test.mjs
+++ b/tests/electron.agent-activity-registration.test.mjs
@@ -1,9 +1,14 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createOwnedJsonHookConfig } from "../electron/main/terminal-agent/activity/registration/owned-config-mutation.mjs";
-import { createBridgeCommand } from "../electron/main/terminal-agent/activity/registration/bridge-installer.mjs";
+import { createOwnedCursorCliHookConfig } from "../electron/main/terminal-agent/activity/registration/cursor-cli-hook-config.mjs";
+import {
+  createAgentActivityBridgeInstaller,
+  createBridgeCommand,
+} from "../electron/main/terminal-agent/activity/registration/bridge-installer.mjs";
+import { createHookRegistrationService } from "../electron/main/terminal-agent/activity/registration/hook-registration-service.mjs";
 
 const directories = [];
 
@@ -54,6 +59,148 @@ describe("owned Agent activity Hook registration", () => {
     expect(await readFile(configPath, "utf8")).toContain("old/puppyone-agent-hook.mjs");
   });
 
+  it("merges idempotent Cursor CLI handlers without changing user Hooks", async () => {
+    const directory = await temporaryDirectory();
+    const configPath = path.join(directory, ".cursor", "hooks.json");
+    await writeFileAfterMkdir(configPath, JSON.stringify({
+      version: 1,
+      note: "keep me",
+      hooks: {
+        preToolUse: [{ command: "user-hook", matcher: "Shell" }],
+        stop: [{ command: "user-stop-hook" }],
+      },
+    }));
+    const registration = createOwnedCursorCliHookConfig({
+      configPath,
+      command: "puppyone-agent-hook.mjs --provider cursor",
+    });
+
+    await expect(registration.inspect()).resolves.toMatchObject({ enrollment: "not-configured" });
+    await expect(registration.enable()).resolves.toMatchObject({ enrollment: "enabled" });
+    await registration.enable();
+
+    const enabledSource = await readFile(configPath, "utf8");
+    const enabled = JSON.parse(enabledSource);
+    expect(enabled.note).toBe("keep me");
+    expect(enabled.hooks.preToolUse[0]).toEqual({ command: "user-hook", matcher: "Shell" });
+    expect(enabled.hooks.stop).toEqual([{ command: "user-stop-hook" }]);
+    expect(enabledSource.match(/puppyone-agent-hook\.mjs/gu)).toHaveLength(4);
+    expect(enabled.hooks.preToolUse[1]).toMatchObject({
+      type: "command",
+      matcher: "Read|Write|Grep|Delete",
+      timeout: 2,
+    });
+    expect(enabled.hooks.sessionEnd[0]).not.toHaveProperty("matcher");
+
+    await expect(registration.disable()).resolves.toMatchObject({ enrollment: "not-configured" });
+    const disabled = JSON.parse(await readFile(configPath, "utf8"));
+    expect(disabled.note).toBe("keep me");
+    expect(disabled.hooks).toEqual({
+      preToolUse: [{ command: "user-hook", matcher: "Shell" }],
+      stop: [{ command: "user-stop-hook" }],
+    });
+  });
+
+  it("refuses to overwrite a modified Cursor CLI handler or unknown config version", async () => {
+    const directory = await temporaryDirectory();
+    const configPath = path.join(directory, "hooks.json");
+    await writeFile(configPath, JSON.stringify({
+      version: 1,
+      hooks: {
+        preToolUse: [{
+          type: "command",
+          command: "old/puppyone-agent-hook.mjs --provider cursor",
+          matcher: "Read|Write",
+          timeout: 9,
+        }],
+      },
+    }));
+    const registration = createOwnedCursorCliHookConfig({
+      configPath,
+      command: "new/puppyone-agent-hook.mjs --provider cursor",
+    });
+    await expect(registration.inspect()).resolves.toMatchObject({
+      enrollment: "needs-repair",
+      reason: "owned-entry-changed",
+    });
+    await expect(registration.enable()).rejects.toThrow("AGENT_ACTIVITY_CONFIG_CONFLICT");
+
+    await writeFile(configPath, JSON.stringify({ version: 2, hooks: {} }));
+    await expect(registration.inspect()).resolves.toMatchObject({
+      enrollment: "needs-repair",
+      reason: "unsupported-version",
+    });
+    await expect(registration.enable()).rejects.toThrow("AGENT_ACTIVITY_CURSOR_CONFIG_UNSUPPORTED_VERSION");
+  });
+
+  it("exposes Cursor CLI as configurable through the batch registration service", async () => {
+    const homedir = await temporaryDirectory();
+    const install = vi.fn(async () => undefined);
+    const ensureCurrent = vi.fn(async () => undefined);
+    const service = createHookRegistrationService({
+      homedir,
+      bridgeInstaller: {
+        command: "puppyone-agent-hook.mjs",
+        install,
+        isCurrent: async () => true,
+        ensureCurrent,
+      },
+    });
+
+    await expect(service.getSnapshot()).resolves.toMatchObject({
+      providers: expect.arrayContaining([
+        expect.objectContaining({
+          providerId: "cursor",
+          displayName: "Cursor Agent CLI",
+          configurable: true,
+          enrollment: "not-configured",
+        }),
+      ]),
+    });
+    await expect(service.setEnabled("cursor", true)).resolves.toMatchObject({ enrollment: "enabled" });
+    expect(install).toHaveBeenCalledOnce();
+    expect(await readFile(path.join(homedir, ".cursor", "hooks.json"), "utf8"))
+      .toContain("--provider cursor");
+    await expect(service.isEnabled("cursor")).resolves.toBe(true);
+    expect(ensureCurrent).toHaveBeenCalledOnce();
+  });
+
+  it("repairs an outdated installed bridge before an enrolled Agent session starts", async () => {
+    const directory = await temporaryDirectory();
+    const sourceDirectory = path.join(directory, "source");
+    const userDataPath = path.join(directory, "user-data");
+    await mkdir(sourceDirectory);
+    const bridgeSources = {
+      "puppyone-agent-hook.mjs": "export const bridge = 'current';\n",
+      "payload-projector.mjs": "export const projector = 'current';\n",
+      "shell-file-intent.mjs": "export const shell = 'current';\n",
+    };
+    await Promise.all(Object.entries(bridgeSources).map(([fileName, source]) => (
+      writeFile(path.join(sourceDirectory, fileName), source)
+    )));
+    const installer = createAgentActivityBridgeInstaller({
+      sourceDirectory,
+      userDataPath,
+      executablePath: "/Applications/PuppyOne",
+    });
+    await installer.install();
+    const installedProjector = path.join(
+      userDataPath,
+      "agent-activity",
+      "bridge",
+      "current",
+      "payload-projector.mjs",
+    );
+    await writeFile(installedProjector, "export const projector = 'old';\n");
+    await expect(installer.isCurrent()).resolves.toBe(false);
+
+    await installer.ensureCurrent();
+
+    await expect(installer.isCurrent()).resolves.toBe(true);
+    await expect(readFile(installedProjector, "utf8"))
+      .resolves.toBe(bridgeSources["payload-projector.mjs"]);
+  });
+
   it("creates an Electron-as-Node bridge command without shell interpolation", () => {
     expect(createBridgeCommand({
       bridgePath: "/tmp/Puppy One/puppyone-agent-hook.mjs",
@@ -67,4 +214,9 @@ async function temporaryDirectory() {
   const directory = await mkdtemp(path.join(os.tmpdir(), "puppyone-hook-registration-"));
   directories.push(directory);
   return directory;
+}
+
+async function writeFileAfterMkdir(filePath, source) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, source);
 }

--- a/tests/electron.terminal-agent-activity-adapters.test.mjs
+++ b/tests/electron.terminal-agent-activity-adapters.test.mjs
@@ -1,8 +1,12 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   extractPatchPaths,
   projectAgentHookPayload,
 } from "../electron/main/terminal-agent/activity/bridge/payload-projector.mjs";
+import {
+  extractShellReadPaths,
+} from "../electron/main/terminal-agent/activity/bridge/shell-file-intent.mjs";
 import { createTerminalAgentActivityAdapterRegistry } from "../electron/main/terminal-agent/activity/terminal-agent-activity-adapter-registry.mjs";
 import { createTerminalAgentActivityHost } from "../electron/main/terminal-agent/activity/terminal-agent-activity-host.mjs";
 
@@ -36,6 +40,65 @@ describe("Terminal Agent activity bridge projection", () => {
     });
     expect(payload.input).toEqual({ file_path: "/workspace/a.md" });
   });
+
+  it("projects Cursor CLI Hook input without forwarding file content", () => {
+    const payload = projectAgentHookPayload({
+      hook_event_name: "preToolUse",
+      conversation_id: "cursor-conversation",
+      generation_id: "cursor-generation",
+      tool_name: "Read",
+      tool_use_id: "cursor-call",
+      cwd: "/workspace",
+      tool_input: { path: "/workspace/cursor.ts", content: "private" },
+    });
+    expect(payload).toMatchObject({
+      eventName: "preToolUse",
+      sessionId: "cursor-conversation",
+      toolCallId: "cursor-call",
+      toolName: "Read",
+      input: { path: "/workspace/cursor.ts" },
+    });
+    expect(JSON.stringify(payload)).not.toContain("private");
+  });
+
+  it("projects literal Codex Bash reads without forwarding the shell command", () => {
+    const payload = projectAgentHookPayload(readFixture("codex-0.147.0/pre-tool-use-bash-read.json"));
+    expect(payload).toMatchObject({
+      eventName: "PreToolUse",
+      toolName: "Bash",
+      input: { read_paths: ["notes.md"] },
+    });
+    expect(JSON.stringify(payload)).not.toContain("tail -20");
+  });
+
+  it("projects a versioned Codex apply_patch payload without forwarding its body", () => {
+    const payload = projectAgentHookPayload(
+      readFixture("codex-0.147.0/pre-tool-use-apply-patch-write.json"),
+    );
+    expect(payload).toMatchObject({
+      eventName: "PreToolUse",
+      toolName: "apply_patch",
+      input: { paths: ["notes.md"] },
+    });
+    expect(JSON.stringify(payload)).not.toContain("+new");
+  });
+
+  it("extracts literal reads from pipelines and fails closed for dynamic shell paths", () => {
+    expect(extractShellReadPaths("tail -c 80 notes.md | od -An -t x1"))
+      .toEqual(["notes.md"]);
+    expect(extractShellReadPaths("cat 'notes with spaces.md'"))
+      .toEqual(["notes with spaces.md"]);
+    expect(extractShellReadPaths("sed -n '1,220p' notes.md"))
+      .toEqual(["notes.md"]);
+    expect(extractShellReadPaths("sed -f transforms.sed notes.md"))
+      .toEqual(["transforms.sed", "notes.md"]);
+    expect(extractShellReadPaths("sed -i '' 's/old/new/' notes.md")).toEqual([]);
+    expect(extractShellReadPaths('cat "$TARGET"')).toEqual([]);
+    expect(extractShellReadPaths("cat *.md")).toEqual([]);
+    expect(extractShellReadPaths("cat $(resolve-file)")).toEqual([]);
+    expect(extractShellReadPaths("cd nested && cat note.md")).toEqual([]);
+    expect(extractShellReadPaths("python3 script.py note.md")).toEqual([]);
+  });
 });
 
 describe("Terminal Agent activity adapter registry", () => {
@@ -63,13 +126,35 @@ describe("Terminal Agent activity adapter registry", () => {
     });
   });
 
-  it("keeps shell commands target-free", () => {
+  it("normalizes conservatively projected shell reads as exact file activity", () => {
+    const adapter = createTerminalAgentActivityAdapterRegistry().get("codex");
+    const event = adapter.normalize(projectAgentHookPayload(
+      readFixture("codex-0.147.0/pre-tool-use-bash-read.json"),
+    ), {
+      terminalSessionId: "terminal-1",
+      occurredAt: 42,
+    });
+    expect(event).toMatchObject({
+      operation: "file.read",
+      targets: [{ path: "notes.md", access: "read", confidence: "exact" }],
+    });
+  });
+
+  it("keeps unsupported shell commands target-free", () => {
     const adapter = createTerminalAgentActivityAdapterRegistry().get("codex");
     const event = adapter.normalize(projectedPayload({ eventName: "PreToolUse", toolName: "Bash" }), {
       terminalSessionId: "terminal-1",
       occurredAt: 42,
     });
     expect(event).toMatchObject({ operation: "command", targets: [] });
+  });
+
+  it("closes a Cursor CLI source session when its shell remains open", () => {
+    const adapter = createTerminalAgentActivityAdapterRegistry().get("cursor");
+    expect(adapter.normalize(projectedPayload({ eventName: "sessionEnd", toolName: "unknown" }), {
+      terminalSessionId: "terminal-1",
+      occurredAt: 42,
+    })).toEqual({ kind: "source-session-ended", sourceSessionId: "session-1" });
   });
 });
 
@@ -120,4 +205,8 @@ function projectedPayload({ eventName, toolName }) {
     cwd: "/workspace",
     input: { file_path: "src/a.ts" },
   };
+}
+
+function readFixture(relativePath) {
+  return JSON.parse(readFileSync(new URL(`./fixtures/agent-activity/${relativePath}`, import.meta.url), "utf8"));
 }

--- a/tests/electron.terminal-agent-launch.test.mjs
+++ b/tests/electron.terminal-agent-launch.test.mjs
@@ -199,6 +199,48 @@ describe("Terminal Agent launch boundary", () => {
     expect(resolved).toBe(true);
   });
 
+  it("answers startup default-color probes before forwarding Agent output", async () => {
+    const workspaceRoot = await makeTemporaryDirectory();
+    const terminal = createFakeTerminal();
+    const sender = createSender();
+    const service = createService({
+      agentRevealTimeoutMs: 5_000,
+      environment: { PATH: "/usr/bin", SHELL: "/bin/zsh" },
+      platform: "darwin",
+      ptyService: { spawn: vi.fn(() => terminal) },
+      resolveTerminalAgentLaunch: vi.fn(async () => ({
+        args: [],
+        displayName: "Codex",
+        executablePath: "/verified/codex",
+      })),
+    });
+
+    const createPromise = service.create(sender, {
+      id: "terminal_codex_colors",
+      cwd: workspaceRoot,
+      cols: 80,
+      rows: 24,
+      launcherId: "codex",
+      defaultColors: {
+        foreground: [109, 102, 93],
+        background: [251, 250, 247],
+      },
+    }, workspaceRoot);
+
+    await vi.waitFor(() => expect(terminal.write).toHaveBeenCalledOnce());
+    terminal.emitData(
+      "before\u001b]10;?\u001b\\middle\u001b]11;?\u001b\\after\u001b[?1049h",
+    );
+    await expect(createPromise).resolves.toMatchObject({ shell: "Codex" });
+
+    expect(terminal.write).toHaveBeenNthCalledWith(2, "\u001b]10;rgb:6d6d/6666/5d5d\u001b\\");
+    expect(terminal.write).toHaveBeenNthCalledWith(3, "\u001b]11;rgb:fbfb/fafa/f7f7\u001b\\");
+    expect(sender.send).toHaveBeenCalledWith("terminal:data", {
+      id: "terminal_codex_colors",
+      data: "beforemiddleafter\u001b[?1049h",
+    });
+  });
+
   it("closes the host shell if the Agent bootstrap cannot be written", async () => {
     const workspaceRoot = await makeTemporaryDirectory();
     const terminal = createFakeTerminal();

--- a/tests/electron.terminal-color-query.test.mjs
+++ b/tests/electron.terminal-color-query.test.mjs
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { createTerminalDefaultColorResponder } from "../electron/main/terminal-service.mjs";
+
+const colors = {
+  foreground: [109, 102, 93],
+  background: [251, 250, 247],
+};
+
+describe("terminal default-color query responder", () => {
+  it("answers and removes OSC 10/11 probes before xterm rendering", () => {
+    const responder = createTerminalDefaultColorResponder(colors);
+
+    expect(responder.process(
+      "before\u001b]10;?\u001b\\middle\u001b]11;?\u0007after",
+    )).toEqual({
+      data: "beforemiddleafter",
+      replies: [
+        "\u001b]10;rgb:6d6d/6666/5d5d\u001b\\",
+        "\u001b]11;rgb:fbfb/fafa/f7f7\u001b\\",
+      ],
+    });
+  });
+
+  it("recognizes a color query split across PTY output chunks", () => {
+    const responder = createTerminalDefaultColorResponder(colors);
+
+    expect(responder.process("prompt\u001b]11;?")).toEqual({
+      data: "prompt",
+      replies: [],
+    });
+    expect(responder.process("\u001b\\rest")).toEqual({
+      data: "rest",
+      replies: ["\u001b]11;rgb:fbfb/fafa/f7f7\u001b\\"],
+    });
+    expect(responder.flush()).toBe("");
+  });
+
+  it("keeps the normal xterm path when renderer colors are invalid", () => {
+    expect(createTerminalDefaultColorResponder({
+      foreground: [109, 102, 999],
+      background: [251, 250, 247],
+    })).toBeNull();
+  });
+});

--- a/tests/elevationArchitecture.test.ts
+++ b/tests/elevationArchitecture.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const readSource = (path: string) => readFileSync(new URL(path, import.meta.url), "utf8");
+
+const tokens = readSource("../src/styles/tokens.css");
+const menus = readSource("../src/styles/menus.css");
+const minimalMode = readSource("../src/styles/minimal-mode.css");
+const helpLauncher = readSource("../src/features/app-shell/desktop-help-launcher.css");
+const fileActions = readSource("../src/styles/file-actions.css");
+const plugins = readSource("../src/features/plugins/plugins.css");
+const dataShell = readSource("../src/features/data-workspace/data-shell.css");
+const assetLibrary = readSource("../src/styles/asset-library-home.css");
+const aiEdits = readSource("../src/ai-edits/ai-edits.css");
+const accessMethodCard = readSource(
+  "../src/features/cloud/sections/access/styles/method-card.css",
+);
+const utilityScreens = readSource("../src/styles/utility-screens.css");
+const agentFilePresence = readSource(
+  "../src/features/desktop-agent-presence/ui/agent-file-presence.css",
+);
+const editorFind = readSource("../packages/shared-ui/src/styles/editor/editor-find.css");
+const editorChrome = readSource("../packages/shared-ui/src/styles/editor/editor-chrome.css");
+const csvEditor = readSource("../packages/shared-ui/src/styles/editor/csv-table-editor.css");
+const markdownEditor = readSource("../packages/shared-ui/src/styles/editor/markdown-editor.css");
+const splitView = readSource(
+  "../src/features/editor-workbench/layout/desktop-editor-split-view.css",
+);
+
+describe("desktop elevation architecture", () => {
+  it("keeps compact controls and popovers on a two-level shared elevation scale", () => {
+    expect(tokens).toContain("--po-elevation-low: 0 2px 4px -2px");
+    expect(tokens).toContain("--po-elevation-popover: 0 3px 8px -4px");
+    expect(tokens).toContain("--po-menu-shadow-compact: var(--po-elevation-low);");
+    expect(tokens).toContain("--po-menu-shadow: var(--po-elevation-popover);");
+    expect(tokens).not.toContain("--po-menu-shadow: 0 18px 44px");
+
+    const compactMenuRule = readCssBlock(
+      menus,
+      '.desktop-menu-surface[data-menu-elevation="compact"]',
+    );
+    expect(compactMenuRule).toContain("box-shadow: var(--po-menu-shadow-compact);");
+    expect(compactMenuRule).not.toContain("color-mix(");
+  });
+
+  it("does not give expanding chrome controls their own ambient shadow", () => {
+    expect(readCssBlock(helpLauncher, ".desktop-help-launcher")).toContain("box-shadow: none;");
+    expect(readCssBlock(
+      helpLauncher,
+      ".desktop-help-launcher:hover,\n.desktop-help-launcher:focus-visible",
+    )).toContain("box-shadow: none;");
+    expect(readCssBlock(accessMethodCard, ".desktop-cloud-access-method-copy-button"))
+      .toContain("box-shadow: none;");
+    expect(minimalMode).not.toContain("0 12px 34px");
+    expect(helpLauncher).not.toContain("0 2px 8px");
+    expect(assetLibrary).not.toContain("6px 7px 0");
+  });
+
+  it("routes small floating UI through the shared low or popover elevations", () => {
+    expect(readCssBlock(minimalMode, ".desktop-minimal-mode-dock"))
+      .toContain("box-shadow: var(--po-elevation-low);");
+    expect(readCssBlock(editorFind, ".editor-find-widget"))
+      .toContain("box-shadow: var(--po-elevation-low);");
+    expect(readCssBlock(editorChrome, ".editor-mode-toggle"))
+      .toContain("box-shadow: var(--po-elevation-low);");
+    expect(readCssBlock(plugins, ".desktop-plugin-menu > div"))
+      .toContain("box-shadow: var(--po-menu-shadow-compact);");
+    expect(fileActions).toContain("box-shadow: var(--po-menu-shadow-compact);");
+    expect(dataShell).toContain("box-shadow: var(--po-elevation-low);");
+    expect(assetLibrary).toContain("box-shadow: var(--po-menu-shadow);");
+    expect(aiEdits).toContain("box-shadow: var(--po-menu-shadow);");
+    expect(readCssBlock(utilityScreens, ".panic-undo"))
+      .toContain("box-shadow: var(--po-elevation-low);");
+    expect(readCssBlock(agentFilePresence, ".desktop-agent-file-presence"))
+      .toContain("box-shadow: var(--po-elevation-low);");
+    expect(csvEditor).toContain("box-shadow: var(--po-elevation-low);");
+    expect(markdownEditor).toContain("box-shadow: var(--po-menu-shadow);");
+    expect(readCssBlock(splitView, ".desktop-editor-pane-move-preview"))
+      .toContain("box-shadow: var(--po-elevation-popover);");
+  });
+});
+
+function readCssBlock(css: string, selector: string): string {
+  const start = css.indexOf(`${selector} {`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = css.indexOf("}", start);
+  expect(end).toBeGreaterThan(start);
+  return css.slice(start, end + 1);
+}

--- a/tests/fixtures/agent-activity/README.md
+++ b/tests/fixtures/agent-activity/README.md
@@ -1,0 +1,13 @@
+# Agent activity fixtures
+
+Fixtures in this directory model provider payload shapes but must never be copied
+from a developer machine without sanitization.
+
+- Use `/workspace` as `cwd` and generic relative filenames such as `notes.md`.
+- Use synthetic model, session, turn, conversation, generation and tool IDs.
+- Set transcript paths to `null` and remove prompts, file contents and secrets.
+- Never retain usernames, home directories, repository names or personal filenames.
+- Keep the provider version in the directory name so schema drift is explicit.
+
+`scripts/check-agent-activity-architecture.mjs` enforces the machine-checkable
+parts of this policy during boundary checks and production builds.

--- a/tests/fixtures/agent-activity/codex-0.147.0/pre-tool-use-apply-patch-write.json
+++ b/tests/fixtures/agent-activity/codex-0.147.0/pre-tool-use-apply-patch-write.json
@@ -1,0 +1,14 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "codex-session-fixture",
+  "turn_id": "codex-turn-fixture",
+  "tool_name": "apply_patch",
+  "tool_use_id": "codex-patch-fixture",
+  "cwd": "/workspace",
+  "model": "gpt-test",
+  "permission_mode": "default",
+  "transcript_path": null,
+  "tool_input": {
+    "command": "*** Begin Patch\n*** Update File: notes.md\n@@\n-old\n+new\n*** End Patch"
+  }
+}

--- a/tests/fixtures/agent-activity/codex-0.147.0/pre-tool-use-bash-read.json
+++ b/tests/fixtures/agent-activity/codex-0.147.0/pre-tool-use-bash-read.json
@@ -1,0 +1,14 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "codex-session-fixture",
+  "turn_id": "codex-turn-fixture",
+  "tool_name": "Bash",
+  "tool_use_id": "codex-tool-fixture",
+  "cwd": "/workspace",
+  "model": "gpt-test",
+  "permission_mode": "default",
+  "transcript_path": null,
+  "tool_input": {
+    "command": "tail -20 notes.md && wc -l notes.md"
+  }
+}

--- a/tests/localAgentSelection.test.ts
+++ b/tests/localAgentSelection.test.ts
@@ -4,6 +4,7 @@ import {
   installedLocalAgents,
   isLocalAgentEnabled,
   isLocalAgentRuntimeEnabled,
+  localAgentActivityProviderId,
   setLocalAgentEnabled,
 } from "../src/features/local-agents";
 import type { AgentLocalConnection } from "../shared/agent-contract/types";
@@ -21,9 +22,14 @@ describe("Local Agent selection", () => {
   });
 
   it("maps installed product identities to their Editor runtime routes", () => {
-    const settings = { enabledAgentIds: ["codex", "opencode"] };
-    expect(enabledLocalAgentRuntimeIds(settings)).toEqual(["codex", "opencode-native"]);
+    const settings = { enabledAgentIds: ["codex", "cursor-agent", "opencode"] };
+    expect(enabledLocalAgentRuntimeIds(settings)).toEqual(["codex", "cursor", "opencode-native"]);
     expect(isLocalAgentRuntimeEnabled(settings, "opencode-native")).toBe(true);
+  });
+
+  it("maps Cursor CLI inventory identity to its activity adapter", () => {
+    expect(localAgentActivityProviderId("cursor-agent")).toBe("cursor");
+    expect(localAgentActivityProviderId("claude")).toBe("claude");
   });
 });
 

--- a/tests/markdownEmbedRuntime.test.ts
+++ b/tests/markdownEmbedRuntime.test.ts
@@ -17,6 +17,10 @@ import {
 import { CodeBlockWidget } from "../packages/shared-ui/src/editor/markdown/features/code-block/codeBlockWidget";
 import { MermaidBlockWidget } from "../packages/shared-ui/src/editor/markdown/features/mermaid/mermaidBlockWidget";
 import {
+  markdownCodeMirrorBaseExtensions,
+  markdownLivePreviewExtension,
+} from "../packages/shared-ui/src/editor/markdown/markdownCodeMirrorExtensions";
+import {
   createTableCellEditor,
   disposeTableCellEditor,
 } from "../packages/shared-ui/src/editor/markdown/features/table/tableCellEditor";
@@ -59,6 +63,23 @@ function createView(source: string): EditorView {
   const view = new EditorView({
     parent,
     state: EditorState.create({ doc: source }),
+  });
+  views.push(view);
+  return view;
+}
+
+function createProjectedView(source: string): EditorView {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const view = new EditorView({
+    parent,
+    state: EditorState.create({
+      doc: source,
+      extensions: [
+        ...markdownCodeMirrorBaseExtensions(false),
+        markdownLivePreviewExtension("safe", null, "note.md", null, "", null),
+      ],
+    }),
   });
   views.push(view);
   return view;
@@ -186,6 +207,25 @@ describe("Markdown embedded runtime", () => {
     secondWidget.destroy(secondDom);
   });
 
+  it("keeps a mounted code block anchored after an edit before its widget", () => {
+    const source = "Intro\n\n```ts\nold\n```";
+    const view = createProjectedView(source);
+    const widgetBefore = view.dom.querySelector<HTMLElement>(".cm-md-code-widget");
+    if (!widgetBefore) throw new Error("Code block did not mount");
+
+    view.dispatch({ changes: { from: 0, insert: "Shifted\n" } });
+
+    const widgetAfter = view.dom.querySelector<HTMLElement>(".cm-md-code-widget");
+    expect(widgetAfter).toBe(widgetBefore);
+    const editor = widgetAfter?.querySelector<HTMLTextAreaElement>(".cm-md-code-textarea");
+    if (!editor) throw new Error("Code block editor did not mount");
+    editor.value = "new";
+    editor.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    editor.dispatchEvent(new FocusEvent("blur"));
+
+    expect(view.state.doc.toString()).toBe("Shifted\nIntro\n\n```ts\nnew\n```");
+  });
+
   it("uses the exact code-fence slice and commits only when focus leaves the composite widget", () => {
     const source = "~~~js\nold\n~~~";
     const view = createView(source);
@@ -255,6 +295,7 @@ describe("Markdown embedded runtime", () => {
       rowIndex: 0,
       rows: firstTable.rows,
       renderInlinePreview,
+      getTableRange: () => ({ from: firstTable.from, to: firstTable.to }),
       tableFrom: firstTable.from,
       tableTo: firstTable.to,
       view,
@@ -289,6 +330,7 @@ describe("Markdown embedded runtime", () => {
       rowIndex: 0,
       rows: movedTable.rows,
       renderInlinePreview,
+      getTableRange: () => ({ from: movedTable.from, to: movedTable.to }),
       tableFrom: movedTable.from,
       tableTo: movedTable.to,
       view,
@@ -325,6 +367,7 @@ describe("Markdown embedded runtime", () => {
       rowIndex: 0,
       rows: table.rows,
       renderInlinePreview,
+      getTableRange: () => ({ from: table.from, to: table.to }),
       tableFrom: table.from,
       tableTo: table.to,
       view,
@@ -365,5 +408,27 @@ describe("Markdown embedded runtime", () => {
     await Promise.resolve();
     await Promise.resolve();
     widget.destroy(dom);
+  });
+
+  it("creates a delayed Mermaid edit session from the widget's mapped range", () => {
+    const source = "Intro\n\n```mermaid\ngraph TD; A-->B\n```";
+    const view = createProjectedView(source);
+    const widgetBefore = view.dom.querySelector<HTMLElement>(".cm-md-mermaid-widget");
+    if (!widgetBefore) throw new Error("Mermaid block did not mount");
+
+    view.dispatch({ changes: { from: 0, insert: "Shifted\n" } });
+
+    const widgetAfter = view.dom.querySelector<HTMLElement>(".cm-md-mermaid-widget");
+    expect(widgetAfter).toBe(widgetBefore);
+    widgetAfter?.querySelector<HTMLButtonElement>(".cm-md-mermaid-action")?.click();
+    const editor = widgetAfter?.querySelector<HTMLTextAreaElement>(".cm-md-mermaid-source");
+    if (!editor) throw new Error("Mermaid editor did not open");
+    editor.value = "graph TD; A-->C";
+    editor.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    widgetAfter?.querySelector<HTMLButtonElement>(".cm-md-mermaid-action")?.click();
+
+    expect(view.state.doc.toString()).toBe(
+      "Shifted\nIntro\n\n```mermaid\ngraph TD; A-->C\n```",
+    );
   });
 });

--- a/tests/markdownPaneModeMenu.test.tsx
+++ b/tests/markdownPaneModeMenu.test.tsx
@@ -28,13 +28,13 @@ afterEach(() => {
 
 describe("Markdown pane mode menu", () => {
   it("switches source mode from the three-dot pane menu without floating editor controls", async () => {
-    const path = "notes.md";
+    const path = "20260817";
     const node: DataNode = {
       id: path,
       path,
       name: path,
       type: "file",
-      mimeType: "text/markdown",
+      mimeType: "text/markdown; charset=utf-8",
       source: "local",
     };
     const editorGroup = openEditor(EMPTY_EDITOR_GROUP, createEditorInput(path));
@@ -132,6 +132,23 @@ describe("Markdown pane mode menu", () => {
     expect(document.querySelector<HTMLButtonElement>(
       '[role="menuitemradio"][aria-label="Live view"]',
     )?.getAttribute("aria-checked")).toBe("false");
+
+    await act(async () => {
+      handle?.click();
+      await Promise.resolve();
+    });
+    expect(document.querySelector(".desktop-editor-pane-menu")).toBeNull();
+
+    await act(async () => {
+      handle?.click();
+      await Promise.resolve();
+    });
+    await waitForCondition(() => document.querySelector(
+      '.desktop-editor-pane-menu-segmented-control[aria-label="Editor mode"]',
+    ) !== null);
+    expect(document.querySelector<HTMLButtonElement>(
+      '[role="menuitemradio"][aria-label="Source code"]',
+    )?.getAttribute("aria-checked")).toBe("true");
   });
 });
 

--- a/tests/markdownPaneModeMenu.test.tsx
+++ b/tests/markdownPaneModeMenu.test.tsx
@@ -98,7 +98,7 @@ describe("Markdown pane mode menu", () => {
     );
     expect(document.querySelector<HTMLElement>(
       ".desktop-editor-pane-menu",
-    )?.style.width).toBe("177px");
+    )?.style.width).toBe("173px");
     const primaryActions = document.querySelector(".desktop-editor-pane-menu-primary-actions");
     expect(primaryActions?.firstElementChild).toBe(modeControl);
     expect(document.querySelector(".desktop-editor-pane-menu-secondary-actions")).toBeNull();

--- a/tests/markdownPaneModeMenu.test.tsx
+++ b/tests/markdownPaneModeMenu.test.tsx
@@ -95,6 +95,10 @@ describe("Markdown pane mode menu", () => {
     const modeControl = document.querySelector<HTMLElement>(
       '.desktop-editor-pane-menu-segmented-control[aria-label="Editor mode"]',
     );
+    const primaryActions = document.querySelector(".desktop-editor-pane-menu-primary-actions");
+    expect(primaryActions?.firstElementChild).toBe(modeControl);
+    expect(document.querySelector(".desktop-editor-pane-menu-secondary-actions")).toBeNull();
+    expect(document.querySelector(".desktop-editor-pane-menu-action-divider")).not.toBeNull();
     const liveModeItem = modeControl?.querySelector<HTMLButtonElement>(
       '[role="menuitemradio"][aria-label="Live view"]',
     );

--- a/tests/markdownPaneModeMenu.test.tsx
+++ b/tests/markdownPaneModeMenu.test.tsx
@@ -92,21 +92,38 @@ describe("Markdown pane mode menu", () => {
     });
     await waitForCondition(() => document.querySelector(".desktop-editor-pane-menu") !== null);
 
-    const sourceModeItem = Array.from(
-      document.querySelectorAll<HTMLButtonElement>('[role="menuitemcheckbox"]'),
-    ).find((item) => item.textContent?.includes("Source code"));
+    const modeControl = document.querySelector<HTMLElement>(
+      '.desktop-editor-pane-menu-segmented-control[aria-label="Editor mode"]',
+    );
+    const liveModeItem = modeControl?.querySelector<HTMLButtonElement>(
+      '[role="menuitemradio"][aria-label="Live view"]',
+    );
+    const sourceModeItem = modeControl?.querySelector<HTMLButtonElement>(
+      '[role="menuitemradio"][aria-label="Source code"]',
+    );
+    expect(modeControl?.textContent).toBe("");
+    expect(liveModeItem?.getAttribute("aria-checked")).toBe("true");
     expect(sourceModeItem).toBeInstanceOf(HTMLButtonElement);
     expect(sourceModeItem?.getAttribute("aria-checked")).toBe("false");
 
-    await act(async () => sourceModeItem?.click());
+    liveModeItem?.focus();
+    await act(async () => liveModeItem?.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowRight",
+      bubbles: true,
+      cancelable: true,
+    })));
     await waitForCondition(() => container.querySelector(
       '.markdown-codemirror-editor[data-preview-state="source"]',
     ) !== null);
 
     expect(document.querySelector(".desktop-editor-pane-menu")).not.toBeNull();
+    expect(document.activeElement?.getAttribute("aria-label")).toBe("Source code");
     expect(document.querySelector<HTMLButtonElement>(
-      '[role="menuitemcheckbox"][aria-checked="true"]',
-    )?.textContent).toContain("Source code");
+      '[role="menuitemradio"][aria-label="Source code"]',
+    )?.getAttribute("aria-checked")).toBe("true");
+    expect(document.querySelector<HTMLButtonElement>(
+      '[role="menuitemradio"][aria-label="Live view"]',
+    )?.getAttribute("aria-checked")).toBe("false");
   });
 });
 

--- a/tests/markdownPaneModeMenu.test.tsx
+++ b/tests/markdownPaneModeMenu.test.tsx
@@ -98,7 +98,7 @@ describe("Markdown pane mode menu", () => {
     );
     expect(document.querySelector<HTMLElement>(
       ".desktop-editor-pane-menu",
-    )?.style.width).toBe("173px");
+    )?.style.width).toBe("155px");
     const primaryActions = document.querySelector(".desktop-editor-pane-menu-primary-actions");
     expect(primaryActions?.firstElementChild).toBe(modeControl);
     expect(document.querySelector(".desktop-editor-pane-menu-secondary-actions")).toBeNull();

--- a/tests/markdownPaneModeMenu.test.tsx
+++ b/tests/markdownPaneModeMenu.test.tsx
@@ -33,7 +33,7 @@ describe("Markdown pane mode menu", () => {
       id: path,
       path,
       name: path,
-      type: "markdown",
+      type: "file",
       mimeType: "text/markdown",
       source: "local",
     };
@@ -60,6 +60,7 @@ describe("Markdown pane mode menu", () => {
             markdownBlockDragEnabled: false,
           }}
           editorTree={[node]}
+          externalOpen={{ getAppName: () => "Terminal", open: vi.fn() }}
           fileIconTheme="default"
           layout={createEditorPaneLayout(path)}
           markdownEnvironment={workspaceState(node).markdownEnvironment}
@@ -95,6 +96,9 @@ describe("Markdown pane mode menu", () => {
     const modeControl = document.querySelector<HTMLElement>(
       '.desktop-editor-pane-menu-segmented-control[aria-label="Editor mode"]',
     );
+    expect(document.querySelector<HTMLElement>(
+      ".desktop-editor-pane-menu",
+    )?.style.width).toBe("177px");
     const primaryActions = document.querySelector(".desktop-editor-pane-menu-primary-actions");
     expect(primaryActions?.firstElementChild).toBe(modeControl);
     expect(document.querySelector(".desktop-editor-pane-menu-secondary-actions")).toBeNull();

--- a/tests/markdownTableInteractions.test.ts
+++ b/tests/markdownTableInteractions.test.ts
@@ -220,6 +220,69 @@ describe("Markdown table EditorView interactions", () => {
     expect((document.activeElement as HTMLElement | null)?.dataset.mdTableColumn).toBe("3");
   });
 
+  it("targets the current table range after an earlier edit outside its projection patch", () => {
+    const prefix = [
+      "Top",
+      "",
+      "Paragraph one",
+      "Paragraph two",
+      "Paragraph three",
+      "",
+    ].join("\n");
+    const view = createTableView(`${prefix}${TABLE_SOURCE}\nOutro`);
+    const tableBeforeEdit = view.dom.querySelector<HTMLElement>(".cm-md-table-widget-wrap");
+    if (!tableBeforeEdit) throw new Error("Table did not mount before the edit");
+
+    view.dispatch({
+      changes: {
+        from: view.state.doc.line(2).to,
+        insert: "\nInserted before the table",
+      },
+    });
+
+    const tableAfterEdit = view.dom.querySelector<HTMLElement>(".cm-md-table-widget-wrap");
+    expect(tableAfterEdit).toBe(tableBeforeEdit);
+    tableAfterEdit?.querySelector<HTMLButtonElement>(".cm-md-table-add-row")?.click();
+
+    expect(source(view)).toContain("Paragraph two");
+    expect(source(view)).toMatch(/\| four \| five \| six\s+\|\n\|\s+\|\s+\|\s+\|\nOutro/);
+  });
+
+  it("commits a cell to the current table range after an earlier mapped edit", () => {
+    const prefix = [
+      "Top",
+      "",
+      "Paragraph one",
+      "Paragraph two",
+      "Paragraph three",
+      "",
+    ].join("\n");
+    const view = createTableView(`${prefix}${TABLE_SOURCE}\nOutro`);
+    const tableBeforeEdit = view.dom.querySelector<HTMLElement>(".cm-md-table-widget-wrap");
+    if (!tableBeforeEdit) throw new Error("Table did not mount before the edit");
+
+    view.dispatch({
+      changes: {
+        from: view.state.doc.line(2).to,
+        insert: "\nInserted before the table",
+      },
+    });
+
+    const tableAfterEdit = view.dom.querySelector<HTMLElement>(".cm-md-table-widget-wrap");
+    expect(tableAfterEdit).toBe(tableBeforeEdit);
+    const firstBodyCell = tableAfterEdit?.querySelector<HTMLElement>(
+      '.cm-md-table-cell-content[data-md-table-row="1"][data-md-table-column="0"]',
+    );
+    if (!firstBodyCell) throw new Error("Editable table cell did not mount");
+    firstBodyCell.focus();
+    firstBodyCell.textContent = "updated";
+    firstBodyCell.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    firstBodyCell.blur();
+
+    expect(source(view)).toContain("Paragraph two");
+    expect(source(view)).toContain("| updated | two | three |");
+  });
+
   it("keeps the inline viewport session across a structural Widget replacement", async () => {
     const view = createTableView();
     const firstRoot = view.dom.querySelector<HTMLElement>(".cm-md-table-widget-wrap")!;

--- a/tests/markdownTaskCheckboxInteraction.test.ts
+++ b/tests/markdownTaskCheckboxInteraction.test.ts
@@ -49,6 +49,33 @@ describe("Markdown task checkbox interaction", () => {
     expect(view.state.doc.toString()).toBe("- [ ] Repeat");
   });
 
+  it("resolves a task from the current document after edits before its line", () => {
+    const view = mountMarkdown([
+      "- [ ] Top",
+      "",
+      "Paragraph one",
+      "Paragraph two",
+      "Paragraph three",
+      "",
+      "- [ ] Middle",
+      "",
+      "- [ ] Bottom",
+    ].join("\n"));
+    const middleBeforeEdit = getTaskControl(view, 1);
+    const insertAt = view.state.doc.line(2).to;
+
+    view.dispatch({
+      changes: { from: insertAt, insert: "\nInserted between task groups" },
+    });
+
+    const middleAfterEdit = getTaskControl(view, 1);
+    expect(middleAfterEdit).toBe(middleBeforeEdit);
+    middleAfterEdit.click();
+
+    expect(view.state.doc.toString()).toContain("- [x] Middle");
+    expect(view.state.doc.toString()).toContain("- [ ] Bottom");
+  });
+
   it("changes only on native activation, never on pointer-down alone", () => {
     const view = mountMarkdown("- [ ] Native click");
     const control = getTaskControl(view, 0);

--- a/tests/titlebarDragRegionArchitecture.test.ts
+++ b/tests/titlebarDragRegionArchitecture.test.ts
@@ -22,6 +22,10 @@ describe("titlebar drag-region architecture", () => {
     expect(windowChromeCss).toContain("-webkit-app-region: drag;");
     expect(windowChromeCss).toContain('[data-window-no-drag="true"]');
     expect(windowChromeCss).toContain("-webkit-app-region: no-drag;");
+    expect(windowChromeCss).toContain('body:has([data-titlebar-context-menu="true"])');
+    expect(windowChromeCss).toMatch(
+      /body:has\(\[data-titlebar-context-menu="true"\]\)[\s\S]*\[data-window-drag-region="true"\][\s\S]*-webkit-app-region:\s*no-drag;/,
+    );
     expect(titlebarCss).not.toContain("-webkit-app-region");
     expect(baseCss).not.toContain("-webkit-app-region");
   });

--- a/tests/titlebarMenuInteractions.test.tsx
+++ b/tests/titlebarMenuInteractions.test.tsx
@@ -28,6 +28,7 @@ describe("titlebar Portal menu interactions", () => {
     root = createRoot(container);
     const anchorRef = createRef<HTMLDivElement>();
     const onGoHome = vi.fn();
+    const onClose = vi.fn();
     const onOpenItem = vi.fn();
     const workspace = createWorkspace("one", "Workspace one");
     const item = {
@@ -47,6 +48,7 @@ describe("titlebar Portal menu interactions", () => {
           titlebarLabel={workspace.name}
           workspace={workspace}
           items={[item]}
+          onClose={onClose}
           onOpenFolder={vi.fn()}
           onOpenItem={onOpenItem}
           onGoHome={onGoHome}
@@ -59,11 +61,51 @@ describe("titlebar Portal menu interactions", () => {
     const menu = requireMenu();
     expect(container.contains(menu)).toBe(false);
     expect(menu.dataset.windowNoDrag).toBe("true");
+    expect(menu.style.width).toBe("300px");
     act(() => menu.querySelector<HTMLButtonElement>(".desktop-project-home")?.click());
     act(() => menu.querySelector<HTMLButtonElement>(".desktop-project-option")?.click());
 
     expect(onGoHome).toHaveBeenCalledOnce();
     expect(onOpenItem).toHaveBeenCalledWith(item);
+  });
+
+  it("dismisses a titlebar menu when the user points outside it", async () => {
+    const container = document.createElement("div");
+    const titlebarDragRegion = document.createElement("div");
+    titlebarDragRegion.dataset.windowDragRegion = "true";
+    document.body.append(container, titlebarDragRegion);
+    root = createRoot(container);
+    const onClose = vi.fn();
+
+    await act(async () => {
+      root?.render(withTestLocalization(
+        <DesktopWorkspaceSwitcher
+          compact={false}
+          open
+          refObject={createRef<HTMLDivElement>()}
+          titlebarLabel="Workspace one"
+          workspace={createWorkspace("one", "Workspace one")}
+          items={[]}
+          onClose={onClose}
+          onOpenFolder={vi.fn()}
+          onOpenItem={vi.fn()}
+          onGoHome={vi.fn()}
+          onToggle={vi.fn()}
+        />,
+      ));
+      await Promise.resolve();
+    });
+
+    act(() => {
+      requireMenu().dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    });
+    expect(onClose).not.toHaveBeenCalled();
+
+    act(() => {
+      titlebarDragRegion.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    });
+
+    expect(onClose).toHaveBeenCalledOnce();
   });
 
   it("executes branch checkout from the Portal menu and closes after success", async () => {
@@ -91,6 +133,7 @@ describe("titlebar Portal menu interactions", () => {
           workspaceSwitcherRef={createRef<HTMLDivElement>()}
           onCheckoutBranch={onCheckoutBranch}
           onCloseBranchSwitcher={onCloseBranchSwitcher}
+          onCloseWorkspaceSwitcher={vi.fn()}
           onGoHome={vi.fn()}
           onOpenFolder={vi.fn()}
           onOpenWorkspaceSwitcherItem={vi.fn()}

--- a/tests/titlebarMenuOverlayArchitecture.test.ts
+++ b/tests/titlebarMenuOverlayArchitecture.test.ts
@@ -21,7 +21,15 @@ describe("titlebar menu overlay architecture", () => {
   });
 
   it("keeps portal menu interactions inside the controlled open state", () => {
-    expect(appSource).toContain("target.closest('[data-titlebar-context-menu=\"true\"]')");
+    expect(layerSource).toContain('document.addEventListener("pointerdown", closeOnPointerDown, true)');
+    expect(layerSource).toContain("overlayRef.current?.contains(target)");
+    expect(layerSource).toContain("anchorRef.current?.contains(target)");
+    expect(appSource).not.toContain("const closeOnPointerDown = (event: PointerEvent)");
+  });
+
+  it("uses a compact fixed width for both project and branch menus", () => {
+    expect(layerSource).toContain("const TITLEBAR_CONTEXT_MENU_WIDTH = 300;");
+    expect(titlebarCss).toContain("width: min(300px, calc(100vw - 16px));");
   });
 
   it("fits a titlebar menu into a narrow viewport instead of clipping it", () => {

--- a/tests/titlebarTypographyArchitecture.test.ts
+++ b/tests/titlebarTypographyArchitecture.test.ts
@@ -73,6 +73,7 @@ describe("titlebar typography architecture", () => {
     expect(layoutRoot).toContain("--desktop-toolbar-action-radius: 5px;");
     expect(layoutRoot).toContain("--desktop-titlebar-control-height: 24px;");
     expect(layoutRoot).toContain("--desktop-titlebar-tool-action-width: 34px;");
+    expect(layoutRoot).toContain("--desktop-titlebar-button-gap: 3px;");
   });
 
   it("uses the compact titlebar height without shrinking shared sidebar controls", () => {
@@ -126,9 +127,19 @@ describe("titlebar typography architecture", () => {
     expect(titlebarContextSource).not.toContain("desktop-titlebar-context-divider");
     expect(titlebarContextSource).not.toContain("VersionControlIcon");
     expect(workspaceSwitcherSource).toContain("{compact && (");
-    expect(context).toContain("gap: 0;");
+    expect(context).toContain("gap: var(--desktop-titlebar-button-gap);");
     expect(projectName).toContain("color: var(--desktop-titlebar-text-muted);");
     expect(branchButton).toContain("color: var(--desktop-titlebar-text-muted);");
+  });
+
+  it("spaces project, branch, and Header actions with one button-gap contract", () => {
+    const context = readCssBlock(titlebarCss, ".desktop-titlebar-context");
+    const actions = readCssBlock(titlebarCss, ".desktop-titlebar-actions");
+    const compactMediaRule = readCssMediaBlock(titlebarCss, "@media (max-width: 720px)");
+
+    expect(context).toContain("gap: var(--desktop-titlebar-button-gap);");
+    expect(actions).toContain("gap: var(--desktop-titlebar-button-gap);");
+    expect(compactMediaRule).toContain("--desktop-titlebar-button-gap: 1px;");
   });
 
   it("keeps branch-menu metadata quiet without introducing new type sizes", () => {

--- a/tests/xtermWebglAtlasPatch.test.mjs
+++ b/tests/xtermWebglAtlasPatch.test.mjs
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { patchXtermWebglSource } from "../scripts/patch-xterm-webgl-atlas.mjs";
+
+describe("xterm WebGL glyph-atlas patch", () => {
+  it("replaces mipmap generation with explicit non-mipmapped filters", () => {
+    const original = "t.texImage2D(t.TEXTURE_2D,0,t.RGBA),t.generateMipmap(t.TEXTURE_2D),page.version=1";
+    const result = patchXtermWebglSource(original, "fixture");
+
+    expect(result.changed).toBe(true);
+    expect(result.source).not.toContain("generateMipmap");
+    expect(result.source).toContain(
+      "t.texParameteri(t.TEXTURE_2D,t.TEXTURE_MIN_FILTER,t.LINEAR)",
+    );
+    expect(result.source).toContain(
+      "t.texParameteri(t.TEXTURE_2D,t.TEXTURE_MAG_FILTER,t.LINEAR)",
+    );
+  });
+
+  it("is idempotent and fails closed if the upstream bundle shape changes", () => {
+    const original = "g.generateMipmap(g.TEXTURE_2D)";
+    const first = patchXtermWebglSource(original, "fixture");
+    const second = patchXtermWebglSource(first.source, "fixture");
+
+    expect(second).toEqual({ changed: false, source: first.source });
+    expect(() => patchXtermWebglSource("const renderer = 'changed';", "fixture"))
+      .toThrow(/no longer matches/);
+  });
+
+  it("runs after installs and leaves both published bundles on the safe path", () => {
+    const manifest = JSON.parse(source("package.json"));
+    expect(manifest.scripts.postinstall).toContain("patch-xterm-webgl-atlas.mjs");
+
+    for (const relativePath of [
+      "node_modules/@xterm/addon-webgl/lib/addon-webgl.js",
+      "node_modules/@xterm/addon-webgl/lib/addon-webgl.mjs",
+    ]) {
+      const bundle = source(relativePath);
+      expect(bundle).not.toContain("generateMipmap");
+      expect(bundle).toContain("TEXTURE_MIN_FILTER");
+      expect(bundle).toContain("TEXTURE_MAG_FILTER");
+    }
+  });
+});
+
+function source(relativePath) {
+  return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
+}


### PR DESCRIPTION
## Summary

- refine the per-pane action menu, including Markdown edit/source mode controls, Find placement, compact spacing, outside-click dismissal, and quiet shared elevation
- harden Markdown task and mapped-widget interactions against stale source ranges while preserving pane focus continuity
- keep the sidebar resize affordance as an overlay so the scrollbar, divider, editor edge, and selected-row treatment share one physical boundary
- centralize Create New menu metadata and custom-file submenu behavior across the titlebar, settings, and workspace surfaces
- harden Terminal Agent file-activity Hooks with bounded payload projection, canonical workspace paths, Cursor CLI enrollment, bridge freshness, and end-to-end fixtures
- answer startup terminal color probes at the PTY boundary and backport the reviewed xterm WebGL glyph-atlas filter fix

## Why

This integration candidate closes a set of related interaction and architecture gaps found while refining the Desktop editor. Several controls were visually or behaviorally coupled to individual panes, resize hit targets occupied layout space, widget callbacks could retain stale source coordinates, and native Agent Hook bridges could outlive the app version that installed them.

The changes move those concerns into shared contribution registries, overlay contracts, current-state command resolution, and provider-neutral activity boundaries so future pane types and Agent providers can extend the same architecture without duplicating UI or security logic.

## User impact

- pane menus are smaller, quieter, and consistently dismiss when the user clicks elsewhere in the header
- Markdown edit/source mode remains available on every Markdown pane without increasing menu height or leaking into unrelated pane types
- sidebar scrolling, resizing, and editor selection edges align without an artificial layout gap
- Create New exposes core file types first and keeps specialized types in an accessible submenu
- file-presence indicators receive safer and more reliable metadata from supported local Agents
- terminal startup colors and WebGL glyph rendering are more reliable on affected macOS/Chromium GPU paths

## Validation

- `npm run lint`
- `npm test` — 367 files, 2421 tests passed
- `npm run build` — architecture checks, TypeScript, Vite build, renderer assets, bundle budget, and packaged artifact budget passed
- `npm audit --omit=dev` — 0 vulnerabilities
- targeted Agent activity, Create New/titlebar, Markdown widget, and terminal color/WebGL regression suites passed before the final full run

The production build still reports the existing CodeMirror dynamic-import and large-chunk advisory messages; both configured bundle budget checks pass.
