### PR TITLE
release: prepare PuppyOne Desktop 0.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppyone/desktop",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppyone/desktop",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puppyone/desktop",
   "private": true,
-  "version": "0.3.6",
+  "version": "0.3.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump PuppyOne Desktop from 0.3.6 to 0.3.7
- keep package metadata and lockfile release identity aligned
- base the release on the qubits-promoted, security-refreshed main commit

## Validation
- complete `npm audit`: 0 vulnerabilities
- architecture and repository boundary checks: passed
- product candidate CI on PR #41: passed
- security refresh CI on PR #43: passed
- qubits-to-main promotion CI on PR #44: passed