### PR TITLE
release: v0.3.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppyone/desktop",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppyone/desktop",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puppyone/desktop",
   "private": true,
-  "version": "0.3.12",
+  "version": "0.3.13",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/scripts/build-macos-stable-release.mjs
+++ b/scripts/build-macos-stable-release.mjs
@@ -24,7 +24,6 @@ try {
   if (unknownArguments.length > 0) {
     throw new Error(`Unknown stable release arguments: ${unknownArguments.join(", ")}`);
   }
-  assertMacReleaseReadiness({ packageMetadata, env: process.env, platform: process.platform });
   if (!packageOnly) {
     await prepareDesktopBuild({
       repositoryRoot: repoRoot,
@@ -33,6 +32,15 @@ try {
       commitSha: process.env.GITHUB_SHA,
       expectedTag: process.env.PUPPYONE_RELEASE_TAG ?? `v${packageMetadata.version}`,
     });
+  }
+  const builderConfig = JSON.parse(await fs.readFile(builderConfigPath, "utf8"));
+  assertMacReleaseReadiness({
+    packageMetadata,
+    builderConfig,
+    env: process.env,
+    platform: process.platform,
+  });
+  if (!packageOnly) {
     await fs.rm(releaseDirectory, { recursive: true, force: true });
     for (const script of ["prepare:mac:release"]) {
       await runCommand("npm", ["run", script], { cwd: repoRoot });

--- a/scripts/check-macos-release-config.mjs
+++ b/scripts/check-macos-release-config.mjs
@@ -32,7 +32,8 @@ const stableMacConfig = createDesktopElectronBuilderConfig({
   target: getDesktopTargetDefinition("macos-arm64"),
 });
 const errors = inspectMacReleaseReadiness({
-  packageMetadata: { ...packageMetadata, build: stableMacConfig },
+  packageMetadata,
+  builderConfig: stableMacConfig,
   platform: "darwin",
   env: {
     CSC_LINK: "configured-by-ci",

--- a/scripts/release-support/macos-release-policy.mjs
+++ b/scripts/release-support/macos-release-policy.mjs
@@ -5,15 +5,16 @@ import {
 
 export function inspectMacReleaseReadiness({
   packageMetadata,
+  builderConfig,
   env = process.env,
   platform = process.platform,
   requireUploadCredentials = false,
 }) {
   const errors = [];
-  const mac = packageMetadata?.build?.mac ?? {};
-  const publish = Array.isArray(packageMetadata?.build?.publish)
-    ? packageMetadata.build.publish
-    : [packageMetadata?.build?.publish].filter(Boolean);
+  const mac = builderConfig?.mac ?? {};
+  const publish = Array.isArray(builderConfig?.publish)
+    ? builderConfig.publish
+    : [builderConfig?.publish].filter(Boolean);
   const version = packageMetadata?.version;
 
   if (platform !== "darwin") {

--- a/tests/macosReleasePolicy.test.mjs
+++ b/tests/macosReleasePolicy.test.mjs
@@ -24,46 +24,42 @@ const signingEnvironment = {
   APPLE_API_KEY_ID: "KEY123",
   APPLE_API_ISSUER: "issuer-id",
 };
-const stablePackageMetadata = {
-  ...packageMetadata,
-  build: createDesktopElectronBuilderConfig({
-    packageMetadata,
-    buildInfo: resolveDesktopBuildIdentity({
-      baseVersion: packageMetadata.version,
-      buildNumber: 42,
-      builtAt: "2026-08-29T00:00:00.000Z",
-      channel: "stable",
-      commitSha: "a".repeat(40),
-    }),
-    target: getDesktopTargetDefinition("macos-arm64"),
+const stableBuilderConfig = createDesktopElectronBuilderConfig({
+  packageMetadata,
+  buildInfo: resolveDesktopBuildIdentity({
+    baseVersion: packageMetadata.version,
+    buildNumber: 42,
+    builtAt: "2026-08-29T00:00:00.000Z",
+    channel: "stable",
+    commitSha: "a".repeat(40),
   }),
-};
+  target: getDesktopTargetDefinition("macos-arm64"),
+});
 
 describe("macOS stable release policy", () => {
   it("accepts the production package config with complete signing and notarization credentials", () => {
     expect(inspectMacReleaseReadiness({
-      packageMetadata: stablePackageMetadata,
+      packageMetadata,
+      builderConfig: stableBuilderConfig,
       env: signingEnvironment,
       platform: "darwin",
     })).toEqual([]);
   });
 
   it("rejects internal signing overrides and partial notarization credentials", () => {
-    const unsafePackage = {
-      ...stablePackageMetadata,
-      build: {
-        ...stablePackageMetadata.build,
-        mac: {
-          ...stablePackageMetadata.build.mac,
-          identity: "-",
-          hardenedRuntime: false,
-          notarize: false,
-          strictVerify: false,
-        },
+    const unsafeBuilderConfig = {
+      ...stableBuilderConfig,
+      mac: {
+        ...stableBuilderConfig.mac,
+        identity: "-",
+        hardenedRuntime: false,
+        notarize: false,
+        strictVerify: false,
       },
     };
     const errors = inspectMacReleaseReadiness({
-      packageMetadata: unsafePackage,
+      packageMetadata,
+      builderConfig: unsafeBuilderConfig,
       env: {
         CSC_IDENTITY_AUTO_DISCOVERY: "false",
         APPLE_ID: "release@example.com",
@@ -81,7 +77,8 @@ describe("macOS stable release policy", () => {
 
   it("requires upload credentials and a tag matching the package version", () => {
     const errors = inspectMacReleaseReadiness({
-      packageMetadata: stablePackageMetadata,
+      packageMetadata,
+      builderConfig: stableBuilderConfig,
       env: {
         ...signingEnvironment,
         PUPPYONE_RELEASE_TAG: "v9.9.9",
@@ -100,7 +97,7 @@ describe("macOS stable release policy", () => {
 
   it("uses immutable version and mutable latest R2 prefixes", () => {
     const coordinates = getStableReleaseCoordinates({
-      packageMetadata: stablePackageMetadata,
+      packageMetadata,
       env: {
         CLOUDFLARE_ACCOUNT_ID: "account",
         PUPPYONE_RELEASE_TAG: `v${packageMetadata.version}`,
@@ -113,7 +110,7 @@ describe("macOS stable release policy", () => {
       tag: `v${packageMetadata.version}`,
       versionPrefix: `desktop/stable/mac/v${packageMetadata.version}`,
     });
-    expect(new URL(stablePackageMetadata.build.publish[0].url).pathname).toBe(`/${coordinates.latestPrefix}`);
+    expect(new URL(stableBuilderConfig.publish[0].url).pathname).toBe(`/${coordinates.latestPrefix}`);
   });
 });
 


### PR DESCRIPTION
Release v0.3.13 after the v0.3.12 stable pipeline exposed a generated-config integration defect.\n\n- add a regression test matching the real target-specific builder config path\n- validate the generated macOS builder config instead of the base package build block\n- preserve every hardened runtime, signing, notarization, target, and update-feed gate\n- bump the Desktop version to 0.3.13\n\nLocal gates: npm ci, 456 test files / 2997 tests, lint, architecture boundaries, and production build all pass.